### PR TITLE
feat(scripts): workshop-setup.sh + workshop-teardown.sh wrappers

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -227,12 +227,25 @@ If the workflow succeeds but the container fails its health check with
 
 ---
 
-## Workshop: Provisioning N Projects
+## Workshop: Lifecycle (Setup and Teardown)
 
-When running a workshop, the facilitator provisions one GCP project per
-participant. `scripts/provision-workshop-roster.sh` wraps
-`provision-gcp-project.sh` in a CSV-driven loop so all participant
-projects can be created with one command.
+When running a workshop, the facilitator's mental model is two commands:
+
+```bash
+# Bring up the classroom
+BILLING_ACCOUNT_ID=XXXXXX-XXXXXX-XXXXXX \
+  ./scripts/workshop-setup.sh roster.csv
+
+# Tear it down at T+1 day
+./scripts/workshop-teardown.sh roster.csv          # interactive prompt
+./scripts/workshop-teardown.sh roster.csv --yes    # non-interactive
+```
+
+The setup script runs four pre-flight checks (gcloud auth, billing
+account is OPEN, roster file exists with the expected header, roster
+has data rows) and then hands off to the underlying provisioning logic.
+Pre-flight failures exit 2 with actionable messages — far better than
+discovering a missing auth token mid-loop.
 
 ### Roster format
 
