### PR TITLE
feat(scripts): automate Workload Identity Federation per project

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -140,9 +140,10 @@ either system — just secret values.
 names `bob-gh/agile-flow-gcp` exactly. Tell participants in their
 day-1 email: do not rename the fork.
 
-WIF setup is currently per-project and manual; ticket [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5) tracks
-folding it into `provision-gcp-project.sh` so the four secrets above
-fall out of one provisioning command.
+As of #5, WIF setup is automatic per-project — the four secrets above
+fall out of `provision-gcp-project.sh` Step 5.5 when `GITHUB_USERNAME`
+is set. The workshop wrapper exports it automatically per CSV row.
+See Step 5 below for details.
 
 ---
 
@@ -151,6 +152,40 @@ fall out of one provisioning command.
 Workload Identity Federation lets GitHub Actions authenticate to GCP
 without storing a long-lived service account key. This is the best
 practice and should be your default.
+
+**As of `provision-gcp-project.sh` Step 5.5, this is automatic per
+project.** Set `GITHUB_USERNAME` and the script creates the pool, the
+OIDC provider, and the IAM binding scoped to
+`<github_user>/agile-flow-gcp`.
+
+```bash
+GCP_PROJECT_ID=af-alice-2026-05 \
+BILLING_ACCOUNT_ID=XXX-XXXX-XXXX \
+GITHUB_USERNAME=alice-gh \
+  ./scripts/provision-gcp-project.sh --create-project
+```
+
+The script's "Next steps" output prints the exact `GCP_WORKLOAD_IDENTITY_PROVIDER`
+and `GCP_SERVICE_ACCOUNT` values to paste into the participant's fork
+secrets — no copying from this doc, no project-number arithmetic.
+
+The workshop wrapper (`provision-workshop-roster.sh`) reads `github_user`
+from each `roster.csv` row and exports `GITHUB_USERNAME` automatically,
+so a facilitator running the canonical workshop flow never needs to
+think about WIF setup at all. The wrapper also records the WIF provider
+resource string in `roster-output.csv` per row.
+
+> **Don't rename the fork.** The IAM binding is pinned to
+> `<github_user>/agile-flow-gcp` exactly. If a participant renames their
+> fork (e.g. `bob-gh/my-cool-project`), WIF auth fails on first deploy
+> with a clear error from `google-github-actions/auth`. Tell participants
+> in their day-1 email: fork as-is, do not rename.
+
+#### Manual fallback (rarely needed)
+
+If you need to set WIF up by hand — for an out-of-band project, a
+non-default repo name without using the `WIF_REPO` env override, or
+debugging — the original sequence:
 
 ```bash
 # Create the pool
@@ -165,7 +200,6 @@ gcloud iam workload-identity-pools providers create-oidc github \
   --location=global \
   --issuer-uri="https://token.actions.githubusercontent.com" \
   --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.actor=assertion.actor" \
-  --attribute-condition="assertion.repository_owner == 'YOUR_GITHUB_ORG'" \
   --project=YOUR_PROJECT_ID
 
 # Get the project number (different from project ID)
@@ -175,11 +209,11 @@ PROJECT_NUMBER=$(gcloud projects describe YOUR_PROJECT_ID --format='value(projec
 gcloud iam service-accounts add-iam-policy-binding \
   "deployer@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/YOUR_GITHUB_ORG/YOUR_REPO" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/GITHUB_USER/REPO_NAME" \
   --project=YOUR_PROJECT_ID
 ```
 
