### PR TITLE
fix(ci): remove secrets.* from if: expressions in deploy/preview/rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,16 +28,26 @@ jobs:
     steps:
       - name: Check for required secrets
         id: check_secrets
+        # GitHub Actions hard-rejects `secrets.*` in `if:` expressions, so
+        # we promote presence checks into outputs that downstream `if:`
+        # gates can read. `auth_method` selects between WIF (keyless,
+        # recommended) and service account key (workshop shortcut).
         run: |
           if [ -z "${{ secrets.GCP_PROJECT_ID }}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
             echo "GCP_PROJECT_ID not configured — skipping deployment."
             echo "See docs/PLATFORM-GUIDE.md for setup instructions."
-          elif [ -z "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ] && [ -z "${{ secrets.GCP_SA_KEY }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Neither GCP_WORKLOAD_IDENTITY_PROVIDER nor GCP_SA_KEY configured — skipping."
-          else
+          elif [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "Neither GCP_WORKLOAD_IDENTITY_PROVIDER nor GCP_SA_KEY configured — skipping."
           fi
 
       - name: Checkout code
@@ -48,14 +58,14 @@ jobs:
       # Falls back to a service account JSON key if GCP_SA_KEY is set —
       # this is the workshop shortcut and is NOT recommended for production.
       - name: Authenticate to Google Cloud (Workload Identity Federation)
-        if: steps.check_secrets.outputs.skip != 'true' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        if: steps.check_secrets.outputs.auth_method == 'wif'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
-        if: steps.check_secrets.outputs.skip != 'true' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' && secrets.GCP_SA_KEY != ''
+        if: steps.check_secrets.outputs.auth_method == 'sa-key'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -21,10 +21,37 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
 
     steps:
+      - name: Check for required secrets
+        id: check_secrets
+        # GitHub Actions hard-rejects `secrets.*` in `if:` expressions, so
+        # we promote presence checks into outputs that downstream `if:`
+        # gates can read. `gcp_configured` gates GCP cleanup; `auth_method`
+        # selects between WIF and SA key; `neon_configured` gates the
+        # Neon branch deletion.
+        run: |
+          if [ -n "${{ secrets.GCP_PROJECT_ID }}" ]; then
+            echo "gcp_configured=true" >> "$GITHUB_OUTPUT"
+            if [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
+              echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+            elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
+              echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+            else
+              echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "gcp_configured=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "${{ secrets.NEON_API_KEY }}" ]; then
+            echo "neon_configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ── Neon: delete the PR branch database ───────────────────────────
 
       - name: Delete Neon branch
-        if: secrets.NEON_API_KEY != ''
+        if: steps.check_secrets.outputs.neon_configured == 'true'
         uses: neondatabase/delete-branch-action@v3
         continue-on-error: true
         with:
@@ -35,20 +62,20 @@ jobs:
       # ── GCP: remove the Cloud Run revision tag ────────────────────────
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
-        if: secrets.GCP_PROJECT_ID != '' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        if: steps.check_secrets.outputs.auth_method == 'wif'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
-        if: secrets.GCP_PROJECT_ID != '' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' && secrets.GCP_SA_KEY != ''
+        if: steps.check_secrets.outputs.auth_method == 'sa-key'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up gcloud
-        if: secrets.GCP_PROJECT_ID != ''
+        if: steps.check_secrets.outputs.gcp_configured == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
       # Removing a revision tag stops routing traffic to the preview
@@ -58,7 +85,7 @@ jobs:
       # We don't delete the underlying revision because Cloud Run charges
       # nothing for inactive revisions and keeping them aids forensics.
       - name: Remove Cloud Run revision tag
-        if: secrets.GCP_PROJECT_ID != ''
+        if: steps.check_secrets.outputs.gcp_configured == 'true'
         continue-on-error: true
         run: |
           TAG="pr-${{ env.PR_NUMBER }}"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -31,15 +31,33 @@ jobs:
     steps:
       - name: Check for required secrets
         id: check_secrets
+        # GitHub Actions hard-rejects `secrets.*` in `if:` expressions, so
+        # we promote presence checks into outputs that downstream `if:`
+        # gates can read. `auth_method` selects between WIF (keyless,
+        # recommended) and SA key (workshop shortcut). `neon_configured`
+        # gates the per-PR Neon-branch creation step.
         run: |
           if [ -z "${{ secrets.GCP_PROJECT_ID }}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
             echo "GCP_PROJECT_ID not configured — skipping preview deploy."
-          elif [ -z "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ] && [ -z "${{ secrets.GCP_SA_KEY }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No GCP auth configured — skipping preview deploy."
-          else
+          elif [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
+            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
+            echo "No GCP auth configured — skipping preview deploy."
+          fi
+          if [ -n "${{ secrets.NEON_API_KEY }}" ]; then
+            echo "neon_configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "neon_configured=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout code
@@ -50,7 +68,7 @@ jobs:
 
       - name: Create Neon branch
         id: neon
-        if: steps.check_secrets.outputs.skip != 'true' && secrets.NEON_API_KEY != ''
+        if: steps.check_secrets.outputs.skip != 'true' && steps.check_secrets.outputs.neon_configured == 'true'
         uses: neondatabase/create-branch-action@v5
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
@@ -78,14 +96,14 @@ jobs:
       # ── GCP: auth and build image ─────────────────────────────────────
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
-        if: steps.check_secrets.outputs.skip != 'true' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        if: steps.check_secrets.outputs.auth_method == 'wif'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
-        if: steps.check_secrets.outputs.skip != 'true' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' && secrets.GCP_SA_KEY != ''
+        if: steps.check_secrets.outputs.auth_method == 'sa-key'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -28,21 +28,33 @@ jobs:
 
     steps:
       - name: Check for required secrets
+        id: check_secrets
+        # GitHub Actions hard-rejects `secrets.*` in `if:` expressions, so
+        # we promote auth-method selection into an output. Rollback hard-
+        # requires GCP_PROJECT_ID; the step exits 1 if it is missing.
         run: |
           if [ -z "${{ secrets.GCP_PROJECT_ID }}" ]; then
             echo "GCP_PROJECT_ID is not configured. Cannot rollback."
             exit 1
           fi
+          if [ -n "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}" ]; then
+            echo "auth_method=wif" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "auth_method=sa-key" >> "$GITHUB_OUTPUT"
+          else
+            echo "Neither GCP_WORKLOAD_IDENTITY_PROVIDER nor GCP_SA_KEY configured. Cannot rollback."
+            exit 1
+          fi
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
-        if: secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''
+        if: steps.check_secrets.outputs.auth_method == 'wif'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to Google Cloud (Service Account Key fallback)
-        if: secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' && secrets.GCP_SA_KEY != ''
+        if: steps.check_secrets.outputs.auth_method == 'sa-key'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary

Closes #28. **P0 — workshop dry-run is in 3 days.**

GitHub Actions hard-rejects `secrets.*` in `if:` expressions. Workflows that violate the rule fail at workflow-load time with `0s` elapsed, no logs, no jobs run. **Every fork hits this on first deploy.**

Live reproducer this afternoon: `tck517/agile-flow-gcp` (fresh fork) pushed to `main`, `deploy.yml` recorded a `0s` startup_failure. No Cloud Run service was ever created. The same pattern would block every workshop participant on day-1 step 4.

## What changed

Promote secret-presence checks into a `check_secrets` step's outputs in each affected workflow. Downstream auth and conditional steps gate on `steps.check_secrets.outputs.X` (allowed in `if:`) instead of `secrets.X` (rejected).

Per-workflow:

| Workflow | Output(s) added | Notes |
|---|---|---|
| `deploy.yml` | `auth_method` (wif / sa-key / none) | Existing `check_secrets` step extended |
| `preview-deploy.yml` | `auth_method`, `neon_configured` | Existing `check_secrets` step extended |
| `preview-cleanup.yml` | `auth_method`, `gcp_configured`, `neon_configured` | **New `check_secrets` step** — none existed before |
| `rollback-production.yml` | `auth_method` | Existing step extended; hard-fails if no auth method available |

No behavioral change — same skip semantics, same auth precedence (WIF over SA key when both set).

## Verification

```bash
grep -nE "if:.*[^_]secrets\.[A-Z]" .github/workflows/*.yml
```

Returns zero matches (the negative lookbehind `[^_]` excludes the `check_secrets` step ID, which contains the substring "secrets" but is not the `secrets` context).

## Why mocked tests didn't catch this

Workflow YAML is validated by GitHub Actions on push. We have no local linter for the secrets-in-if rule. **`actionlint` does catch it** — worth a follow-up ticket to add a pre-push hook or CI step that runs actionlint on `.github/workflows/*.yml`.

This is the third "mocked tests verify shape, not acceptance" lesson this session:
- #26 had a bash-quote-stripping bug
- #27 was missing `--attribute-condition` (Google requires it)
- This PR is `secrets.*` in `if:` (GitHub rejects it)

Real-world signal arrives via real GitHub / GCP. Worth a separate ticket to harden the test scaffolding.

## Test plan

- [x] grep returns zero `secrets.X` references in `if:` lines
- [x] No behavioral change — same skip-when-not-configured semantics
- [ ] Real-fork smoke: user re-forks `tck517/agile-flow-gcp` after merge, repeats secrets/push, confirms deploy.yml runs and creates a Cloud Run service

## Coordination

After merge, user plans to nuke `tck517/agile-flow-gcp` and re-fork. The smoke test that surfaced this bug (and the previous bugs from today) becomes the acceptance signal for the entire chain: pre-flight checks, idempotent provisioning, retry helpers, ownership probe, org-policy override, WIF setup, attribute-condition fix, and now this. If `deploy.yml` runs end-to-end after the re-fork, today's eight (and now nine) PRs are validated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)