### PR TITLE
fix(ci): pass --service-account via flags, not as top-level input

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,13 +117,14 @@ jobs:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
           image: ${{ steps.build.outputs.image }}
-          # Pin the runtime SA to the deployer SA. By default Cloud Run
-          # uses the legacy Compute Engine default SA at runtime, which
-          # has none of the roles we provisioned (e.g. secretAccessor).
-          # Using one SA for deploy + runtime keeps the audit trail clear
-          # and avoids granting roles to a default SA we did not create.
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # Runtime-SA pin: --service-account is passed via flags: rather
+          # than as a top-level input, because deploy-cloudrun@v2 does NOT
+          # accept service_account as a top-level input (only auth@v2
+          # does — the asymmetry is easy to miss). Without this flag,
+          # Cloud Run uses the legacy Compute Engine default SA at runtime,
+          # which has none of the roles we provisioned (e.g. secretAccessor).
           flags: |
+            --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
             --port=8080
             --memory=512Mi
             --cpu=1


### PR DESCRIPTION
## Summary

Closes #32. **P0 — undoes a silent regression I introduced in #31.**

PR #31 added `service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}` as a top-level input to `deploy-cloudrun@v2`. **The action does not accept `service_account` as a top-level input.** GitHub Actions logged a warning and silently dropped the input, so the runtime-SA pin from #30 (defect 2) silently never happened post-merge.

Live evidence:

```text
Warning: Unexpected input(s) 'service_account', valid inputs are
['service', 'job', 'metadata', 'image', 'source', 'suffix',
 'env_vars', ..., 'flags', ...]
```

## Fix

The action's `flags:` input forwards arbitrary args to `gcloud run deploy`. Move `--service-account=...` there:

```yaml
flags: |
  --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
  --port=8080
  ...
```

`preview-deploy.yml` is unaffected — it uses raw `gcloud run deploy --service-account=…`, which has been correct since #31.

## The asymmetry that bit me

`auth@v2` *does* accept `service_account:` as a top-level input. `deploy-cloudrun@v2` does not. Same `google-github-actions/*` org, same parameter name, different APIs. Easy to confuse. The new comment in `deploy.yml` names this trap explicitly so the next reader doesn't repeat the mistake.

## Test plan

- [x] secrets-in-if invariant still holds: `grep -nE "if:.*[^_]secrets\.[A-Z]"` returns zero matches
- [x] markdownlint clean (no doc changes)
- [ ] CI green
- [ ] Real-GCP smoke at user's next nuke-and-fork — the runtime-SA pin should actually take effect this time

## Why a separate PR (not amended into #31)

#31 is merged. The fix has to land on top of main. One-line PR is the smallest unit; bundling with the database-url-secret automation (filed as #33, P1) would conflate two scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)