-The WIF provider resource name you need for GitHub secrets is:
+The WIF provider resource name to paste into GitHub secrets is:
 
 ```
 projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/github

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -289,6 +289,78 @@ for role in "${ROLES[@]}"; do
       --quiet >/dev/null
 done
 
+# ── Step 5.5: Workload Identity Federation (when GITHUB_USERNAME set) ────
+#
+# Trust GitHub Actions OIDC tokens from a specific repo so deploys can
+# impersonate the deployer SA without a long-lived JSON key. Gated on
+# GITHUB_USERNAME being set — when unset, this whole block is skipped
+# and the script's existing --with-sa-key path remains the auth fallback.
+#
+# WIF_REPO defaults to `agile-flow-gcp`. Workshop participants fork the
+# canonical template without renaming, so the binding pattern is always
+# <github_user>/agile-flow-gcp. Override WIF_REPO if you ever need a
+# different repo name (dry-run smoke, non-workshop callers).
+#
+# We deliberately do NOT add --attribute-condition restricting to a
+# specific GitHub org — workshop participants fork under their personal
+# accounts, not the canonical org. Access is scoped at the IAM binding
+# layer instead, where attribute.repository=<user>/agile-flow-gcp
+# pins the trust to one specific repo.
+#
+# All three sub-steps (pool, provider, binding) are idempotent.
+
+if [[ -n "${GITHUB_USERNAME:-}" ]]; then
+  WIF_REPO="${WIF_REPO:-agile-flow-gcp}"
+  WIF_POOL="github"
+  WIF_PROVIDER="github"
+
+  PROJECT_NUMBER="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')"
+
+  # 5.5a: Create the workload-identity pool (idempotent)
+  if gcloud iam workload-identity-pools describe "$WIF_POOL" \
+    --location=global \
+    --project="$GCP_PROJECT_ID" >/dev/null 2>&1; then
+    echo "[skip] WIF pool '$WIF_POOL' already exists"
+  else
+    echo "[create] WIF pool '$WIF_POOL'"
+    gcloud iam workload-identity-pools create "$WIF_POOL" \
+      --location=global \
+      --display-name="GitHub Actions" \
+      --project="$GCP_PROJECT_ID"
+  fi
+
+  # 5.5b: Create the OIDC provider trusting GitHub Actions tokens
+  if gcloud iam workload-identity-pools providers describe "$WIF_PROVIDER" \
+    --workload-identity-pool="$WIF_POOL" \
+    --location=global \
+    --project="$GCP_PROJECT_ID" >/dev/null 2>&1; then
+    echo "[skip] WIF provider '$WIF_PROVIDER' already exists"
+  else
+    echo "[create] WIF provider '$WIF_PROVIDER'"
+    gcloud iam workload-identity-pools providers create-oidc "$WIF_PROVIDER" \
+      --workload-identity-pool="$WIF_POOL" \
+      --location=global \
+      --issuer-uri="https://token.actions.githubusercontent.com" \
+      --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.actor=assertion.actor" \
+      --project="$GCP_PROJECT_ID"
+  fi
+
+  # 5.5c: Bind the deployer SA so the specific repo can impersonate it.
+  # add-iam-policy-binding is idempotent — re-running with the same member
+  # is a no-op.
+  WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/attribute.repository/${GITHUB_USERNAME}/${WIF_REPO}"
+  echo "[bind] roles/iam.workloadIdentityUser <- ${GITHUB_USERNAME}/${WIF_REPO}"
+  gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+    --role="roles/iam.workloadIdentityUser" \
+    --member="$WIF_MEMBER" \
+    --project="$GCP_PROJECT_ID" \
+    --quiet >/dev/null
+
+  WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/providers/${WIF_PROVIDER}"
+else
+  echo "[skip] WIF setup not requested (GITHUB_USERNAME unset)"
+fi
+
 # ── Step 6: Service account key (workshop shortcut) ─────────────────────
 
 if [[ "$WITH_SA_KEY" == "true" ]]; then
@@ -322,8 +394,11 @@ echo ""
 echo "   GCP_PROJECT_ID         = $GCP_PROJECT_ID"
 if [[ "$WITH_SA_KEY" == "true" ]]; then
   echo "   GCP_SA_KEY             = (contents of ${GCP_PROJECT_ID}-deployer-key.json)"
+elif [[ -n "${WIF_PROVIDER_RESOURCE:-}" ]]; then
+  echo "   GCP_WORKLOAD_IDENTITY_PROVIDER = $WIF_PROVIDER_RESOURCE"
+  echo "   GCP_SERVICE_ACCOUNT    = $SA_EMAIL"
 else
-  echo "   GCP_WORKLOAD_IDENTITY_PROVIDER = (see docs/PLATFORM-GUIDE.md Step 5)"
+  echo "   GCP_WORKLOAD_IDENTITY_PROVIDER = (set GITHUB_USERNAME or see docs/PLATFORM-GUIDE.md Step 5)"
   echo "   GCP_SERVICE_ACCOUNT    = $SA_EMAIL"
 fi
 echo ""

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -477,6 +477,200 @@ if [[ -f "$T11/gcloud.log" ]]; then
 fi
 assert_eq "0" "$set_policy_calls" "set-policy NOT called when constraint absent"
 
+# ── Test 12-14: Step 5.5 WIF setup ──────────────────────────────────────
+#
+# Step 5.5 has three branches:
+#   - GITHUB_USERNAME unset                 → entire block skipped
+#   - GITHUB_USERNAME set, WIF artifacts absent → pool + provider + binding created
+#   - GITHUB_USERNAME set, WIF artifacts present → all three sub-steps log [skip]
+#                                                  (binding still calls add-iam — idempotent)
+#
+# Stubs gcloud at PATH and short-circuits the script after Step 5.5 by
+# exiting non-zero in code paths past the WIF block (Step 6 only runs
+# when --with-sa-key is set; we don't pass it). The script naturally
+# completes after Step 5.5 + the closing summary.
+
+run_step5_5_test() {
+  local wif_state="$1"   # "absent" | "present"
+  local tmp; tmp=$(mktemp -d -t aflowtest-XXXX)
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    # Existence check (no --format) returns 1 so we take the create path.
+    # Lifecycle check returns ACTIVE.
+    # ProjectNumber check returns 12345.
+    # Note: bash strips the single quotes around --format='value(...)'
+    # before invoking gcloud, so the stub matches without quotes.
+    if echo "\$*" | grep -q "projectNumber"; then
+      echo "12345"
+    elif echo "\$*" | grep -q "lifecycleState"; then
+      echo "ACTIVE"
+    else
+      exit 1
+    fi
+    exit 0
+    ;;
+  "projects create"|"projects get-iam-policy"|"projects add-iam-policy-binding") exit 0 ;;
+  "billing projects") exit 0 ;;
+  "resource-manager org-policies")
+    # Step 1.5: pretend constraint not enforced so we skip past quickly
+    case "\$3" in
+      describe) exit 1 ;;
+      list)     exit 0 ;;
+    esac
+    ;;
+  "services enable") exit 0 ;;
+  "artifacts repositories")
+    case "\$3" in
+      describe) exit 1 ;;   # not exists -> create path
+      create)   exit 0 ;;
+    esac
+    ;;
+  "iam service-accounts")
+    case "\$3" in
+      describe) exit 1 ;;   # not exists -> create path
+      create)   exit 0 ;;
+      add-iam-policy-binding) exit 0 ;;   # used for SA roles + WIF binding
+    esac
+    ;;
+  "iam workload-identity-pools")
+    case "\$3" in
+      describe)
+        case "$wif_state" in
+          present) exit 0 ;;
+          *)       exit 1 ;;
+        esac
+        ;;
+      create) exit 0 ;;
+      providers)
+        case "\$4" in
+          describe)
+            case "$wif_state" in
+              present) exit 0 ;;
+              *)       exit 1 ;;
+            esac
+            ;;
+          create-oidc) exit 0 ;;
+        esac
+        ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+
+  set +e
+  PATH="$tmp/bin:$PATH" \
+    GCP_PROJECT_ID="af-wif-test" \
+    BILLING_ACCOUNT_ID="FAKE" \
+    GITHUB_USERNAME="${2:-}" \
+    "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
+  set -e
+
+  echo "$tmp"
+}
+
+# Test 12: GITHUB_USERNAME unset → entire WIF block skipped
+
+echo ""
+echo "Test 12: Step 5.5 skipped when GITHUB_USERNAME unset"
+
+T12=$(run_step5_5_test "absent" "")
+
+if grep -q "WIF setup not requested" "$T12/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'WIF setup not requested' in stdout"
+  cat "$T12/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+wif_pool_calls=0
+if [[ -f "$T12/gcloud.log" ]]; then
+  wif_pool_calls="$(grep -c 'workload-identity-pools' "$T12/gcloud.log" || true)"
+fi
+assert_eq "0" "$wif_pool_calls" "no workload-identity-pools calls when GITHUB_USERNAME unset"
+
+# Test 13: GITHUB_USERNAME set, WIF artifacts absent → pool + provider + binding created
+
+echo ""
+echo "Test 13: Step 5.5 creates pool + provider + binding when WIF absent"
+
+T13=$(run_step5_5_test "absent" "alice-gh")
+
+if grep -q "create.*WIF pool" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} create-pool log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[create] WIF pool' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "create.*WIF provider" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} create-provider log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[create] WIF provider' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} binding log names alice-gh/agile-flow-gcp (default WIF_REPO)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected binding log to mention alice-gh/agile-flow-gcp"
+  cat "$T13/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Final summary line should print the WIF provider resource path with project number 12345
+if grep -q "GCP_WORKLOAD_IDENTITY_PROVIDER = projects/12345/locations/global/workloadIdentityPools/github/providers/github" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} final summary prints concrete WIF provider resource"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected concrete WIF provider in final summary; got:"
+  grep "WORKLOAD_IDENTITY" "$T13/stdout.log" || echo "(no WORKLOAD_IDENTITY line found)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 14: GITHUB_USERNAME set, WIF artifacts present → idempotent skip
+
+echo ""
+echo "Test 14: Step 5.5 idempotent when WIF artifacts already present"
+
+T14=$(run_step5_5_test "present" "alice-gh")
+
+if grep -q "skip.*WIF pool" "$T14/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip-pool log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] WIF pool' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "skip.*WIF provider" "$T14/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip-provider log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] WIF provider' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+# Binding step is always called (it's idempotent at the gcloud level)
+if grep -q "bind.*workloadIdentityUser" "$T14/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} binding step still ran (idempotent)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected binding step to log [bind]"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -94,10 +94,10 @@ skipped=0
 
 # tail -n +2 skips header. Process substitution avoids subshell so counters
 # survive into the summary block.
-# shellcheck disable=SC2034  # github_user is reserved for #5 (WIF binding) and notification steps
 while IFS=',' read -r handle github_user email cohort; do
   # Strip whitespace and CR (Windows line endings)
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
+  github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
   email="$(echo "$email" | tr -d '[:space:]\r')"
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
 
@@ -126,11 +126,14 @@ while IFS=',' read -r handle github_user email cohort; do
   fi
 
   # Run the inner provisioner. It handles "already exists" internally;
-  # we just pass through the env it needs.
+  # we just pass through the env it needs. GITHUB_USERNAME enables the
+  # WIF setup in Step 5.5 of the inner script — when empty, that step
+  # is skipped and the SA-key shortcut remains the auth fallback.
   GCP_PROJECT_ID="$project_id" \
   BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
   GCP_REGION="${GCP_REGION:-us-central1}" \
   ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}" \
+  GITHUB_USERNAME="$github_user" \
     "$PROVISION_SCRIPT" --create-project
 
   # Grant the participant editor on their own project. Idempotent.
@@ -142,9 +145,17 @@ while IFS=',' read -r handle github_user email cohort; do
     --condition=None \
     --quiet >/dev/null
 
-  # WIF setup is ticket #5; not in scope here. Output column stays empty
-  # until #5 lands or the facilitator wires it manually.
+  # WIF provider resource path. The inner script's Step 5.5 created the
+  # pool + provider when GITHUB_USERNAME was non-empty; record the canonical
+  # resource string for the summary CSV so the facilitator can paste it
+  # straight into participant fork secrets.
   wif_provider=""
+  if [[ -n "$github_user" ]]; then
+    project_number="$(gcloud projects describe "$project_id" --format='value(projectNumber)' 2>/dev/null || true)"
+    if [[ -n "$project_number" ]]; then
+      wif_provider="projects/${project_number}/locations/global/workloadIdentityPools/github/providers/github"
+    fi
+  fi
 
   echo "$handle,$project_id,$status,$wif_provider,$timestamp" >> "$OUTPUT_CSV"
 done < <(tail -n +2 "$ROSTER_CSV")


### PR DESCRIPTION
## Summary

Closes #5. Automates the last manual gcloud step in the provisioning flow.

`provision-gcp-project.sh` gains Step 5.5: when `GITHUB_USERNAME` is set, the script creates the WIF pool, the OIDC provider, and the IAM binding scoped to `${GITHUB_USERNAME}/${WIF_REPO:-agile-flow-gcp}`. The workshop wrapper exports `GITHUB_USERNAME` automatically from each `roster.csv` row, so a facilitator running the canonical workshop flow never touches WIF gcloud commands by hand.

The four GitHub Actions secrets a participant pastes into their fork now fall out of provisioner output directly — no copying from docs, no project-number arithmetic.

## Scope changes vs. original ticket

(Already documented on the issue body — I'll mention them here for review context.)

| Original ticket | This PR |
|---|---|
| `--with-wif owner/repo` flag | `GITHUB_USERNAME` env var (matches existing env-var pattern) |
| Implicit `repo` column in roster | No CSV schema change; repo hardcoded to `agile-flow-gcp` with `WIF_REPO` env override |
| Real-GCP end-to-end verification | Mocked-shell tests + dry-run deferral (consistent with #4/#14/#16/#19/#22) |

User explicitly approved the hardcoded-repo decision: workshop participants fork without renaming, so `<github_user>/agile-flow-gcp` is the de-facto convention. `WIF_REPO=` stays as the escape hatch.

## What's in the PR

### `scripts/provision-gcp-project.sh`

New Step 5.5 (~70 lines) between the deployer-SA IAM bindings and the optional `--with-sa-key` path. Three sub-steps (all idempotent):

- 5.5a: Create WIF pool `github` if absent
- 5.5b: Create OIDC provider `github` if absent
- 5.5c: Bind `roles/iam.workloadIdentityUser` on the deployer SA to `attribute.repository/<github_user>/<wif_repo>`

The "Next steps" output at the end of the script now prints the concrete WIF provider resource path (`projects/<number>/locations/...`) instead of a placeholder, so the facilitator copy-pastes directly into participant fork secrets.

### `scripts/provision-workshop-roster.sh`

- Reads `github_user` from each CSV row, strips whitespace, exports `GITHUB_USERNAME` before calling the inner script
- After each row, queries the project number and writes a concrete `wif_provider` value into `roster-output.csv` (was empty placeholder before)
- Removes the now-stale `# shellcheck disable=SC2034 github_user reserved for #5` comment

