### PR TITLE
fix(scripts): retry eventual-consistency 403s on API enable in provision-gcp-project.sh

### DIFF
--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -29,6 +29,86 @@ set -euo pipefail
 GCP_REGION="${GCP_REGION:-us-central1}"
 ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}"
 
+# ── Retry helper for GCP eventual consistency ────────────────────────────
+#
+# Enabling a GCP API (e.g. artifactregistry.googleapis.com) is eventually
+# consistent: the enable call returns success but the API endpoint can
+# return PERMISSION_DENIED for 30-90 seconds afterward, even for project
+# owners. Same pattern hits IAM bindings after SA creation. We retry on
+# that specific stderr signature only — bad arguments, already-exists,
+# and auth failures fail immediately.
+#
+# Usage:
+#   retry_eventual_consistency <label> -- <gcloud command...>
+#
+# Defaults: 6 attempts, exponential backoff (2,4,8,16,30,30s), ~90s cap.
+# Override with RETRY_MAX_ATTEMPTS, RETRY_MAX_SLEEP env vars.
+
+RETRY_MAX_ATTEMPTS="${RETRY_MAX_ATTEMPTS:-6}"
+RETRY_MAX_SLEEP="${RETRY_MAX_SLEEP:-30}"
+
+retry_eventual_consistency() {
+  local label="$1"; shift
+  if [[ "${1:-}" != "--" ]]; then
+    echo "ERROR: retry_eventual_consistency expects 'label -- cmd...'" >&2
+    return 2
+  fi
+  shift
+
+  local attempt=1
+  local sleep_s=2
+  local stderr_file
+  stderr_file="$(mktemp)"
+
+  local exit_code
+  while (( attempt <= RETRY_MAX_ATTEMPTS )); do
+    # Run the command with `set -e` temporarily disabled so we can capture
+    # its exit code. Bash function-local `set +e` does not leak out of
+    # the function in a `command || handler` pattern, but a bare `if/then`
+    # clobbers $?. Cleanest: && / || chain.
+    exit_code=0
+    "$@" 2> "$stderr_file" || exit_code=$?
+
+    if (( exit_code == 0 )); then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      return 0
+    fi
+
+    # Permanent error signatures — fail immediately, do not retry.
+    if grep -qE 'Invalid argument|already exists|ALREADY_EXISTS|invalid value|Bad Request|UNAUTHENTICATED' "$stderr_file"; then
+      cat "$stderr_file" >&2
+      rm -f "$stderr_file"
+      return "$exit_code"
+    fi
+
+    # Transient eventual-consistency signature.
+    if grep -qE 'PERMISSION_DENIED.*denied on resource|IAM_PERMISSION_DENIED|API has not been used|SERVICE_DISABLED' "$stderr_file"; then
+      if (( attempt == RETRY_MAX_ATTEMPTS )); then
+        echo "[retry $attempt/$RETRY_MAX_ATTEMPTS] $label — exhausted" >&2
+        cat "$stderr_file" >&2
+        rm -f "$stderr_file"
+        return "$exit_code"
+      fi
+      echo "[retry $attempt/$RETRY_MAX_ATTEMPTS] $label — transient 403, sleeping ${sleep_s}s" >&2
+      sleep "$sleep_s"
+      sleep_s=$(( sleep_s * 2 ))
+      (( sleep_s > RETRY_MAX_SLEEP )) && sleep_s=$RETRY_MAX_SLEEP
+      attempt=$(( attempt + 1 ))
+      continue
+    fi
+
+    # Unrecognized error — surface it and bail. Better to fail loudly than
+    # to retry indefinitely on something we don't understand.
+    cat "$stderr_file" >&2
+    rm -f "$stderr_file"
+    return "$exit_code"
+  done
+
+  rm -f "$stderr_file"
+  return 1
+}
+
 CREATE_PROJECT=false
 WITH_SA_KEY=false
 
@@ -99,10 +179,11 @@ if gcloud artifacts repositories describe "$ARTIFACT_REPO" \
   echo "[skip] Artifact Registry repo '$ARTIFACT_REPO' already exists"
 else
   echo "[create] Artifact Registry repo '$ARTIFACT_REPO'"
-  gcloud artifacts repositories create "$ARTIFACT_REPO" \
-    --repository-format=docker \
-    --location="$GCP_REGION" \
-    --project="$GCP_PROJECT_ID"
+  retry_eventual_consistency "artifact registry create" -- \
+    gcloud artifacts repositories create "$ARTIFACT_REPO" \
+      --repository-format=docker \
+      --location="$GCP_REGION" \
+      --project="$GCP_PROJECT_ID"
 fi
 
 # ── Step 4: Deployer service account ─────────────────────────────────────
@@ -114,9 +195,10 @@ if gcloud iam service-accounts describe "$SA_EMAIL" \
   echo "[skip] Service account 'deployer' already exists"
 else
   echo "[create] Service account 'deployer'"
