### PR TITLE
feat(scripts): add optional neon_branch column to roster.csv + wrapper plumbing

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -327,7 +327,10 @@ discovering a missing auth token mid-loop.
 
 ### Roster format
 
-Create `roster.csv` with this exact header:
+`roster.csv` accepts two header shapes. Both have the same first four
+columns; the 5th is optional and used only by the Neon-branch automation.
+
+**Minimal (4 columns):**
 
 ```csv
 handle,github_user,email,cohort
@@ -335,16 +338,32 @@ alice,alice-gh,alice@example.com,2026-05
 bob,bob-gh,bob@example.com,2026-05
 ```
 
+**Extended (5 columns):**
+
+```csv
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,
+bob,bob-gh,bob@example.com,2026-05,bob_personal
+```
+
+Columns:
+
 - `handle` — short, lowercase, stable identifier; appears in the GCP project ID
-- `github_user` — reserved for future use (WIF binding, notification);
-  required in the row but not used by the current scripts
+- `github_user` — the participant's GitHub username; used to scope the
+  WIF binding to `<github_user>/agile-flow-gcp`
 - `email` — Google identity granted `roles/editor` on the new project
 - `cohort` — `YYYY-MM` of the workshop date; appears in the project ID
+- `neon_branch` *(optional, 5-column shape only)* — Neon branch name for
+  this attendee. When empty or absent, defaults to `handle`. Use the
+  override when the same person needs a stable branch across cohorts
+  (different `cohort`, same `neon_branch`). Must be 1-63 chars,
+  alphanumeric + hyphen + underscore.
 
 Project IDs follow the pattern `af-{handle}-{cohort}`. This shape is
 referenced from the facilitator runbook, the participant day-1 doc, and
 the dry-run checklist — do not change it. A working example lives at
-`scripts/roster.example.csv`.
+`scripts/roster.example.csv` (uses the 5-column shape with one default
+and one explicit override).
 
 ### Setup behavior
 

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -15,11 +15,21 @@
 #   GCP_REGION           (default: us-central1) — passed through to inner script
 #   ARTIFACT_REPO        (default: agile-flow)  — passed through to inner script
 #   PROVISION_SCRIPT     (default: scripts/provision-gcp-project.sh) — for tests
+#   NEON_API_KEY         optional; forwarded to inner script for branch creation
+#   NEON_PROJECT_ID      optional; forwarded to inner script for branch creation
 #
-# CSV format (header required):
+# CSV format (header required, accepts either 4 or 5 columns):
 #   handle,github_user,email,cohort
 #   alice,alice-gh,alice@example.com,2026-05
 #   bob,bob-gh,bob@example.com,2026-05
+#
+#   handle,github_user,email,cohort,neon_branch        (5-column variant)
+#   alice,alice-gh,alice@example.com,2026-05,alice
+#   bob,bob-gh,bob@example.com,2026-05,bob_personal    (explicit branch override)
+#
+# When the optional `neon_branch` column is empty or absent, NEON_BRANCH_NAME
+# defaults to the row's `handle`. Use the override when the same person needs
+# a stable Neon branch across cohorts (different `cohort` value, same branch).
 #
 # Project IDs follow the pattern  af-{handle}-{cohort}  and are globally
 # unique. This is non-negotiable: the runbook, day-1 doc, and dry-run
@@ -68,12 +78,25 @@ if [[ ! -x "$PROVISION_SCRIPT" ]]; then
 fi
 
 # ── CSV header validation ────────────────────────────────────────────────
+#
+# The roster format accepts two header shapes:
+#   1. handle,github_user,email,cohort               (4 columns, original)
+#   2. handle,github_user,email,cohort,neon_branch   (5 columns, with Neon
+#                                                     branch override)
+#
+# When the 5th column is present and non-empty for a row, NEON_BRANCH_NAME
+# takes that value. Otherwise it defaults to the row's `handle` — which
+# matches the GCP project ID's handle component, so attendee branches are
+# named alice / bob / etc. by default.
 
