### PR TITLE
fix(scripts): add required --attribute-condition to WIF OIDC provider

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -200,6 +200,7 @@ gcloud iam workload-identity-pools providers create-oidc github \
   --location=global \
   --issuer-uri="https://token.actions.githubusercontent.com" \
   --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.actor=assertion.actor" \
+  --attribute-condition="assertion.repository != ''" \
   --project=YOUR_PROJECT_ID
 
 # Get the project number (different from project ID)

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -301,11 +301,14 @@ done
 # <github_user>/agile-flow-gcp. Override WIF_REPO if you ever need a
 # different repo name (dry-run smoke, non-workshop callers).
 #
-# We deliberately do NOT add --attribute-condition restricting to a
-# specific GitHub org — workshop participants fork under their personal
-# accounts, not the canonical org. Access is scoped at the IAM binding
-# layer instead, where attribute.repository=<user>/agile-flow-gcp
-# pins the trust to one specific repo.
+# Google requires --attribute-condition on OIDC providers (it must
+# reference at least one provider claim). We use a trivially-true
+# condition (`assertion.repository != ''`) so the provider doesn't gate
+# access by org or repo — workshop participants fork under their
+# personal GitHub accounts, not the canonical org, and we cannot
+# enumerate every domain ahead of time. Trust scoping happens at the
+# IAM binding layer instead, where attribute.repository=<user>/<repo>
+# pins each binding to one specific repo.
 #
 # All three sub-steps (pool, provider, binding) are idempotent.
 
@@ -342,6 +345,7 @@ if [[ -n "${GITHUB_USERNAME:-}" ]]; then
       --location=global \
       --issuer-uri="https://token.actions.githubusercontent.com" \
       --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.actor=assertion.actor" \
+      --attribute-condition="assertion.repository != ''" \
       --project="$GCP_PROJECT_ID"
   fi
 

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -620,6 +620,17 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# create-oidc must include --attribute-condition. Google requires it; we
+# learned that the hard way when a real-GCP run failed with INVALID_ARGUMENT.
+if grep -q "providers create-oidc.*attribute-condition" "$T13/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} create-oidc invoked with --attribute-condition"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected --attribute-condition on create-oidc call; got:"
+  grep "create-oidc" "$T13/gcloud.log" || echo "(no create-oidc call found)"
+  FAIL=$((FAIL + 1))
+fi
+
 if grep -q "alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} binding log names alice-gh/agile-flow-gcp (default WIF_REPO)"
   PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary

Quick fix — no linked ticket. Live failure during workshop smoke just now:

```text
ERROR: (gcloud.iam.workload-identity-pools.providers.create-oidc) INVALID_ARGUMENT:
The attribute condition must reference one of the provider's claims.
```

Google now requires `--attribute-condition` on OIDC providers. PR #26 removed it on the (logically correct) assumption that the IAM binding gates access — but Google rejects provider creation entirely without a condition.

## Fix

Use a trivially-true condition:

```bash
--attribute-condition="assertion.repository != ''"
```

Always passes for any GitHub OIDC token. Satisfies Google's "must reference a claim" rule. **Doesn't restrict access** by org or repo — trust scoping stays at the IAM binding layer where `attribute.repository=<user>/<repo>` pins each binding to one specific repo.

## What changed

- **`scripts/provision-gcp-project.sh`** Step 5.5b: add the condition; updated inline comment to explain the choice
- **`docs/PLATFORM-GUIDE.md`** manual-fallback snippet: same condition so copy-paste users hit the same fix
- **`scripts/provision-gcp-project.test.sh`** test 13: assert the `create-oidc` invocation includes `--attribute-condition`. Future-proofs against someone removing it again.

## Why this slipped past mocked tests

The mocked-shell tests verified the script *issues* the create-oidc call. They didn't assert what *flags* it passed. Real gcloud rejected the flagless call; a `gcloud projects describe` stub couldn't have caught that. The new assertion in test 13 closes the gap — any future regression to "no condition" fails the test before it ships.

This is the second test-mismatch lesson from the workshop work (the first was the bash-quote-stripping bug in #26). Mocked tests verify call shape; they can't verify call *acceptance* by the real API. Real-GCP smoke at the dry-run remains the load-bearing acceptance signal.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] 38/38 helper tests pass (existing 37 + 1 new condition assertion)
- [x] No regression on wrapper
- [x] markdownlint clean
- [ ] Real-GCP re-run on `af-reviewer-2026-05a` / `af-worker-2026-05a` — that's what surfaced the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)