### `docs/PLATFORM-GUIDE.md`

- Step 5 rewritten to describe the automatic flow first
- Original gcloud sequence kept as "Manual fallback (rarely needed)" subsection
- Adds a "don't rename your fork" callout for the participant day-1 email
- Handoff section's forward-ref to ticket #5 → "as of #5 it's automatic"

## Implementation notes worth a re-read

- **No `--attribute-condition` on the OIDC provider.** Workshop participants fork under their personal accounts, not the vibeacademy org. The doc's existing condition (`assertion.repository_owner == 'YOUR_GITHUB_ORG'`) wouldn't match. The IAM binding's `attribute.repository=<user>/<repo>` is the correct trust scope. Comment in the code explains this trade-off.
- **`add-iam-policy-binding` is idempotent at gcloud's level**, so test 14 confirms the binding step still runs even when pool + provider already exist (it's not gated on those skips). This matches how the existing deployer-SA bindings work in Step 5.
- **`WIF_PROVIDER_RESOURCE` is set inside the if-block.** The output section uses `${WIF_PROVIDER_RESOURCE:-}` to detect whether WIF was set up; if unset (env not provided) the output falls back to the placeholder. This keeps the script's behavior backwards-compatible for callers that don't pass `GITHUB_USERNAME`.

## Tests

`scripts/provision-gcp-project.test.sh` gains tests 12-14 — 9 new assertions across three scenarios. Total: 37/37 passing.

A subtle bug caught during test development: the stub's `--format='value(...)'` discriminator failed because bash strips the inner single quotes before exec'ing gcloud. Fixed by matching on the inner field name (`projectNumber`, `lifecycleState`) instead. Comment in the test code captures the gotcha.

## Test plan

- [x] `bash -n` and `shellcheck` clean on all four files
- [x] 37/37 helper tests pass (28 existing + 9 new)
- [x] No regression on `provision-workshop-roster.test.sh` (14/14)
- [x] CI green (will verify after push)
- [ ] Real-GCP smoke at 2026-05-01 dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)