### PR TITLE
fix(scripts): override iam.allowedPolicyMemberDomains in provisioner; correct doc command

### DIFF
--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -993,24 +993,35 @@ first IAM binding for the very first participant fails.
 
 **Pattern: disable the constraint per-project, scoped to workshop projects only.**
 
-Run this *once per participant project*, after `provision-gcp-project.sh`
-creates the project and before `gcloud projects add-iam-policy-binding`
-attempts the binding (the workshop wrapper calls the binding directly,
-so the override must run in between):
+As of `provision-gcp-project.sh` Step 1.5, the override is applied
+automatically per project right after creation. You do not normally need
+to run it by hand. The pattern below is for reference and for
+out-of-band cases (e.g. recovering an existing project).
+
+> **`disable-enforce` does not work here.** This is a *list constraint*
+> (with `allowedValues` / `allValues`), not a boolean. `disable-enforce`
+> only works on boolean constraints — using it returns
+> `INVALID_ARGUMENT: Policy and Constraint must be of the same type`.
+> Use `set-policy` with the YAML/JSON `listPolicy: { allValues: ALLOW }`
+> form below.
 
 ```bash
-# Check whether the org has the constraint enforced. Idempotent — no-op
-# if not enforced. Requires roles/orgpolicy.policyAdmin on the project,
+# Apply per project. Idempotent — re-running is a no-op.
+# Requires roles/orgpolicy.policyAdmin on the project,
 # which the project creator has by default.
 
 if gcloud resource-manager org-policies describe \
   iam.allowedPolicyMemberDomains \
   --project="$GCP_PROJECT_ID" \
-  --format='value(booleanPolicy.enforced)' 2>/dev/null | grep -q true; then
-  echo "[override] disabling domain-restricted-sharing for $GCP_PROJECT_ID"
-  gcloud resource-manager org-policies disable-enforce \
-    iam.allowedPolicyMemberDomains \
-    --project="$GCP_PROJECT_ID"
+  --format='value(listPolicy.allValues)' 2>/dev/null | grep -q '^ALLOW$'; then
+  echo "[skip] override already in place for $GCP_PROJECT_ID"
+elif gcloud resource-manager org-policies list \
+  --project="$GCP_PROJECT_ID" \
+  --format='value(constraint)' 2>/dev/null | grep -q 'allowedPolicyMemberDomains'; then
+  echo "[override] applying domain-restricted-sharing override for $GCP_PROJECT_ID"
+  echo '{"constraint":"constraints/iam.allowedPolicyMemberDomains","listPolicy":{"allValues":"ALLOW"}}' \
+    | gcloud resource-manager org-policies set-policy /dev/stdin \
+        --project="$GCP_PROJECT_ID"
 fi
 ```
 
@@ -1036,8 +1047,10 @@ that failed will succeed within seconds. There is no propagation lag
 on the policy override itself in our experience, but the SA-binding
 retry helper covers the rare case where there is.
 
-**Where this fits in the workshop flow:** the runbook's T-3 days
-provisioning step covers the override. Once
-`provision-workshop-roster.sh` ships the override inline (planned
-follow-up; not yet shipped), facilitators won't need to think about
-this.
+**Where this fits in the workshop flow:** as of #19,
+`provision-gcp-project.sh` runs the override automatically per project
+(Step 1.5, between project creation and API enable). Facilitators do
+not need to apply it manually for new workshop projects. The runbook's
+T-3 days section retains a recovery snippet for projects provisioned
+before #19, or for cases where the override needs to be re-applied
+out-of-band.

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -185,6 +185,35 @@ if [[ "$CREATE_PROJECT" == "true" ]]; then
     --billing-account="$BILLING_ACCOUNT_ID"
 fi
 