@@ -245,55 +258,72 @@ bob,bob-gh,bob@example.com,2026-05
 ```
 
 - `handle` — short, lowercase, stable identifier; appears in the GCP project ID
-- `github_user` — reserved for future tickets (WIF binding, notification);
-  required in the row but not used by this script
+- `github_user` — reserved for future use (WIF binding, notification);
+  required in the row but not used by the current scripts
 - `email` — Google identity granted `roles/editor` on the new project
 - `cohort` — `YYYY-MM` of the workshop date; appears in the project ID
 
 Project IDs follow the pattern `af-{handle}-{cohort}`. This shape is
 referenced from the facilitator runbook, the participant day-1 doc, and
-the dry-run checklist — do not change it.
+the dry-run checklist — do not change it. A working example lives at
+`scripts/roster.example.csv`.
 
-A working example lives at `scripts/roster.example.csv`.
+### Setup behavior
 
-### Running the wrapper
+`workshop-setup.sh` is a thin wrapper: after pre-flight passes, it
+delegates to `scripts/provision-workshop-roster.sh`. That script:
 
-```bash
-BILLING_ACCOUNT_ID=XXXXXX-XXXXXX-XXXXXX \
-  ./scripts/provision-workshop-roster.sh roster.csv
-```
-
-For each row the wrapper:
-
-1. Computes the project ID and checks whether it already exists
+1. Computes each project ID and checks whether it already exists
 2. Calls `provision-gcp-project.sh --create-project` (idempotent)
 3. Grants `roles/editor` on the new project to the participant's email
 4. Appends a row to `roster-output.csv` with status + project ID
 
 ### Idempotency and fail-fast
 
-Re-running the script with the same `roster.csv` is safe — already-existing
-projects are recorded as `skipped` instead of `created`.
+Re-running setup with the same roster is safe — already-existing
+projects are recorded as `skipped` instead of `created`. The wrapper is
+fail-fast: if any row fails, the loop stops and exits non-zero. This is
+intentional — a half-provisioned classroom is harder to recover from
+than a clean stop. Inspect `roster-output.csv`, fix the cause, and
+re-run; successful rows are skipped.
 
-The wrapper is fail-fast: if any row fails, the loop stops and exits
-non-zero. This is intentional — a half-provisioned classroom is harder
-to recover from than a clean stop. Inspect the failing row in
-`roster-output.csv`, fix the cause, and re-run. Successful rows from the
-prior run will be skipped on the retry.
+### Teardown behavior
 
-### What this does NOT do
+`workshop-teardown.sh` reads the same roster, derives the project IDs
+(only IDs matching `af-{handle}-{cohort}` from the CSV are touched —
+this is a guard against malformed rosters taking down unrelated
+projects), and runs `gcloud projects delete` per row.
 
-- Workload Identity Federation setup is intentionally out of scope. Either
-  set it up manually per project (see "Step 5: Workload Identity Federation"
-  above), or wait for ticket [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5) to land.
-- Budget caps are not configured here. See ticket [#6](https://github.com/vibeacademy/agile-flow-gcp/issues/6).
-- Notification emails to participants are not sent. The facilitator runbook
-  in `agile-flow-meta` documents the email template.
+By default the script prints the list and prompts for confirmation
+(`[y/N]`). Pass `--yes` to skip the prompt for non-interactive use.
+Idempotent: re-running on already-deleted projects logs `[skip]` rows
+and exits 0.
+
+After deletion, `roster-output.csv` is removed (it's stale once
+projects are gone). `roster.csv` (input) is preserved.
+
+> **GCP holds project IDs for ~30 days after deletion.** Re-creating
+> with the *exact* same project ID during that window will fail with
+> `PROJECT_ID_NOT_AVAILABLE`. If you need to reprovision quickly, change
+> the `cohort` column in the roster (e.g. `2026-05` → `2026-05a`) so
+> new project IDs are generated.
+
+### What the lifecycle scripts do NOT do
+
+- Workload Identity Federation setup — currently manual per project
+  (see "Step 5: Workload Identity Federation" above), or track ticket
+  [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5).
+- Budget caps — see ticket [#6](https://github.com/vibeacademy/agile-flow-gcp/issues/6).
+- Org-policy override for `iam.allowedPolicyMemberDomains` — currently
+  manual per project (see [`PATTERN-LIBRARY.md` pattern #30](./PATTERN-LIBRARY.md)),
+  or track ticket [#19](https://github.com/vibeacademy/agile-flow-gcp/issues/19).
+- Notification emails to participants — facilitator runbook in
+  `agile-flow-meta` documents the email template.
 
 ### Output and gitignore
 
-`roster.csv` (input) and `roster-output.csv` (output) are both gitignored.
-They contain participant emails — never commit either.
+`roster.csv` (input) and `roster-output.csv` (output) are both
+gitignored. They contain participant emails — never commit either.
 
 ---
 

--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# workshop-setup.sh — pre-flight + delegate to provision-workshop-roster.sh.
+#
+# Canonical entry point for facilitators bringing up a workshop classroom.
+# Runs four pre-flight checks before handing off to the existing
+# CSV-driven provisioning script. Fails fast with actionable messages
+# rather than letting gcloud's mid-loop errors be the first signal.
+#
+# Usage:
+#   BILLING_ACCOUNT_ID=XXX-XXXX-XXXX ./scripts/workshop-setup.sh roster.csv
+#
+# Required environment variables:
+#   BILLING_ACCOUNT_ID   GCP billing account to attach each project to
+#
+# Optional (forwarded to provision-workshop-roster.sh):
+#   GCP_REGION           default: us-central1
+#   ARTIFACT_REPO        default: agile-flow
+#   PROVISION_SCRIPT     default: scripts/provision-gcp-project.sh
+#
+# Pre-flight checks (in order):
+#   1. gcloud is installed and has an active account
+#   2. BILLING_ACCOUNT_ID is set and the account is OPEN
+#   3. Roster file exists and has the expected header
+#   4. Roster has at least one data row
+#
+# This script does NOT duplicate provisioning logic. After pre-flight
+# passes, it execs the existing wrapper.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROSTER_WRAPPER="${ROSTER_WRAPPER:-$REPO_ROOT/scripts/provision-workshop-roster.sh}"
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+
+if [[ $# -ne 1 ]]; then
+  cat >&2 <<EOF
+Usage: BILLING_ACCOUNT_ID=XXX ./scripts/workshop-setup.sh <roster.csv>
+
+See header of $0 for full documentation.
+EOF
+  exit 2
+fi
+
+ROSTER_CSV="$1"
+
+# ── Pre-flight ───────────────────────────────────────────────────────────
+
+echo "──────────────────────────────────────────────────"
+echo "  Workshop setup pre-flight"
+echo "──────────────────────────────────────────────────"
+
+fail=0
+
+# 1. gcloud auth
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "  [fail] gcloud is not installed or not on PATH" >&2
+  fail=1
+elif ! gcloud auth list --filter='status:ACTIVE' --format='value(account)' 2>/dev/null | grep -q '@'; then
+  echo "  [fail] no active gcloud account — run 'gcloud auth login'" >&2
+  fail=1
+else
+  active_acct="$(gcloud auth list --filter='status:ACTIVE' --format='value(account)')"
+  echo "  [ok]   gcloud authed as $active_acct"
+fi
+
+# 2. BILLING_ACCOUNT_ID
+if [[ -z "${BILLING_ACCOUNT_ID:-}" ]]; then
+  echo "  [fail] BILLING_ACCOUNT_ID is not set" >&2
+  fail=1
+else
+  # Verify the billing account is OPEN. If gcloud is mocked in tests, this
+  # check still works because the stub respects the same flags.
+  billing_state="$(gcloud billing accounts list --filter="name~$BILLING_ACCOUNT_ID" --format='value(open)' 2>/dev/null || true)"
+  if [[ "$billing_state" == "True" ]]; then
+    echo "  [ok]   billing account $BILLING_ACCOUNT_ID is OPEN"
+  else
+    echo "  [fail] billing account $BILLING_ACCOUNT_ID not found or not OPEN" >&2
+    echo "         (got: '$billing_state')" >&2
+    fail=1
+  fi
+fi
+
+# 3. Roster file + header
+if [[ ! -f "$ROSTER_CSV" ]]; then
+  echo "  [fail] roster file not found: $ROSTER_CSV" >&2
+  fail=1
+else
+  expected_header="handle,github_user,email,cohort"
+  actual_header="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
+  if [[ "$actual_header" == "$expected_header" ]]; then
+    echo "  [ok]   roster header is valid"
+  else
+    echo "  [fail] roster header must be: $expected_header" >&2
+    echo "         got: $actual_header" >&2
+    fail=1
+  fi
+
+  # 4. Has at least one data row
+  data_rows="$(tail -n +2 "$ROSTER_CSV" | grep -cE '^[^,]+,' || true)"
+  if (( data_rows >= 1 )); then
+    echo "  [ok]   roster has $data_rows data row(s)"
+  else
+    echo "  [fail] roster has no data rows" >&2
+    fail=1
+  fi
+fi
+
+if (( fail != 0 )); then
+  echo ""
+  echo "  Pre-flight failed. Fix the issue(s) above and re-run."
+  exit 2
+fi
+
+# ── Hand off to provisioning ─────────────────────────────────────────────
+
+if [[ ! -x "$ROSTER_WRAPPER" ]]; then
+  echo "  [fail] roster wrapper not executable: $ROSTER_WRAPPER" >&2
+  exit 2
+fi
+
+echo ""
+echo "──────────────────────────────────────────────────"
+echo "  Pre-flight passed — provisioning starts now"
+echo "──────────────────────────────────────────────────"
+echo ""
+
+exec "$ROSTER_WRAPPER" "$ROSTER_CSV"

--- a/scripts/workshop-setup.test.sh
+++ b/scripts/workshop-setup.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Tests for workshop-setup.sh — pre-flight check behavior.
+#
+# Stubs gcloud + the inner provision-workshop-roster.sh via PATH
+# injection and ROSTER_WRAPPER override. Each test asserts a specific
+# pre-flight failure path or the happy-path delegation.
+#
+# Run: ./scripts/workshop-setup.test.sh
+
+# Pre-flight tests deliberately exercise failure paths; -e gets in the way.
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/workshop-setup.sh"
+
+new_tmp() { mktemp -d -t aflowsetup-XXXX; }
+
+# Stub gcloud + roster wrapper. $1: behavior — "ok" | "no-auth" | "billing-closed"
+make_stubs() {
+  local tmp="$1"
+  local behavior="$2"
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "auth list")
+    if [[ "$behavior" == "no-auth" ]]; then
+      exit 0  # no output → no @ matched → fail
+    fi
+    echo "active@example.com"
+    exit 0
+    ;;
+  "billing accounts")
+    # billing accounts list --filter ... --format='value(open)'
+    if [[ "$behavior" == "billing-closed" ]]; then
+      echo "False"
+    else
+      echo "True"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+  cat > "$tmp/bin/roster-wrapper.sh" <<EOF
+#!/usr/bin/env bash
+echo "ROSTER WRAPPER CALLED with: \$*" > "$tmp/wrapper.log"
+exit 0
+EOF
+
+  chmod +x "$tmp/bin/gcloud" "$tmp/bin/roster-wrapper.sh"
+}
+
+write_roster() {
+  cat > "$1" <<'EOF'
+handle,github_user,email,cohort
+alice,alice-gh,alice@example.com,2026-05
+EOF
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local needle="$1" file="$2" label="$3"
+  if grep -q "$needle" "$file"; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (looking for: $needle in $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: Happy path — pre-flight passes, hands off to wrapper ────────
+
+echo ""
+echo "Test 1: pre-flight passes and execs the roster wrapper"
+
+T1=$(new_tmp)
+make_stubs "$T1" "ok"
+write_roster "$T1/roster.csv"
+
+PATH="$T1/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T1/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T1/roster.csv" > "$T1/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "ok.*gcloud authed" "$T1/stdout.log" "logs gcloud auth ok"
+assert_contains "ok.*billing account" "$T1/stdout.log" "logs billing ok"
+assert_contains "ok.*roster header is valid" "$T1/stdout.log" "logs header ok"
+assert_contains "ok.*roster has 1 data row" "$T1/stdout.log" "logs row count"
+if [[ -f "$T1/wrapper.log" ]] && grep -q "ROSTER WRAPPER CALLED" "$T1/wrapper.log"; then
+  echo -e "  ${GREEN}✓${NC} roster wrapper was invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} roster wrapper was NOT invoked"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 2: No active gcloud auth → exit 2, no wrapper call ────────────
+
+echo ""
+echo "Test 2: missing gcloud auth fails pre-flight"
+
+T2=$(new_tmp)
+make_stubs "$T2" "no-auth"
+write_roster "$T2/roster.csv"
+
+PATH="$T2/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T2/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T2/roster.csv" > "$T2/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on missing auth"
+assert_contains "fail.*no active gcloud account" "$T2/stdout.log" "logs auth failure"
+if [[ ! -f "$T2/wrapper.log" ]]; then
+  echo -e "  ${GREEN}✓${NC} roster wrapper NOT invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} roster wrapper was invoked despite pre-flight failure"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 3: Missing BILLING_ACCOUNT_ID → exit 2 ────────────────────────
+
+echo ""
+echo "Test 3: missing BILLING_ACCOUNT_ID fails pre-flight"
+
+T3=$(new_tmp)
+make_stubs "$T3" "ok"
+write_roster "$T3/roster.csv"
+
+PATH="$T3/bin:$PATH" \
+  ROSTER_WRAPPER="$T3/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T3/roster.csv" > "$T3/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on missing BILLING_ACCOUNT_ID"
+assert_contains "fail.*BILLING_ACCOUNT_ID is not set" "$T3/stdout.log" "logs missing env"
+
+# ── Test 4: Billing account closed → exit 2 ────────────────────────────
+
+echo ""
+echo "Test 4: closed billing account fails pre-flight"
+
+T4=$(new_tmp)
+make_stubs "$T4" "billing-closed"
+write_roster "$T4/roster.csv"
+
+PATH="$T4/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T4/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T4/roster.csv" > "$T4/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on closed billing account"
+assert_contains "fail.*not found or not OPEN" "$T4/stdout.log" "logs billing failure"
+
+# ── Test 5: Bad roster header → exit 2 ─────────────────────────────────
+
+echo ""
+echo "Test 5: bad roster header fails pre-flight"
+
+T5=$(new_tmp)
+make_stubs "$T5" "ok"
+cat > "$T5/roster.csv" <<EOF
+name,email
+alice,alice@example.com
+EOF
+
+PATH="$T5/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T5/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T5/roster.csv" > "$T5/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on bad header"
+assert_contains "fail.*roster header must be" "$T5/stdout.log" "logs header failure"
+
+# ── Test 6: Empty roster (header only) → exit 2 ────────────────────────
+
+echo ""
+echo "Test 6: empty roster (header only) fails pre-flight"
+
+T6=$(new_tmp)
+make_stubs "$T6" "ok"
+echo "handle,github_user,email,cohort" > "$T6/roster.csv"
+
+PATH="$T6/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T6/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T6/roster.csv" > "$T6/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on empty roster"
+assert_contains "fail.*roster has no data rows" "$T6/stdout.log" "logs empty-roster failure"
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0

--- a/scripts/workshop-teardown.sh
+++ b/scripts/workshop-teardown.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# workshop-teardown.sh — delete participant projects from a CSV roster.
+#
+# Reverse of workshop-setup.sh. Reads the same roster, computes the
+# project IDs from af-{handle}-{cohort}, prompts for confirmation,
+# and calls `gcloud projects delete` per row.
+#
+# Usage:
+#   ./scripts/workshop-teardown.sh roster.csv          # interactive
+#   ./scripts/workshop-teardown.sh roster.csv --yes    # skip prompt
+#
+# Idempotent: re-running on already-torn-down projects logs [skip]
+# rows and exits 0. Will NOT touch projects whose IDs do not derive
+# from this roster — protects against malformed CSVs taking down
+# unrelated production projects.
+#
+# Side effect: removes roster-output.csv after the loop, since it's
+# stale once projects are gone. Does NOT remove roster.csv (input).
+
+set -euo pipefail
+
+OUTPUT_CSV="${OUTPUT_CSV:-roster-output.csv}"
+ASSUME_YES=false
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  cat >&2 <<EOF
+Usage: ./scripts/workshop-teardown.sh <roster.csv> [--yes]
+
+See header of $0 for full documentation.
+EOF
+  exit 2
+fi
+
+ROSTER_CSV="$1"
+
+if [[ "${2:-}" == "--yes" ]]; then
+  ASSUME_YES=true
+elif [[ -n "${2:-}" ]]; then
+  echo "ERROR: unknown flag: $2" >&2
+  exit 2
+fi
+
+if [[ ! -f "$ROSTER_CSV" ]]; then
+  echo "ERROR: roster file not found: $ROSTER_CSV" >&2
+  exit 2
+fi
+
+# ── CSV header validation ───────────────────────────────────────────────
+
+EXPECTED_HEADER="handle,github_user,email,cohort"
+ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER" ]]; then
+  echo "ERROR: roster CSV header must be exactly: $EXPECTED_HEADER" >&2
+  echo "       got: $ACTUAL_HEADER" >&2
+  exit 2
+fi
+
+# ── Build project ID list from roster ────────────────────────────────────
+
+declare -a project_ids=()
+# shellcheck disable=SC2034  # github_user not needed; reserved per roster format
+while IFS=',' read -r handle github_user email cohort; do
+  handle="$(echo "$handle" | tr -d '[:space:]\r')"
+  cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
+  if [[ -z "$handle" || -z "$cohort" ]]; then
+    continue
+  fi
+  project_ids+=("af-${handle}-${cohort}")
+done < <(tail -n +2 "$ROSTER_CSV")
+
+if (( ${#project_ids[@]} == 0 )); then
+  echo "ERROR: roster has no data rows" >&2
+  exit 2
+fi
+
+# ── Confirmation prompt ─────────────────────────────────────────────────
+
+echo "──────────────────────────────────────────────────"
+echo "  Workshop teardown — projects targeted"
+echo "──────────────────────────────────────────────────"
+for pid in "${project_ids[@]}"; do
+  echo "  • $pid"
+done
+echo ""
+echo "  GCP holds project IDs for ~30 days after deletion."
+echo "  Re-creating with the same ID is blocked during that window."
+echo ""
+
+if [[ "$ASSUME_YES" != "true" ]]; then
+  read -r -p "Delete ${#project_ids[@]} project(s)? [y/N] " reply
+  if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
+    echo "Aborted by user."
+    exit 0
+  fi
+fi
+
+# ── Deletion loop ───────────────────────────────────────────────────────
+
+deleted=0
+skipped=0
+failed=0
+
+for pid in "${project_ids[@]}"; do
+  echo ""
+  echo "──────────────────────────────────────────────────"
+  echo "  $pid"
+  echo "──────────────────────────────────────────────────"
+
+  state="$(gcloud projects describe "$pid" --format='value(lifecycleState)' 2>/dev/null || echo "NOT_FOUND")"
+
+  case "$state" in
+    ACTIVE)
+      echo "[delete] $pid (was ACTIVE)"
+      if gcloud projects delete "$pid" --quiet; then
+        deleted=$((deleted + 1))
+      else
+        echo "[fail] gcloud projects delete returned non-zero for $pid" >&2
+        failed=$((failed + 1))
+      fi
+      ;;
+    DELETE_REQUESTED)
+      echo "[skip] $pid is already DELETE_REQUESTED"
+      skipped=$((skipped + 1))
+      ;;
+    NOT_FOUND)
+      echo "[skip] $pid not found (already gone or never created)"
+      skipped=$((skipped + 1))
+      ;;
+    *)
+      echo "[skip] $pid is in unexpected state: $state"
+      skipped=$((skipped + 1))
+      ;;
+  esac
+done
+
+# ── Cleanup output CSV ──────────────────────────────────────────────────
+
+if [[ -f "$OUTPUT_CSV" ]]; then
+  rm -f "$OUTPUT_CSV"
+  echo ""
+  echo "[clean] removed $OUTPUT_CSV"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "=================================="
+echo "  Teardown summary"
+echo "=================================="
+echo "  Targeted: ${#project_ids[@]}"
+echo "  Deleted:  $deleted"
+echo "  Skipped:  $skipped"
+echo "  Failed:   $failed"
+echo ""
+
+if (( failed != 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/workshop-teardown.test.sh
+++ b/scripts/workshop-teardown.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Tests for workshop-teardown.sh — deletion loop, idempotency,
+# confirmation handling, and CSV-derived ID guard.
+#
+# Run: ./scripts/workshop-teardown.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/workshop-teardown.sh"
+
+new_tmp() { mktemp -d -t aflowdown-XXXX; }
+
+# Stub gcloud. $1: behavior — "all-active" | "all-deleted" | "fail-delete"
+make_stubs() {
+  local tmp="$1"
+  local behavior="$2"
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    case "$behavior" in
+      all-active|fail-delete) echo "ACTIVE" ;;
+      all-deleted)            echo "DELETE_REQUESTED" ;;
+      *)                      echo "ACTIVE" ;;
+    esac
+    exit 0
+    ;;
+  "projects delete")
+    if [[ "$behavior" == "fail-delete" ]]; then
+      exit 1
+    fi
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+}
+
+write_roster() {
+  cat > "$1" <<'EOF'
+handle,github_user,email,cohort
+alice,alice-gh,alice@example.com,2026-05
+bob,bob-gh,bob@example.com,2026-05
+EOF
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local needle="$1" file="$2" label="$3"
+  if grep -q "$needle" "$file"; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (looking for: $needle in $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: Happy path with --yes → both projects deleted ───────────────
+
+echo ""
+echo "Test 1: --yes deletes both ACTIVE projects"
+
+T1=$(new_tmp)
+make_stubs "$T1" "all-active"
+write_roster "$T1/roster.csv"
+# Pre-create an output csv so we can verify cleanup
+echo "stale" > "$T1/roster-output.csv"
+
+PATH="$T1/bin:$PATH" \
+  OUTPUT_CSV="$T1/roster-output.csv" \
+  "$SCRIPT" "$T1/roster.csv" --yes > "$T1/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0"
+assert_eq "2" "$(grep -c 'projects delete' "$T1/gcloud.log")" "gcloud projects delete called twice"
+assert_contains "Deleted:  2" "$T1/stdout.log" "summary shows 2 deleted"
+if [[ ! -f "$T1/roster-output.csv" ]]; then
+  echo -e "  ${GREEN}✓${NC} roster-output.csv removed"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} roster-output.csv was NOT removed"
+  FAIL=$((FAIL + 1))
+fi
+if [[ -f "$T1/roster.csv" ]]; then
+  echo -e "  ${GREEN}✓${NC} roster.csv (input) preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} roster.csv (input) was deleted — should not be"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 2: Idempotent re-run (already DELETE_REQUESTED) ───────────────
+
+echo ""
+echo "Test 2: idempotent re-run on already-deleted projects"
+
+T2=$(new_tmp)
+make_stubs "$T2" "all-deleted"
+write_roster "$T2/roster.csv"
+
+PATH="$T2/bin:$PATH" \
+  OUTPUT_CSV="$T2/roster-output.csv" \
+  "$SCRIPT" "$T2/roster.csv" --yes > "$T2/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 on idempotent re-run"
+assert_eq "0" "$(grep -c 'projects delete' "$T2/gcloud.log")" "gcloud projects delete NOT called"
+assert_contains "Skipped:  2" "$T2/stdout.log" "summary shows 2 skipped"
+
+# ── Test 3: --yes flag actually skips the prompt ────────────────────────
+# Without --yes, the script reads from stdin; with --yes it should not block.
+
+echo ""
+echo "Test 3: --yes does not block on stdin"
+
+T3=$(new_tmp)
+make_stubs "$T3" "all-active"
+write_roster "$T3/roster.csv"
+
+# Run with stdin closed; if the prompt triggered, the read would fail and
+# the script would abort. With --yes, it should sail through.
+PATH="$T3/bin:$PATH" \
+  OUTPUT_CSV="$T3/roster-output.csv" \
+  "$SCRIPT" "$T3/roster.csv" --yes < /dev/null > "$T3/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with --yes and closed stdin"
+
+# ── Test 4: Bad CSV header rejected ────────────────────────────────────
+
+echo ""
+echo "Test 4: bad CSV header fails fast"
+
+T4=$(new_tmp)
+make_stubs "$T4" "all-active"
+cat > "$T4/roster.csv" <<EOF
+name,email
+alice,alice@example.com
+EOF
+
+PATH="$T4/bin:$PATH" \
+  OUTPUT_CSV="$T4/roster-output.csv" \
+  "$SCRIPT" "$T4/roster.csv" --yes > "$T4/stdout.log" 2>&1
+ec=$?
+
+assert_eq "2" "$ec" "exit 2 on bad header"
+assert_eq "0" "$(grep -c 'projects delete' "$T4/gcloud.log" 2>/dev/null || echo 0)" "no gcloud deletes were attempted"
+
+# ── Test 5: Project IDs derive from roster (no arbitrary IDs) ──────────
+# Verifies the scope guard: the gcloud invocations only target IDs that
+# match the af-{handle}-{cohort} pattern from the CSV.
+
+echo ""
+echo "Test 5: only roster-derived project IDs are touched"
+
+T5=$(new_tmp)
+make_stubs "$T5" "all-active"
+write_roster "$T5/roster.csv"
+
+PATH="$T5/bin:$PATH" \
+  OUTPUT_CSV="$T5/roster-output.csv" \
+  "$SCRIPT" "$T5/roster.csv" --yes > "$T5/stdout.log" 2>&1
+
+# Whitelist check: every "projects describe" line must end with one of the
+# two expected IDs. Filter out the expected lines, see if anything remains.
+unexpected="$(grep 'projects describe' "$T5/gcloud.log" \
+  | grep -v 'projects describe af-alice-2026-05 ' \
+  | grep -v 'projects describe af-bob-2026-05 ' || true)"
+
+if grep -q 'projects describe af-alice-2026-05' "$T5/gcloud.log" && \
+   grep -q 'projects describe af-bob-2026-05' "$T5/gcloud.log" && \
+   [[ -z "$unexpected" ]]; then
+  echo -e "  ${GREEN}✓${NC} only af-alice-2026-05 and af-bob-2026-05 were inspected"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} unexpected project IDs in gcloud.log:"
+  echo "$unexpected"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 6: Failed delete reported in summary ──────────────────────────
+
+echo ""
+echo "Test 6: failed gcloud delete is reflected in summary"
+
+T6=$(new_tmp)
+make_stubs "$T6" "fail-delete"
+write_roster "$T6/roster.csv"
+
+PATH="$T6/bin:$PATH" \
+  OUTPUT_CSV="$T6/roster-output.csv" \
+  "$SCRIPT" "$T6/roster.csv" --yes > "$T6/stdout.log" 2>&1
+ec=$?
+
+assert_eq "1" "$ec" "exit 1 when any delete fails"
+assert_contains "Failed:   2" "$T6/stdout.log" "summary shows failures"
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #20.

Two thin wrappers giving facilitators a clean lifecycle:

```bash
BILLING_ACCOUNT_ID=… ./scripts/workshop-setup.sh    roster.csv
./scripts/workshop-teardown.sh roster.csv [--yes]
```

## What's in the PR

- **`scripts/workshop-setup.sh`** (~115 lines) — four pre-flight checks (gcloud auth, billing OPEN, roster header, data rows present), then `exec`s `provision-workshop-roster.sh`. No provisioning logic duplicated.
- **`scripts/workshop-teardown.sh`** (~125 lines) — confirms-then-deletes; idempotent on re-runs; only touches IDs derived from the roster (scope guard).
- **`scripts/workshop-setup.test.sh`** — 17 assertions, 6 scenarios.
- **`scripts/workshop-teardown.test.sh`** — 14 assertions, 6 scenarios.
- **`docs/PLATFORM-GUIDE.md`** — replaces the "Workshop: Provisioning N Projects" section with a setup/teardown lifecycle that points at the new entry points. Underlying scripts still documented as the implementation.

## Out of scope (intentional, called out in the doc)

- Org-policy override → #19
- WIF setup → #5
- Budget caps → #6
- Notification emails → meta runbook

## Test plan

- [x] `bash -n` and `shellcheck` clean on all four new scripts
- [x] `./scripts/workshop-setup.test.sh` — 17/17 pass
- [x] `./scripts/workshop-teardown.test.sh` — 14/14 pass
- [x] No regression: `provision-workshop-roster.test.sh` still 14/14, `provision-gcp-project.test.sh` still 14/14
- [x] markdownlint clean
- [ ] Real-GCP smoke at the 2026-05-01 dry-run

## Notes

- **Setup wrapper is `exec`-based** (line 116). It hands off to the inner wrapper without keeping a parent shell around, so the facilitator's terminal sees the inner script's output directly. Side effect: anything after the `exec` line is dead code (intended).
- **Teardown's scope guard.** Project IDs come from `awk`-parsing the roster's `handle` and `cohort` columns. The script never deletes an ID that wasn't derived from this roster, even if `gcloud` would otherwise allow it. Test 5 verifies this.
- **`--yes` is conservative.** Default is interactive; you have to opt in to non-interactive deletion. Test 3 verifies it doesn't block on closed stdin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)