-EXPECTED_HEADER="handle,github_user,email,cohort"
+EXPECTED_HEADER_4="handle,github_user,email,cohort"
+EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
 
-if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER" ]]; then
-  echo "ERROR: roster CSV header must be exactly: $EXPECTED_HEADER" >&2
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" ]]; then
+  echo "ERROR: roster CSV header must be one of:" >&2
+  echo "       $EXPECTED_HEADER_4" >&2
+  echo "       $EXPECTED_HEADER_5" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -94,15 +117,33 @@ skipped=0
 
 # tail -n +2 skips header. Process substitution avoids subshell so counters
 # survive into the summary block.
-while IFS=',' read -r handle github_user email cohort; do
+#
+# We read 5 fields. When the input is 4-column, neon_branch is empty; the
+# default-to-handle logic below covers it.
+while IFS=',' read -r handle github_user email cohort neon_branch; do
   # Strip whitespace and CR (Windows line endings)
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
   email="$(echo "$email" | tr -d '[:space:]\r')"
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
+  neon_branch="$(echo "${neon_branch:-}" | tr -d '[:space:]\r')"
 
   if [[ -z "$handle" || -z "$cohort" ]]; then
     continue
+  fi
+
+  # Default neon_branch to handle when not explicitly set per row.
+  if [[ -z "$neon_branch" ]]; then
+    neon_branch="$handle"
+  fi
+
+  # Validate Neon branch name: 1-63 chars, alphanumeric + hyphen + underscore.
+  # Reject anything else fail-fast on this row, since the inner script's
+  # Neon API call would error mid-loop with a less-clear message.
+  if ! [[ "$neon_branch" =~ ^[A-Za-z0-9_-]{1,63}$ ]]; then
+    echo "ERROR: invalid neon_branch '$neon_branch' for handle '$handle'" >&2
+    echo "       must be 1-63 chars, alphanumeric + hyphen + underscore only" >&2
+    exit 2
   fi
 
   total=$((total + 1))
@@ -129,11 +170,18 @@ while IFS=',' read -r handle github_user email cohort; do
   # we just pass through the env it needs. GITHUB_USERNAME enables the
   # WIF setup in Step 5.5 of the inner script — when empty, that step
   # is skipped and the SA-key shortcut remains the auth fallback.
+  # NEON_BRANCH_NAME enables the Neon-branch-per-attendee step (#33).
+  # NEON_API_KEY and NEON_PROJECT_ID are forwarded only if set in the
+  # facilitator's environment; the inner script skips that step when
+  # either is missing.
   GCP_PROJECT_ID="$project_id" \
   BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
   GCP_REGION="${GCP_REGION:-us-central1}" \
   ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}" \
   GITHUB_USERNAME="$github_user" \
+  NEON_BRANCH_NAME="$neon_branch" \
+  NEON_API_KEY="${NEON_API_KEY:-}" \
+  NEON_PROJECT_ID="${NEON_PROJECT_ID:-}" \
     "$PROVISION_SCRIPT" --create-project
 
   # Grant the participant editor on their own project. Idempotent.

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -62,8 +62,9 @@ EOF
   # Fake inner provisioner
   cat > "$tmp/bin/provision-gcp-project.sh" <<EOF
 #!/usr/bin/env bash
-# Log every invocation
-echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-}" >> "$tmp/provision.log"
+# Log every invocation along with the env vars the wrapper is supposed
+# to forward. Tests grep this log to verify per-row env passthrough.
+echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-} GITHUB_USERNAME=\${GITHUB_USERNAME:-} NEON_BRANCH_NAME=\${NEON_BRANCH_NAME:-}" >> "$tmp/provision.log"
 
 if [[ "$behavior" == "fail" ]]; then
   echo "fake provision failure" >&2
@@ -229,7 +230,7 @@ else
   echo -e "  ${RED}✗${NC} wrapper should exit 2 on bad header (got $exit_code)"
   FAIL=$((FAIL + 1))
 fi