+# ── Step 1.5: Override Domain Restricted Sharing (workshop projects) ─────
+#
+# If the parent org enforces `iam.allowedPolicyMemberDomains` (a list
+# constraint, on by default for Cloud Identity Free orgs), every
+# subsequent IAM binding to an external-domain identity (Gmail, other
+# Workspace) fails with FAILED_PRECONDITION. Override per project:
+# allValues=ALLOW so any Google identity can be a binding member.
+# Production projects in the same org keep their constraint.
+#
+# This is a list constraint, NOT a boolean — `disable-enforce` does not
+# work; `set-policy` with the explicit listPolicy form does. See
+# docs/PATTERN-LIBRARY.md pattern #30.
+
+if gcloud resource-manager org-policies describe \
+  iam.allowedPolicyMemberDomains \
+  --project="$GCP_PROJECT_ID" \
+  --format='value(listPolicy.allValues)' 2>/dev/null | grep -q '^ALLOW$'; then
+  echo "[skip] domain-restricted-sharing override already in place for $GCP_PROJECT_ID"
+elif gcloud resource-manager org-policies list \
+  --project="$GCP_PROJECT_ID" \
+  --format='value(constraint)' 2>/dev/null | grep -q 'allowedPolicyMemberDomains'; then
+  echo "[override] applying domain-restricted-sharing override for $GCP_PROJECT_ID"
+  echo '{"constraint":"constraints/iam.allowedPolicyMemberDomains","listPolicy":{"allValues":"ALLOW"}}' \
+    | gcloud resource-manager org-policies set-policy /dev/stdin \
+        --project="$GCP_PROJECT_ID"
+else
+  echo "[skip] domain-restricted-sharing not enforced; no override needed"
+fi
+
 # ── Step 2: Enable APIs ──────────────────────────────────────────────────
 
 echo "[enable] Required APIs (may take 30-60 seconds on first run)"

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -330,6 +330,153 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 9-11: Step 1.5 domain-restricted-sharing override ──────────────
+#
+# The script's Step 1.5 has three branches:
+#   - override already in place (allValues=ALLOW)  → [skip]
+#   - constraint enforced, override not yet applied → set-policy is called
+#   - constraint not enforced at all                → [skip]
+#
+# Each branch is exercised below. Stubs inject controlled responses to
+# `org-policies describe` and `org-policies list`, capture set-policy
+# calls in a log, and short-circuit before the real provisioning steps
+# (we exit the stub gcloud non-zero on `services` so the script aborts
+# before Step 2 — this is intentional: we only need to verify Step 1.5
+# behavior, not the whole flow).
+
+run_step1_5_test() {
+  local label="$1"
+  local override_state="$2"   # "already-applied" | "enforced" | "not-enforced"
+  local tmp; tmp=$(mktemp -d -t aflowtest-XXXX)
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    # Existence check returns 1 (project doesn't exist) so the script
+    # takes the create path — but we stub create to succeed.
+    exit 1
+    ;;
+  "projects create") exit 0 ;;
+  "billing projects") exit 0 ;;
+  "resource-manager org-policies")
+    # Branch on subcommand
+    case "\$3" in
+      describe)
+        case "$override_state" in
+          already-applied) echo "ALLOW"; exit 0 ;;
+          *)               exit 1 ;;
+        esac
+        ;;
+      list)
+        case "$override_state" in
+          enforced) echo "constraints/iam.allowedPolicyMemberDomains"; exit 0 ;;
+          *)        exit 0 ;;
+        esac
+        ;;
+      set-policy)
+        # Read the YAML/JSON body from /dev/stdin, log it
+        cat >> "$tmp/set-policy-body.log"
+        exit 0
+        ;;
+    esac
+    ;;
+  "services enable")
+    # Short-circuit here so the test doesn't have to mock the rest.
+    exit 1
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+
+  set +e
+  PATH="$tmp/bin:$PATH" \
+    GCP_PROJECT_ID="af-policy-test" \
+    BILLING_ACCOUNT_ID="FAKE" \
+    "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
+  set -e
+
+  echo "$tmp"
+}
+
+# Test 9: override already applied → [skip] message, set-policy NOT called
+
+echo ""
+echo "Test 9: Step 1.5 skips when override already in place"
+
+T9=$(run_step1_5_test "already-applied" "already-applied")
+
+if grep -q "already in place" "$T9/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'already in place' in stdout"
+  cat "$T9/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+set_policy_calls=0
+if [[ -f "$T9/gcloud.log" ]]; then
+  set_policy_calls="$(grep -c 'set-policy' "$T9/gcloud.log" || true)"
+fi
+assert_eq "0" "$set_policy_calls" "set-policy NOT called when already in place"
+
+# Test 10: constraint enforced → set-policy called with correct body
+
+echo ""
+echo "Test 10: Step 1.5 applies override when constraint is enforced"
+
+T10=$(run_step1_5_test "enforced" "enforced")
+
+if grep -q "applying domain-restricted-sharing override" "$T10/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} override-applied message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'applying domain-restricted-sharing override' in stdout"
+  cat "$T10/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+set_policy_calls=0
+if [[ -f "$T10/gcloud.log" ]]; then
+  set_policy_calls="$(grep -c 'set-policy' "$T10/gcloud.log" || true)"
+fi
+assert_eq "1" "$set_policy_calls" "set-policy called exactly once"
+
+if [[ -f "$T10/set-policy-body.log" ]] && grep -q '"allValues":"ALLOW"' "$T10/set-policy-body.log"; then
+  echo -e "  ${GREEN}✓${NC} set-policy body has allValues:ALLOW"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} set-policy body did not contain allValues:ALLOW"
+  cat "$T10/set-policy-body.log" 2>/dev/null || echo "(body file not written)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 11: constraint not enforced → [skip] message, set-policy NOT called
+
+echo ""
+echo "Test 11: Step 1.5 skips when constraint is not enforced"
+
+T11=$(run_step1_5_test "not-enforced" "not-enforced")
+
+if grep -q "not enforced" "$T11/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} not-enforced skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'not enforced' in stdout"
+  cat "$T11/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+set_policy_calls=0
+if [[ -f "$T11/gcloud.log" ]]; then
+  set_policy_calls="$(grep -c 'set-policy' "$T11/gcloud.log" || true)"
+fi
+assert_eq "0" "$set_policy_calls" "set-policy NOT called when constraint absent"
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #19. **P0 — dry-run is in 4 days.**

