### PR TITLE
fix(scripts+ci): grant SA token-creator + pin Cloud Run runtime SA to deployer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,12 @@ jobs:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
           image: ${{ steps.build.outputs.image }}
+          # Pin the runtime SA to the deployer SA. By default Cloud Run
+          # uses the legacy Compute Engine default SA at runtime, which
+          # has none of the roles we provisioned (e.g. secretAccessor).
+          # Using one SA for deploy + runtime keeps the audit trail clear
+          # and avoids granting roles to a default SA we did not create.
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           flags: |
             --port=8080
             --memory=512Mi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -142,9 +142,15 @@ jobs:
             NEON_URL_FLAG="--update-env-vars=DATABASE_URL=${{ steps.neon.outputs.db_url_pooled }}"
           fi
 
+          # --service-account pins the runtime SA to the deployer SA so
+          # the revision can read mounted Secret Manager secrets and any
+          # other resource the deployer SA already has access to. Without
+          # this, Cloud Run uses the legacy Compute Engine default SA at
+          # runtime, which has none of the roles provisioned in Step 5.
           gcloud run deploy "${{ env.SERVICE_NAME }}" \
             --image="${{ steps.build.outputs.image }}" \
             --region="${{ env.GCP_REGION }}" \
+            --service-account="${{ secrets.GCP_SERVICE_ACCOUNT }}" \
             --tag="pr-${{ env.PR_NUMBER }}" \
             --no-traffic \
             --port=8080 \

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -206,12 +206,16 @@ gcloud iam workload-identity-pools providers create-oidc github \
 # Get the project number (different from project ID)
 PROJECT_NUMBER=$(gcloud projects describe YOUR_PROJECT_ID --format='value(projectNumber)')
 