-assert_contains "header must be exactly" "$T4/stdout.log" "error message mentions header format"
+assert_contains "header must be one of" "$T4/stdout.log" "error message mentions header format"
 
 # ── Test 5: Missing BILLING_ACCOUNT_ID rejected ─────────────────────────
 
@@ -255,6 +256,101 @@ else
   echo -e "  ${RED}✗${NC} wrapper should exit 2 when BILLING_ACCOUNT_ID is unset (got $exit_code)"
   FAIL=$((FAIL + 1))
 fi
+
+# ── Test 6: 5-column header + neon_branch column passes through ─────────
+# Verifies that:
+#   - 5-column header is accepted
+#   - NEON_BRANCH_NAME is exported per row from the 5th column
+#   - When the 5th column is empty for a row, defaults to handle
+
+echo ""
+echo "Test 6: 5-column header forwards NEON_BRANCH_NAME"
+
+T6=$(new_tmp)
+make_stubs "$T6" "ok"
+cat > "$T6/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,
+bob,bob-gh,bob@example.com,2026-05,bob_personal
+EOF
+
+set +e
+PATH="$T6/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T6/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T6/roster-output.csv" \
+  "$WRAPPER" "$T6/roster.csv" > "$T6/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 5-column header"
+# alice row should default neon_branch to handle (empty 5th column → handle)
+assert_contains "GCP_PROJECT_ID=af-alice-2026-05.*NEON_BRANCH_NAME=alice" "$T6/provision.log" "alice row defaults NEON_BRANCH_NAME to handle"
+# bob row uses the explicit override
+assert_contains "GCP_PROJECT_ID=af-bob-2026-05.*NEON_BRANCH_NAME=bob_personal" "$T6/provision.log" "bob row uses explicit neon_branch override"
+
+# ── Test 7: 4-column header still works (NEON_BRANCH_NAME defaults) ─────
+
+echo ""
+echo "Test 7: 4-column header still works (defaults NEON_BRANCH_NAME to handle)"
+
+T7=$(new_tmp)
+make_stubs "$T7" "ok"
+write_roster "$T7/roster.csv"
+
+set +e
+PATH="$T7/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T7/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T7/roster-output.csv" \
+  "$WRAPPER" "$T7/roster.csv" > "$T7/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 4-column header"
+assert_contains "GCP_PROJECT_ID=af-alice-2026-05.*NEON_BRANCH_NAME=alice" "$T7/provision.log" "alice defaults to handle (4-column)"
+assert_contains "GCP_PROJECT_ID=af-bob-2026-05.*NEON_BRANCH_NAME=bob" "$T7/provision.log" "bob defaults to handle (4-column)"
+
+# ── Test 8: invalid neon_branch value fails fast ────────────────────────
+
+echo ""
+echo "Test 8: invalid neon_branch fails the row fast"
+
+T8=$(new_tmp)
+make_stubs "$T8" "ok"
+cat > "$T8/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,bad branch with spaces
+EOF
+
+set +e
+PATH="$T8/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T8/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T8/roster-output.csv" \
+  "$WRAPPER" "$T8/roster.csv" > "$T8/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+# Note: 'bad branch with spaces' → after whitespace stripping → 'badbranchwithspaces'
+# which actually IS valid alphanumeric. Use a value that's invalid even after stripping.
+# Re-write with a value containing $ (definitely invalid).
+cat > "$T8/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,bad\$value
+EOF
+
+set +e
+PATH="$T8/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T8/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T8/roster-output.csv" \
+  "$WRAPPER" "$T8/roster.csv" > "$T8/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "2" "$exit_code" "wrapper exits 2 on invalid neon_branch"
+assert_contains "invalid neon_branch" "$T8/stdout.log" "error message names the field"
 
 # ── Summary ──────────────────────────────────────────────────────────────
 