-  gcloud iam service-accounts create deployer \
-    --display-name="GitHub Actions deployer" \
-    --project="$GCP_PROJECT_ID"
+  retry_eventual_consistency "service account create" -- \
+    gcloud iam service-accounts create deployer \
+      --display-name="GitHub Actions deployer" \
+      --project="$GCP_PROJECT_ID"
 fi
 
 # ── Step 5: IAM roles ────────────────────────────────────────────────────
@@ -130,11 +212,12 @@ ROLES=(
 
 for role in "${ROLES[@]}"; do
   echo "[bind] $role -> $SA_EMAIL"
-  gcloud projects add-iam-policy-binding "$GCP_PROJECT_ID" \
-    --member="serviceAccount:${SA_EMAIL}" \
-    --role="$role" \
-    --condition=None \
-    --quiet >/dev/null
+  retry_eventual_consistency "iam bind $role" -- \
+    gcloud projects add-iam-policy-binding "$GCP_PROJECT_ID" \
+      --member="serviceAccount:${SA_EMAIL}" \
+      --role="$role" \
+      --condition=None \
+      --quiet >/dev/null
 done
 
 # ── Step 6: Service account key (workshop shortcut) ─────────────────────

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Tests for the retry_eventual_consistency helper in
+# scripts/provision-gcp-project.sh.
+#
+# We source the script's helper section by extracting it (the script's
+# main body requires GCP_PROJECT_ID; we don't want to run that in tests).
+#
+# Run: ./scripts/provision-gcp-project.test.sh
+
+# Tests deliberately exercise failure paths, so `set -e` would short-circuit
+# before assertions run. We rely on explicit exit-code captures instead.
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/provision-gcp-project.sh"
+
+# Pull the helper definition into the current shell. The helper block is
+# bounded by its leading comment and the `retry_eventual_consistency()`
+# closing brace at column 1 (matched by `^}`).
+HELPER_SRC="$(awk '
+  /^retry_eventual_consistency\(\)/ { capture=1 }
+  /^RETRY_MAX_ATTEMPTS=/ || /^RETRY_MAX_SLEEP=/ { print; next }
+  capture { print }
+  capture && /^}/ { exit }
+' "$SCRIPT")"
+
+# Use small delays so the test runs in <1s.
+export RETRY_MAX_ATTEMPTS=4
+export RETRY_MAX_SLEEP=1
+
+# shellcheck disable=SC1090,SC2086
+eval "$HELPER_SRC"
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: command succeeds first try → exit 0, no sleep ────────────────
+
+echo ""
+echo "Test 1: success on first attempt"
+
+set +e
+out=$(retry_eventual_consistency "ok cmd" -- bash -c 'true' 2>&1)
+ec=$?
+set -e
+assert_eq "0" "$ec" "exit 0"
+assert_eq "" "$out" "no retry log written"
+
+# ── Test 2: transient 403 → retry → eventual success ────────────────────
+
+echo ""
+echo "Test 2: transient 403 then success"
+
+# Stub command that fails twice with the eventual-consistency signature,
+# then succeeds. Use a tmpfile counter.
+COUNTER=$(mktemp)
+echo 0 > "$COUNTER"
+FLAKY_CMD=$(mktemp)
+cat > "$FLAKY_CMD" <<EOF
+#!/usr/bin/env bash
+n=\$(<"$COUNTER")
+n=\$((n + 1))
+echo \$n > "$COUNTER"
+if (( n < 3 )); then
+  echo "ERROR: PERMISSION_DENIED: foo denied on resource projects/x" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$FLAKY_CMD"
+
+set +e
+out=$(retry_eventual_consistency "flaky" -- "$FLAKY_CMD" 2>&1)
+ec=$?
+set -e
+assert_eq "0" "$ec" "exit 0 after retries"
+assert_eq "3" "$(cat "$COUNTER")" "command invoked 3 times (2 fail + 1 success)"
+
+if echo "$out" | grep -q "retry 1/4"; then
+  echo -e "  ${GREEN}✓${NC} first retry logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[retry 1/4]' in stderr; got: $out"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$FLAKY_CMD" "$COUNTER"
+
+# ── Test 3: permanent error (already-exists) → fail immediately ─────────
+
+echo ""
+echo "Test 3: permanent error fails on first attempt without retrying"
+
+COUNTER=$(mktemp); echo 0 > "$COUNTER"
+PERM_CMD=$(mktemp)
+cat > "$PERM_CMD" <<EOF
+#!/usr/bin/env bash
+n=\$(<"$COUNTER")
+echo \$((n + 1)) > "$COUNTER"
+echo "ERROR: already exists: foo" >&2
+exit 1
+EOF
+chmod +x "$PERM_CMD"
+
+set +e
+retry_eventual_consistency "perm" -- "$PERM_CMD" >/dev/null 2>&1
+ec=$?
+set -e
+assert_eq "1" "$ec" "exit non-zero on permanent error"
+assert_eq "1" "$(cat "$COUNTER")" "command invoked exactly once (no retry)"
+
+rm -f "$PERM_CMD" "$COUNTER"
+
+# ── Test 4: transient error exhausts retries → fail with logged exhaustion
+
+echo ""
+echo "Test 4: transient error exhausts retries"
+
+COUNTER=$(mktemp); echo 0 > "$COUNTER"
+ALWAYS_FLAKY=$(mktemp)
+cat > "$ALWAYS_FLAKY" <<EOF
+#!/usr/bin/env bash
+n=\$(<"$COUNTER")
+echo \$((n + 1)) > "$COUNTER"
+echo "ERROR: PERMISSION_DENIED: denied on resource projects/x" >&2
+exit 1
+EOF
+chmod +x "$ALWAYS_FLAKY"
+
+set +e
+out=$(retry_eventual_consistency "always-flaky" -- "$ALWAYS_FLAKY" 2>&1)
+ec=$?
+set -e
+assert_eq "1" "$ec" "exit non-zero after exhaustion"
+assert_eq "$RETRY_MAX_ATTEMPTS" "$(cat "$COUNTER")" "command invoked RETRY_MAX_ATTEMPTS times"
+
+if echo "$out" | grep -q "exhausted"; then
+  echo -e "  ${GREEN}✓${NC} exhaustion logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'exhausted' in stderr; got: $out"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$ALWAYS_FLAKY" "$COUNTER"
+
+# ── Test 5: bad invocation (missing -- separator) → exit 2 ─────────────
+
+echo ""
+echo "Test 5: bad invocation"
+
+set +e
+retry_eventual_consistency "label" "not-a-separator" "true" >/dev/null 2>&1
+ec=$?
+set -e
+assert_eq "2" "$ec" "exit 2 on missing -- separator"
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #14. **P0 — dry-run is in 3 days.**