-# Allow the GitHub repo to impersonate the deployer service account
-gcloud iam service-accounts add-iam-policy-binding \
-  "deployer@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/GITHUB_USER/REPO_NAME" \
-  --project=YOUR_PROJECT_ID
+# Allow the GitHub repo to impersonate the deployer service account.
+# Two roles are required: workloadIdentityUser to authenticate as the SA,
+# and serviceAccountTokenCreator to mint access tokens (gcloud, docker push).
+for role in roles/iam.workloadIdentityUser roles/iam.serviceAccountTokenCreator; do
+  gcloud iam service-accounts add-iam-policy-binding \
+    "deployer@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+    --role="$role" \
+    --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/GITHUB_USER/REPO_NAME" \
+    --project=YOUR_PROJECT_ID
+done
 ```
 
 The WIF provider resource name to paste into GitHub secrets is:

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -350,15 +350,30 @@ if [[ -n "${GITHUB_USERNAME:-}" ]]; then
   fi
 
   # 5.5c: Bind the deployer SA so the specific repo can impersonate it.
+  # google-github-actions/auth@v2 in impersonation mode (which our deploy
+  # workflow uses by passing both `workload_identity_provider` and
+  # `service_account`) needs TWO roles:
+  #
+  #   roles/iam.workloadIdentityUser    — lets the federated identity
+  #                                        authenticate AS the SA via WIF
+  #   roles/iam.serviceAccountTokenCreator — lets the federated identity
+  #                                        MINT access tokens for the SA
+  #                                        (gcloud auth, docker push, etc.)
+  #
+  # Granting only the first leaves the deploy step's docker-push call
+  # failing with `iam.serviceAccounts.getAccessToken denied`.
+  #
   # add-iam-policy-binding is idempotent — re-running with the same member
   # is a no-op.
   WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/attribute.repository/${GITHUB_USERNAME}/${WIF_REPO}"
-  echo "[bind] roles/iam.workloadIdentityUser <- ${GITHUB_USERNAME}/${WIF_REPO}"
-  gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
-    --role="roles/iam.workloadIdentityUser" \
-    --member="$WIF_MEMBER" \
-    --project="$GCP_PROJECT_ID" \
-    --quiet >/dev/null
+  for wif_role in roles/iam.workloadIdentityUser roles/iam.serviceAccountTokenCreator; do
+    echo "[bind] $wif_role <- ${GITHUB_USERNAME}/${WIF_REPO}"
+    gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+      --role="$wif_role" \
+      --member="$WIF_MEMBER" \
+      --project="$GCP_PROJECT_ID" \
+      --quiet >/dev/null
+  done
 
   WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/providers/${WIF_PROVIDER}"
 else

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -640,6 +640,24 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Both WIF roles must be bound. workloadIdentityUser alone leaves the deploy
+# step unable to mint access tokens for docker push. We learned that the
+# hard way during smoke 2026-04-28.
+if grep -q "\[bind\] roles/iam.workloadIdentityUser <- alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} workloadIdentityUser binding logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.workloadIdentityUser <- alice-gh/agile-flow-gcp'"
+  FAIL=$((FAIL + 1))
+fi
+if grep -q "\[bind\] roles/iam.serviceAccountTokenCreator <- alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} serviceAccountTokenCreator binding logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.serviceAccountTokenCreator <- alice-gh/agile-flow-gcp'"
+  FAIL=$((FAIL + 1))
+fi
+
 # Final summary line should print the WIF provider resource path with project number 12345
 if grep -q "GCP_WORKLOAD_IDENTITY_PROVIDER = projects/12345/locations/global/workloadIdentityPools/github/providers/github" "$T13/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} final summary prints concrete WIF provider resource"


### PR DESCRIPTION
## Summary

Closes #30. **P0 — workshop dry-run is in 3 days.**

Two related defects discovered live during workshop smoke today, bundled because they share test scaffolding and both unblock the same end-to-end deploy.

### Defect 1: Step 5.5c missing serviceAccountTokenCreator

`google-github-actions/auth@v2` in impersonation mode needs **two** roles on the deployer SA. PR #5 granted only `roles/iam.workloadIdentityUser`. The second role, `roles/iam.serviceAccountTokenCreator`, is what `gcloud auth configure-docker` actually uses to refresh tokens for `docker push`.

Without it: `iam.serviceAccounts.getAccessToken denied` → docker push falls back to anonymous → Artifact Registry rejects → workflow fails.

Fix: loop over both roles in Step 5.5c. `add-iam-policy-binding` is idempotent at gcloud's level.

### Defect 2: deploy workflows don't pin Cloud Run runtime SA

After the token-creator fix landed manually and the workflow re-ran, `docker push` succeeded — and the deploy step then failed with:

```text
Permission denied on secret database-url for Revision service account
<num>-compute@developer.gserviceaccount.com.
```

Cloud Run uses the legacy Compute Engine default SA at runtime by default. That SA has none of the roles provisioned in Step 5 (`secretmanager.secretAccessor`, etc.). The **deployer SA** does have them.

Fix: pass the deployer SA as the runtime SA. One service account for deploy + runtime → clearer audit trail, no need to grant roles to a default SA we didn't create.

- `deploy.yml`: `service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}` on `deploy-cloudrun@v2`
- `preview-deploy.yml`: `--service-account="${{ secrets.GCP_SERVICE_ACCOUNT }}"` on raw `gcloud run deploy`

## Tests

`scripts/provision-gcp-project.test.sh` test 13 now asserts **both** `[bind]` log lines. The new assertions:

```bash
grep -q "\[bind\] roles/iam.workloadIdentityUser <- alice-gh/agile-flow-gcp" "$T13/stdout.log"
grep -q "\[bind\] roles/iam.serviceAccountTokenCreator <- alice-gh/agile-flow-gcp" "$T13/stdout.log"
```

40/40 assertions pass (existing 38 + 2 new). No regression.

## Implementation note

Step 5.5c now uses a `for wif_role in ...; do` loop over the two roles instead of two separate `gcloud` invocations. Same idempotency, smaller diff, easier to add a third role in the future if it turns out to also be needed (it almost certainly won't, but the pattern is now established).

## Acceptance

User has confirmed the smoke-test philosophy: clean end-to-end run from a freshly-nuked starting point, not patches against in-flight projects. After this merges, user nukes `tck517/agile-flow-gcp` and re-forks. If the deploy completes cleanly through `Show deployed URL`, today's chain (PRs #14, #16, #19, #22, #5, #27, #29, #30) is end-to-end validated for the workshop.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] 40/40 helper tests pass
- [x] No regression on wrapper tests
- [x] markdownlint clean
- [ ] Real-GCP smoke: user re-forks after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)