### PR TITLE
feat(scripts): multi-project provisioning from CSV roster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ logs/
 # FRAMEWORK:END
 
 # Project-specific ignores (add below this line)
+
+# Workshop roster — input + generated output. Contains participant emails;
+# never commit. Use scripts/roster.example.csv as the format reference.
+roster.csv
+roster-output.csv

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -227,6 +227,76 @@ If the workflow succeeds but the container fails its health check with
 
 ---
 
+## Workshop: Provisioning N Projects
+
+When running a workshop, the facilitator provisions one GCP project per
+participant. `scripts/provision-workshop-roster.sh` wraps
+`provision-gcp-project.sh` in a CSV-driven loop so all participant
+projects can be created with one command.
+
+### Roster format
+
+Create `roster.csv` with this exact header:
+
+```csv
+handle,github_user,email,cohort
+alice,alice-gh,alice@example.com,2026-05
+bob,bob-gh,bob@example.com,2026-05
+```
+
+- `handle` — short, lowercase, stable identifier; appears in the GCP project ID
+- `github_user` — reserved for future tickets (WIF binding, notification);
+  required in the row but not used by this script
+- `email` — Google identity granted `roles/editor` on the new project
+- `cohort` — `YYYY-MM` of the workshop date; appears in the project ID
+
+Project IDs follow the pattern `af-{handle}-{cohort}`. This shape is
+referenced from the facilitator runbook, the participant day-1 doc, and
+the dry-run checklist — do not change it.
+
+A working example lives at `scripts/roster.example.csv`.
+
+### Running the wrapper
+
+```bash
+BILLING_ACCOUNT_ID=XXXXXX-XXXXXX-XXXXXX \
+  ./scripts/provision-workshop-roster.sh roster.csv
+```
+
+For each row the wrapper:
+
+1. Computes the project ID and checks whether it already exists
+2. Calls `provision-gcp-project.sh --create-project` (idempotent)
+3. Grants `roles/editor` on the new project to the participant's email
+4. Appends a row to `roster-output.csv` with status + project ID
+
+### Idempotency and fail-fast
+
+Re-running the script with the same `roster.csv` is safe — already-existing
+projects are recorded as `skipped` instead of `created`.
+
+The wrapper is fail-fast: if any row fails, the loop stops and exits
+non-zero. This is intentional — a half-provisioned classroom is harder
+to recover from than a clean stop. Inspect the failing row in
+`roster-output.csv`, fix the cause, and re-run. Successful rows from the
+prior run will be skipped on the retry.
+
+### What this does NOT do
+
+- Workload Identity Federation setup is intentionally out of scope. Either
+  set it up manually per project (see "Step 5: Workload Identity Federation"
+  above), or wait for ticket [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5) to land.
+- Budget caps are not configured here. See ticket [#6](https://github.com/vibeacademy/agile-flow-gcp/issues/6).
+- Notification emails to participants are not sent. The facilitator runbook
+  in `agile-flow-meta` documents the email template.
+
+### Output and gitignore
+
+`roster.csv` (input) and `roster-output.csv` (output) are both gitignored.
+They contain participant emails — never commit either.
+
+---
+
 ## Daily Operations
 
 ### Viewing Logs

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# provision-workshop-roster.sh — multi-project provisioning from a CSV roster.
+#
+# Wraps scripts/provision-gcp-project.sh for workshop facilitators who need
+# to provision N participant projects in one command.
+#
+# Usage:
+#   BILLING_ACCOUNT_ID=XXX-XXXX-XXXX ./scripts/provision-workshop-roster.sh roster.csv
+#
+# Required environment variables:
+#   BILLING_ACCOUNT_ID   The GCP billing account to attach each project to
+#
+# Optional environment variables:
+#   GCP_REGION           (default: us-central1) — passed through to inner script
+#   ARTIFACT_REPO        (default: agile-flow)  — passed through to inner script
+#   PROVISION_SCRIPT     (default: scripts/provision-gcp-project.sh) — for tests
+#
+# CSV format (header required):
+#   handle,github_user,email,cohort
+#   alice,alice-gh,alice@example.com,2026-05
+#   bob,bob-gh,bob@example.com,2026-05
+#
+# Project IDs follow the pattern  af-{handle}-{cohort}  and are globally
+# unique. This is non-negotiable: the runbook, day-1 doc, and dry-run
+# checklist all assume this shape.
+#
+# Side effects per row:
+#   1. Calls provision-gcp-project.sh --create-project (idempotent)
+#   2. Grants roles/editor on the new project to the participant's email
+#   3. Appends a row to roster-output.csv with status + project ID
+#
+# This script is fail-fast: the loop stops on the first row that errors,
+# so a half-provisioned classroom does not silently happen.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROVISION_SCRIPT="${PROVISION_SCRIPT:-$REPO_ROOT/scripts/provision-gcp-project.sh}"
+OUTPUT_CSV="${OUTPUT_CSV:-roster-output.csv}"
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+
+if [[ $# -ne 1 ]]; then
+  cat >&2 <<EOF
+Usage: BILLING_ACCOUNT_ID=XXX ./scripts/provision-workshop-roster.sh <roster.csv>
+
+See header of $0 for full documentation.
+EOF
+  exit 2
+fi
+
+ROSTER_CSV="$1"
+
+if [[ ! -f "$ROSTER_CSV" ]]; then
+  echo "ERROR: roster file not found: $ROSTER_CSV" >&2
+  exit 2
+fi
+
+if [[ -z "${BILLING_ACCOUNT_ID:-}" ]]; then
+  echo "ERROR: BILLING_ACCOUNT_ID is required" >&2
+  exit 2
+fi
+
+if [[ ! -x "$PROVISION_SCRIPT" ]]; then
+  echo "ERROR: inner provision script not executable: $PROVISION_SCRIPT" >&2
+  exit 2
+fi
+
+# ── CSV header validation ────────────────────────────────────────────────
+
+EXPECTED_HEADER="handle,github_user,email,cohort"
+ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
+
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER" ]]; then
+  echo "ERROR: roster CSV header must be exactly: $EXPECTED_HEADER" >&2
+  echo "       got: $ACTUAL_HEADER" >&2
+  exit 2
+fi
+
+# ── Output CSV setup ─────────────────────────────────────────────────────
+
+if [[ ! -f "$OUTPUT_CSV" ]]; then
+  echo "handle,project_id,status,wif_provider,timestamp" > "$OUTPUT_CSV"
+fi
+
+# ── Counters ─────────────────────────────────────────────────────────────
+
+total=0
+created=0
+skipped=0
+
+# ── Loop ─────────────────────────────────────────────────────────────────
+
+# tail -n +2 skips header. Process substitution avoids subshell so counters
+# survive into the summary block.
+# shellcheck disable=SC2034  # github_user is reserved for #5 (WIF binding) and notification steps
+while IFS=',' read -r handle github_user email cohort; do
+  # Strip whitespace and CR (Windows line endings)
+  handle="$(echo "$handle" | tr -d '[:space:]\r')"
+  email="$(echo "$email" | tr -d '[:space:]\r')"
+  cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
+
+  if [[ -z "$handle" || -z "$cohort" ]]; then
+    continue
+  fi
+
+  total=$((total + 1))
+  project_id="af-${handle}-${cohort}"
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  echo ""
+  echo "──────────────────────────────────────────────────"
+  echo "  [$total] $handle  ->  $project_id"
+  echo "──────────────────────────────────────────────────"
+
+  # Detect whether the project already exists, so we can label the output
+  # row honestly. The inner script is idempotent either way, so this is
+  # purely for the summary CSV.
+  if gcloud projects describe "$project_id" >/dev/null 2>&1; then
+    status="skipped"
+    skipped=$((skipped + 1))
+  else
+    status="created"
+    created=$((created + 1))
+  fi
+
+  # Run the inner provisioner. It handles "already exists" internally;
+  # we just pass through the env it needs.
+  GCP_PROJECT_ID="$project_id" \
+  BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
+  GCP_REGION="${GCP_REGION:-us-central1}" \
+  ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}" \
+    "$PROVISION_SCRIPT" --create-project
+
+  # Grant the participant editor on their own project. Idempotent.
+  echo ""
+  echo "[bind] roles/editor -> user:$email"
+  gcloud projects add-iam-policy-binding "$project_id" \
+    --member="user:$email" \
+    --role="roles/editor" \
+    --condition=None \
+    --quiet >/dev/null
+
+  # WIF setup is ticket #5; not in scope here. Output column stays empty
+  # until #5 lands or the facilitator wires it manually.
+  wif_provider=""
+
+  echo "$handle,$project_id,$status,$wif_provider,$timestamp" >> "$OUTPUT_CSV"
+done < <(tail -n +2 "$ROSTER_CSV")
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "=================================="
+echo "  Workshop provisioning summary"
+echo "=================================="
+echo "  Total rows processed:   $total"
+echo "  Newly created:          $created"
+echo "  Already existed:        $skipped"
+echo "  Failed:                 0   (script is fail-fast — see above for any error)"
+echo ""
+echo "  Output: $OUTPUT_CSV"
+echo "  Next:   set up WIF (manually or via #5) and send each participant"
+echo "          their setup email per docs/PLATFORM-GUIDE.md."

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# Tests for provision-workshop-roster.sh
+#
+# Stubs `gcloud` and the inner provisioner via PATH injection + env override
+# so we can assert behavior without touching real GCP.
+#
+# Run: ./scripts/provision-workshop-roster.test.sh
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/provision-workshop-roster.sh"
+
+# Each test runs in a fresh tmpdir to keep output CSVs isolated.
+new_tmp() {
+  mktemp -d -t aflowtest-XXXX
+}
+
+# Build a fake gcloud + provision-gcp-project.sh in $tmp/bin and prepend to PATH.
+#   $1: tmpdir
+#   $2: behavior — "ok", "skip-first" (project exists for first row), or "fail"
+make_stubs() {
+  local tmp="$1"
+  local behavior="$2"
+  mkdir -p "$tmp/bin"
+
+  # Fake gcloud
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+# Log every invocation to a file so the test can assert on it.
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+
+case "\$1" in
+  projects)
+    case "\$2" in
+      describe)
+        # describe <project_id>
+        if [[ "$behavior" == "skip-first" && "\$3" == af-alice-* ]]; then
+          exit 0  # alice's project "exists"
+        fi
+        exit 1    # default: project does not exist
+        ;;
+      add-iam-policy-binding)
+        exit 0
+        ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+  # Fake inner provisioner
+  cat > "$tmp/bin/provision-gcp-project.sh" <<EOF
+#!/usr/bin/env bash
+# Log every invocation
+echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-}" >> "$tmp/provision.log"
+
+if [[ "$behavior" == "fail" ]]; then
+  echo "fake provision failure" >&2
+  exit 1
+fi
+exit 0
+EOF
+
+  chmod +x "$tmp/bin/gcloud" "$tmp/bin/provision-gcp-project.sh"
+}
+
+write_roster() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+handle,github_user,email,cohort
+alice,alice-gh,alice@example.com,2026-05
+bob,bob-gh,bob@example.com,2026-05
+EOF
+}
+
+assert_contains() {
+  local needle="$1"
+  local haystack_file="$2"
+  local label="$3"
+  if grep -q "$needle" "$haystack_file"; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (looking for: $needle in $haystack_file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: Happy path — both rows attempted, output CSV correct ─────────
+
+echo ""
+echo "Test 1: Happy path with 2-row roster"
+
+T1=$(new_tmp)
+make_stubs "$T1" "ok"
+write_roster "$T1/roster.csv"
+
+set +e
+PATH="$T1/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T1/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T1/roster-output.csv" \
+  "$WRAPPER" "$T1/roster.csv" > "$T1/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0"
+assert_eq "2" "$(grep -c '^provision' "$T1/provision.log")" "inner provisioner called twice"
+assert_contains "alice,af-alice-2026-05,created" "$T1/roster-output.csv" "alice row recorded as created"
+assert_contains "bob,af-bob-2026-05,created" "$T1/roster-output.csv" "bob row recorded as created"
+assert_contains "Total rows processed:   2" "$T1/stdout.log" "summary shows 2 rows"
+
+# ── Test 2: Idempotent re-run — both rows show "skipped" ─────────────────
+
+echo ""
+echo "Test 2: Idempotent re-run (project already exists for both rows)"
+
+T2=$(new_tmp)
+# Custom stub: gcloud projects describe always succeeds (project exists)
+mkdir -p "$T2/bin"
+cat > "$T2/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$T2/gcloud.log"
+case "\$1 \$2" in
+  "projects describe") exit 0 ;;  # always exists
+  "projects add-iam-policy-binding") exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+cat > "$T2/bin/provision-gcp-project.sh" <<EOF
+#!/usr/bin/env bash
+echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-}" >> "$T2/provision.log"
+exit 0
+EOF
+chmod +x "$T2/bin/gcloud" "$T2/bin/provision-gcp-project.sh"
+
+write_roster "$T2/roster.csv"
+
+set +e
+PATH="$T2/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T2/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T2/roster-output.csv" \
+  "$WRAPPER" "$T2/roster.csv" > "$T2/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 on re-run"
+assert_contains "alice,af-alice-2026-05,skipped" "$T2/roster-output.csv" "alice row recorded as skipped"
+assert_contains "bob,af-bob-2026-05,skipped" "$T2/roster-output.csv" "bob row recorded as skipped"
+assert_contains "Already existed:        2" "$T2/stdout.log" "summary shows 2 skipped"
+
+# ── Test 3: Fail-fast — first row fails, second row never attempted ─────
+
+echo ""
+echo "Test 3: Fail-fast on first-row error"
+
+T3=$(new_tmp)
+make_stubs "$T3" "fail"
+write_roster "$T3/roster.csv"
+
+set +e
+PATH="$T3/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T3/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T3/roster-output.csv" \
+  "$WRAPPER" "$T3/roster.csv" > "$T3/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -ne 0 ]]; then
+  echo -e "  ${GREEN}✓${NC} wrapper exits non-zero on inner failure (got $exit_code)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} wrapper should fail on inner script failure (got 0)"
+  FAIL=$((FAIL + 1))
+fi
+assert_eq "1" "$(grep -c '^provision' "$T3/provision.log")" "inner provisioner called only once before exit"
+
+# ── Test 4: Bad CSV header rejected ──────────────────────────────────────
+
+echo ""
+echo "Test 4: Bad CSV header is rejected"
+
+T4=$(new_tmp)
+make_stubs "$T4" "ok"
+cat > "$T4/roster.csv" <<EOF
+name,email
+alice,alice@example.com
+EOF
+
+set +e
+PATH="$T4/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T4/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T4/roster-output.csv" \
+  "$WRAPPER" "$T4/roster.csv" > "$T4/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 2 ]]; then
+  echo -e "  ${GREEN}✓${NC} wrapper exits 2 on bad header"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} wrapper should exit 2 on bad header (got $exit_code)"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "header must be exactly" "$T4/stdout.log" "error message mentions header format"
+
+# ── Test 5: Missing BILLING_ACCOUNT_ID rejected ─────────────────────────
+
+echo ""
+echo "Test 5: Missing BILLING_ACCOUNT_ID is rejected"
+
+T5=$(new_tmp)
+make_stubs "$T5" "ok"
+write_roster "$T5/roster.csv"
+
+set +e
+PATH="$T5/bin:$PATH" \
+  PROVISION_SCRIPT="$T5/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T5/roster-output.csv" \
+  "$WRAPPER" "$T5/roster.csv" > "$T5/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -eq 2 ]]; then
+  echo -e "  ${GREEN}✓${NC} wrapper exits 2 when BILLING_ACCOUNT_ID is unset"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} wrapper should exit 2 when BILLING_ACCOUNT_ID is unset (got $exit_code)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/roster.example.csv
+++ b/scripts/roster.example.csv
@@ -1,0 +1,3 @@
+handle,github_user,email,cohort
+alice,alice-gh,alice@example.com,2026-05
+bob,bob-gh,bob@example.com,2026-05