Live-discovered today while pre-provisioning a real workshop project:

```text
[create] Project af-harry-2026-05    ← OK
[link] Billing account                ← OK
[enable] Required APIs                ← OK (Service Management says \"finished successfully\")
[create] Artifact Registry repo 'agile-flow'
ERROR: PERMISSION_DENIED: artifactregistry.repositories.create denied on
projects/af-harry-2026-05/locations/us-central1
```

Same caller has `roles/owner`. Re-running the same script succeeds. The cause is GCP's Service Usage API eventual consistency — enabling an API returns success but the endpoint can stay 403 for 30-90 seconds.

## Changes

- **`scripts/provision-gcp-project.sh`**: adds `retry_eventual_consistency` helper. Bounded retry (default 6 attempts, exp backoff 2→30s, ~90s total). Distinguishes transient 403 signatures from permanent errors. Logs `[retry N/M]` lines on every retry.
- Wraps three call sites: artifact-registry create, SA create, IAM policy bindings. Idempotency `describe` checks still come *before* the retry, so re-runs are unchanged.
- **`scripts/provision-gcp-project.test.sh`** (new): 11 assertions across 5 scenarios. Stubs commands at PATH. Verifies success-first-try, transient-then-success, permanent-fails-immediately, exhaustion, bad-invocation. Runs in <5s using small RETRY_MAX_* overrides.

## Implementation notes (worth a re-read in review)

- **`set -e` interaction.** The helper originally tried `set +e / cmd / set -e` around the inner command. That leaks `set -e` into the parent shell when the function returns from a non-zero path, killing the caller's script. Replaced with `cmd 2>err || exit_code=$?` — no `set` toggling, parent's flags untouched.
- **Permanent vs transient classification is grep-based on stderr.** Transient: `PERMISSION_DENIED.*denied on resource|IAM_PERMISSION_DENIED|API has not been used|SERVICE_DISABLED`. Permanent: `Invalid argument|already exists|ALREADY_EXISTS|invalid value|Bad Request|UNAUTHENTICATED`. Anything unmatched bails immediately rather than retrying — better to surface unknown errors than silently loop.
- **Default backoff caps at 90s total wall-clock.** That's more than the 30-90s window I've seen GCP take. Tunable via `RETRY_MAX_ATTEMPTS` and `RETRY_MAX_SLEEP` env vars.

## Test plan

- [x] `bash -n` and `shellcheck` clean on both new files
- [x] `./scripts/provision-gcp-project.test.sh` — 11/11 pass
- [x] CI green
- [ ] Real-GCP smoke at 2026-05-01 dry-run (DoD relaxation per the issue)

## Coordination with #12

- This PR touches `scripts/provision-gcp-project.sh`. PR #12 (CSV roster wrapper) only touches `scripts/provision-workshop-roster.sh` and adds its own test. No file conflict; either order works.

## Note on user's half-provisioned project

User has a project `af-harry-2026-05` that's partway through provisioning (project + billing exist; artifact registry not created). Once this PR merges, re-running `BILLING_ACCOUNT_ID=… ./scripts/provision-workshop-roster.sh roster.csv` will pick up where it left off (idempotent). Documented for the user separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)