### PR TITLE
docs(platform): explain how a participant fork links to a GCP project

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -107,6 +107,45 @@ gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
   --role="roles/secretmanager.secretAccessor"
 ```
 
+### How a participant fork "links" to a GCP project
+
+There is no automatic link between a GitHub fork and a GCP project. The
+"link" is just **four GitHub Actions secrets** that point the fork's
+deploy workflow at the right project. When a participant pushes to
+`main` on their fork, `deploy.yml` runs, reads these secrets, and uses
+them to authenticate to GCP and deploy to that specific project.
+
+| Secret | Example | Source |
+|---|---|---|
+| `GCP_PROJECT_ID` | `af-bob-2026-05` | provisioner output |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123456789/locations/global/workloadIdentityPools/github/providers/github` | provisioner output (after Step 5 below) |
+| `GCP_SERVICE_ACCOUNT` | `deployer@af-bob-2026-05.iam.gserviceaccount.com` | provisioner output |
+| `NEON_API_KEY` | the workshop's shared Neon API key | facilitator |
+
+The first three are *per-participant*; the fourth is shared across the
+cohort. The participant pastes them into their fork's
+`Settings > Secrets and variables > Actions` panel, and that's the
+entire handoff. No shared identity, no project metadata stored in
+either system — just secret values.
+
+**End-to-end for one participant (`bob`):**
+
+1. Facilitator runs `provision-workshop-roster.sh` → `af-bob-2026-05` exists with the deployer SA.
+2. Facilitator runs the WIF setup in Step 5 below, plugging in `bob-gh/agile-flow-gcp` as the GitHub repo. This creates the trust relationship: "GitHub Actions runs in `bob-gh/agile-flow-gcp` may impersonate `deployer@af-bob-2026-05`."
+3. Facilitator emails bob the four secret values. (Template in `agile-flow-meta/docs/workshops/gcp-facilitator-runbook.md` §7.)
+4. Bob forks `vibeacademy/agile-flow-gcp` to his account, pastes the four secrets, pushes a trivial change to `main`. The deploy workflow uses WIF to assume the deployer SA and ships the container to bob's project.
+
+**The most common participant footgun:** if bob renames his fork (e.g.
+`bob-gh/my-cool-project`), WIF auth fails because the trust binding
+names `bob-gh/agile-flow-gcp` exactly. Tell participants in their
+day-1 email: do not rename the fork.
+
+WIF setup is currently per-project and manual; ticket [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5) tracks
+folding it into `provision-gcp-project.sh` so the four secrets above
+fall out of one provisioning command.
+
+---
+
 ### Step 5: Set Up Workload Identity Federation (Recommended)
 
 Workload Identity Federation lets GitHub Actions authenticate to GCP


### PR DESCRIPTION
## Summary

Quick fix — no linked ticket. User asked how the handoff works during workshop prep; turned out the docs didn't have a clear conceptual explanation in one place.

Adds a "How a participant fork 'links' to a GCP project" section to `docs/PLATFORM-GUIDE.md` immediately before "Step 5: Workload Identity Federation". The section explains:

- The link is just **four GitHub Actions secrets** — no shared identity, no metadata stored in either system
- A table mapping each secret to its source (provisioner output or facilitator-supplied)
- An end-to-end worked example for one synthetic participant (`bob`)
- The rename-fork footgun called out, with a clear note for what to put in the participant day-1 email
- Forward-reference to ticket #5 (planned WIF automation)

## Why this lives in PLATFORM-GUIDE.md

The conceptual explanation is stack-specific (WIF + GitHub Actions secrets + Cloud Run deploy workflow). PATTERN-LIBRARY.md is for gotchas/recipes, not architectural overviews. The facilitator runbook in `agile-flow-meta` operationalizes the same handoff — this PR could spawn a brief cross-link from there in a follow-up if it'd help.

## Length

~40 lines. Kept short on purpose; long architectural docs decay fastest.

## Test plan

- [x] `markdownlint` clean
- [ ] Reviewer skims for accuracy of the WIF binding string and footgun

🤖 Generated with [Claude Code](https://claude.com/claude-code)