### PR DESCRIPTION
## Summary

Adds `scripts/provision-workshop-roster.sh` — a CSV-driven wrapper around `provision-gcp-project.sh` for workshop facilitators provisioning N participant projects at once.

Closes #4. Unblocks the 2026-05-01 dry-run.

## What's in the PR

- `scripts/provision-workshop-roster.sh` (130 lines) — fail-fast wrapper, idempotent, no SA key generation
- `scripts/provision-workshop-roster.test.sh` (200+ lines, 14 assertions) — mocked-shell test stubbing `gcloud` + the inner script via PATH injection
- `scripts/roster.example.csv` — canonical format reference
- `docs/PLATFORM-GUIDE.md` — new "Workshop: Provisioning N Projects" section with copy-paste runbook
- `.gitignore` — `roster.csv` and `roster-output.csv` (both contain participant emails)

## Project ID convention

Projects use the pattern `af-{handle}-{cohort}`. This shape is referenced from the facilitator runbook (`agile-flow-meta`#80), participant day-1 doc (#81), and dry-run checklist (#82) — already merged. Kept the same here.

## Out of scope (intentional)

- WIF setup → ticket #5 (manual fallback acceptable per user)
- Budget caps → ticket #6
- SA key generation → forbidden by ticket guardrail
- Notification emails → covered in `agile-flow-meta` runbook

## Scope change vs. original ticket

Original DoD required real-GCP execution (creating 2 projects). The authoring agent can't run that. With user approval, replaced with a mocked-shell test suite that asserts the same invariants — idempotency and fail-fast — plus real-GCP smoke deferred to the 2026-05-01 dry-run. Recorded on the issue.

## Test plan

- [x] `bash -n scripts/provision-workshop-roster.sh` passes
- [x] `shellcheck scripts/provision-workshop-roster.sh` clean
- [x] `shellcheck scripts/provision-workshop-roster.test.sh` clean
- [x] `./scripts/provision-workshop-roster.test.sh` — 14/14 assertions pass
- [x] `uv run python -m pytest -q` — 8/8 passing (existing tests unaffected)
- [x] `uv run ruff check .` — clean
- [x] `markdownlint-cli2 docs/PLATFORM-GUIDE.md` — clean
- [ ] Real-GCP smoke at the 2026-05-01 dry-run

## Local pytest note

Local `uv run pytest` fails because `.venv/bin/pytest` has a stale shebang from when this checkout lived at `agile-flow-gcp-staging/`. `uv run python -m pytest` works around it. Pre-existing infrastructure quirk; unrelated to this change. Worth a quick-fix follow-up: `uv sync --reinstall` should fix the shebang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)