Two fixes that ship together:

### 1. provision-gcp-project.sh — new Step 1.5

After project creation and billing-link, before APIs/SA/bindings, the script now detects whether the parent org enforces `iam.allowedPolicyMemberDomains` and applies a per-project override (`allValues: ALLOW`) if so. Three branches:

| Branch | Log |
|---|---|
| Override already in place (`allValues=ALLOW`) | `[skip] override already in place` |
| Constraint enforced, override not yet applied | `[override] applying domain-restricted-sharing override` |
| Constraint absent | `[skip] not enforced; no override needed` |

Idempotent — re-runs through the first branch.

### 2. PATTERN-LIBRARY.md pattern #30 — correct gcloud command

Previous version used `disable-enforce`, which **only works on boolean constraints**. `iam.allowedPolicyMemberDomains` is a list constraint; `disable-enforce` against it returns `INVALID_ARGUMENT: Policy and Constraint must be of the same type`. The correct invocation is `set-policy` with the explicit `listPolicy: { allValues: ALLOW }` body. Pattern #30 now reflects that, with a callout warning future readers about the trap.

The pattern's "Where this fits" section is updated to note the override is now automatic per-project; the manual snippet remains for recovery scenarios.

## Tests

`scripts/provision-gcp-project.test.sh` gains tests 9–11 covering all three branches:

- Test 9: override already applied → `[skip]` message, `set-policy` NOT called
- Test 10: constraint enforced → `set-policy` called exactly once, body contains `"allValues":"ALLOW"`
- Test 11: constraint absent → `[skip]` message, `set-policy` NOT called

All 28 assertions pass (existing 21 + 7 new). No regression.

## Companion PR

`agile-flow-meta`#TBD — runbook §5 also has the wrong `disable-enforce` command; will be filed alongside this. Same fix shape: replace with `set-policy`, mark Step 1.5 as automatic.

## Test plan

- [x] `bash -n` and `shellcheck` clean on the script and the test
- [x] 28/28 helper tests pass
- [x] No regression on existing 21
- [x] markdownlint clean on PATTERN-LIBRARY.md
- [ ] Real-GCP smoke at the 2026-05-01 dry-run

## Implementation notes

- **Detection uses two gcloud calls.** First, `org-policies describe ... --format='value(listPolicy.allValues)'` — if it prints `ALLOW`, the override is already in place. Otherwise, `org-policies list` is grepped for the constraint name; if present, set-policy runs. If neither, skip. This avoids re-applying when the policy is already in the right state, which would otherwise be a wasted `set-policy` call per re-run.
- **set-policy body via `/dev/stdin`.** The `echo '{...}' | gcloud ... set-policy /dev/stdin` form works in both bash and fish; no heredoc indentation traps. Same shape the user discovered manually in fish.
- **Step 1.5 placement.** After project creation + billing-link (Step 1) and before API enable (Step 2). The deployer-SA bindings later target a service account on the project's own domain so they don't actually hit the constraint, but the *participant* binding in `provision-workshop-roster.sh` does — so applying the override early is the correct seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)