--- a/scripts/roster.example.csv
+++ b/scripts/roster.example.csv
@@ -1,3 +1,3 @@
-handle,github_user,email,cohort
-alice,alice-gh,alice@example.com,2026-05
-bob,bob-gh,bob@example.com,2026-05
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,
+bob,bob-gh,bob@example.com,2026-05,bob_personal

--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -87,12 +87,15 @@ if [[ ! -f "$ROSTER_CSV" ]]; then
   echo "  [fail] roster file not found: $ROSTER_CSV" >&2
   fail=1
 else
-  expected_header="handle,github_user,email,cohort"
+  expected_header_4="handle,github_user,email,cohort"
+  expected_header_5="handle,github_user,email,cohort,neon_branch"
   actual_header="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
-  if [[ "$actual_header" == "$expected_header" ]]; then
+  if [[ "$actual_header" == "$expected_header_4" || "$actual_header" == "$expected_header_5" ]]; then
     echo "  [ok]   roster header is valid"
   else
-    echo "  [fail] roster header must be: $expected_header" >&2
+    echo "  [fail] roster header must be one of:" >&2
+    echo "           $expected_header_4" >&2
+    echo "           $expected_header_5" >&2
     echo "         got: $actual_header" >&2
     fail=1
   fi

--- a/scripts/workshop-setup.test.sh
+++ b/scripts/workshop-setup.test.sh
@@ -219,6 +219,27 @@ ec=$?
 assert_eq "2" "$ec" "exit 2 on empty roster"
 assert_contains "fail.*roster has no data rows" "$T6/stdout.log" "logs empty-roster failure"
 
+# ── Test 7: 5-column header is accepted by pre-flight ───────────────────
+
+echo ""
+echo "Test 7: 5-column roster header passes pre-flight"
+
+T7=$(new_tmp)
+make_stubs "$T7" "ok"
+cat > "$T7/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,
+EOF
+
+PATH="$T7/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T7/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T7/roster.csv" > "$T7/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with 5-column header"
+assert_contains "ok.*roster header is valid" "$T7/stdout.log" "logs header ok"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""

--- a/scripts/workshop-teardown.sh
+++ b/scripts/workshop-teardown.sh
@@ -49,11 +49,16 @@ if [[ ! -f "$ROSTER_CSV" ]]; then
 fi
 
 # ── CSV header validation ───────────────────────────────────────────────
+# Accept both 4-column and 5-column shapes. Teardown only reads handle and
+# cohort to compute project IDs; the 5th column is ignored here.
 
-EXPECTED_HEADER="handle,github_user,email,cohort"
+EXPECTED_HEADER_4="handle,github_user,email,cohort"
+EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
-if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER" ]]; then
-  echo "ERROR: roster CSV header must be exactly: $EXPECTED_HEADER" >&2
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" ]]; then
+  echo "ERROR: roster CSV header must be one of:" >&2
+  echo "       $EXPECTED_HEADER_4" >&2
+  echo "       $EXPECTED_HEADER_5" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -61,8 +66,12 @@ fi
 # ── Build project ID list from roster ────────────────────────────────────
 
 declare -a project_ids=()
-# shellcheck disable=SC2034  # github_user not needed; reserved per roster format
-while IFS=',' read -r handle github_user email cohort; do
+# Reads up to 5 fields. 4-column rows leave neon_branch empty (which we
+# ignore here — teardown only deletes GCP projects). 5-column rows have
+# the 5th value captured in neon_branch and are ignored too. Without
+# this 5th name, a 5-column row would leak the branch value into cohort.
+# shellcheck disable=SC2034  # github_user, email, neon_branch unused; required per roster format
+while IFS=',' read -r handle github_user email cohort neon_branch; do
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
   if [[ -z "$handle" || -z "$cohort" ]]; then

--- a/scripts/workshop-teardown.test.sh
+++ b/scripts/workshop-teardown.test.sh
@@ -219,6 +219,29 @@ ec=$?
 assert_eq "1" "$ec" "exit 1 when any delete fails"
 assert_contains "Failed:   2" "$T6/stdout.log" "summary shows failures"
 
+# ── Test 7: 5-column roster is accepted ─────────────────────────────────
+# Teardown only reads handle + cohort, so the 5th column is ignored — but
+# the header validation must accept the wider shape.
+
+echo ""
+echo "Test 7: 5-column roster header is accepted"
+
+T7=$(new_tmp)
+make_stubs "$T7" "all-active"
+cat > "$T7/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch
+alice,alice-gh,alice@example.com,2026-05,
+bob,bob-gh,bob@example.com,2026-05,bob_personal
+EOF
+
+PATH="$T7/bin:$PATH" \
+  OUTPUT_CSV="$T7/roster-output.csv" \
+  "$SCRIPT" "$T7/roster.csv" --yes > "$T7/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with 5-column header"
+assert_eq "2" "$(grep -c 'projects delete' "$T7/gcloud.log")" "both rows still attempted (5th column ignored)"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #35. **Foundation ticket — #33 builds on this.**

Adds an optional 5th column (`neon_branch`) to `roster.csv` and exports `NEON_BRANCH_NAME` per row to the inner provisioning script. The script-side Neon API integration in #33 will read it.

## CSV format

```csv
handle,github_user,email,cohort               (4 columns, unchanged behavior)
handle,github_user,email,cohort,neon_branch   (5 columns, with optional override)
```

- 5th column **empty or absent** → `NEON_BRANCH_NAME` defaults to `handle`
- 5th column **present and non-empty** → used as-is (after whitespace stripping)
- Invalid value (anything other than `^[A-Za-z0-9_-]{1,63}$`) → row fails fast with clear error

The 4-column shape continues to work — existing rosters need zero changes.

## Why an override exists

The default (`neon_branch = handle`) is correct for almost every workshop. The override matters when the same attendee returns for a second cohort: GCP project ID changes (`af-alice-2026-05` → `af-alice-2026-06`), but if they want the same Neon branch (continuity of data), the override gives it to them.

## Files changed

- `scripts/provision-workshop-roster.sh` — both header shapes accepted; loop reads 5 fields; default-to-handle; validate; forward `NEON_BRANCH_NAME`, `NEON_API_KEY`, `NEON_PROJECT_ID` to inner script
- `scripts/workshop-setup.sh` — pre-flight accepts both header shapes
- `scripts/workshop-teardown.sh` — header check accepts both; loop captures 5th field to prevent leak into `cohort`
- `scripts/roster.example.csv` — switched to 5-column shape with one default and one override
- `scripts/*.test.sh` (3 files) — 8 new assertions covering 5-column happy path, 4-column compatibility, invalid override, setup/teardown header acceptance
- `docs/PLATFORM-GUIDE.md` — Roster format section documents both shapes; corrects stale "github_user reserved for future use" note

## Test results

| Suite | Before | After |
|---|---|---|
| `provision-workshop-roster.test.sh` | 14/14 | 22/22 |
| `workshop-setup.test.sh` | 17/17 | 19/19 |
| `workshop-teardown.test.sh` | 14/14 | 16/16 |
| `provision-gcp-project.test.sh` (regression check) | 40/40 | 40/40 |
| **Total** | 85 | **97** |

12 new assertions; zero regressions.

## What this PR does NOT do

- No Neon API calls, no Secret Manager writes — that's #33
- No `NEON_PARENT_BRANCH` GitHub Actions secret integration — that's #36
- No facilitator runbook updates — that's `agile-flow-meta`#89

## Test plan

- [x] `bash -n` and `shellcheck` clean on all 6 modified scripts
- [x] `markdownlint` clean on `docs/PLATFORM-GUIDE.md`
- [x] All 4 test suites pass: 97/97 assertions
- [x] No regression on existing 85 assertions
- [ ] CI green (will verify after push)
- [ ] Real-GCP smoke at user's next nuke-and-fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)