### PR TITLE
feat(scripts): provision Neon branch + database-url secret per attendee

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -258,6 +258,40 @@ From the Neon Console, grab:
 
 ### Step 7: Create a Secret Manager Secret for the Database URL
 
+**As of `provision-gcp-project.sh` Step 5.7, this is automatic per
+project.** Set three env vars before running the provisioner:
+
+```bash
+NEON_API_KEY=neon_api_key_... \
+NEON_PROJECT_ID=dawn-mountain-12345 \
+NEON_BRANCH_NAME=alice \
+GCP_PROJECT_ID=af-alice-2026-05 \
+BILLING_ACCOUNT_ID=XXX-XXXX-XXXX \
+  ./scripts/provision-gcp-project.sh --create-project
+```
+
+Step 5.7 will:
+
+1. Create a Neon branch named `$NEON_BRANCH_NAME` (parented from the
+   project's `main` branch). If the branch already exists, reuse it.
+2. Fetch the branch's pooled connection URI via the Neon API.
+3. Create the `database-url` Secret Manager secret with that URI as
+   the value. If the secret already exists with a different value, add
+   a new version.
+4. Grant the deployer service account `roles/secretmanager.secretAccessor`
+   on the secret.
+
+The workshop wrapper (`provision-workshop-roster.sh`) reads
+`neon_branch` from each `roster.csv` row (defaulting to the row's
+`handle`) and exports `NEON_BRANCH_NAME` automatically. Facilitators
+running the canonical workshop flow don't need to manage this secret
+per project.
+
+#### Manual fallback (rarely needed)
+
+If you're running the inner script standalone or the env vars aren't
+set, the script's "Next steps" footer prints the manual command:
+
 ```bash
 echo -n "postgresql://user:pass@pooled-host/db" | \
   gcloud secrets create database-url \
@@ -265,8 +299,10 @@ echo -n "postgresql://user:pass@pooled-host/db" | \
     --project=YOUR_PROJECT_ID
 ```
 
-Use the **pooled** Neon connection string. Cloud Run exhausts direct
-connections fast because every revision instance opens its own pool.
+Use the **pooled** Neon connection string (the host should contain
+`-pooler.`). Cloud Run exhausts direct connections fast because every
+revision instance opens its own pool. See pattern #9 in
+`docs/PATTERN-LIBRARY.md`.
 
 ### Step 8: Configure GitHub Secrets and Variables
 

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -15,6 +15,19 @@
 #   GCP_REGION           (default: us-central1)
 #   ARTIFACT_REPO        (default: agile-flow)
 #   BILLING_ACCOUNT_ID   (required if --create-project)
+#   GITHUB_USERNAME      (optional) Enables Step 5.5 (WIF setup). Pinned
+#                        to <user>/${WIF_REPO:-agile-flow-gcp}.
+#   WIF_REPO             (default: agile-flow-gcp) Override the repo name
+#                        WIF binds to. Workshop participants fork the
+#                        canonical template without renaming, so the
+#                        default fits.
+#   NEON_API_KEY         (optional) Enables Step 5.7 (Neon branch +
+#                        database-url Secret Manager). Required for
+#                        per-attendee branch automation.
+#   NEON_PROJECT_ID      (optional) Same: required for Step 5.7.
+#   NEON_BRANCH_NAME     (optional) Same: required for Step 5.7.
+#                        Wrapper sets this from the CSV's neon_branch
+#                        column (defaults to handle).
 #
 # Notes:
 # - This script is idempotent. Re-running skips resources that already exist.
@@ -380,6 +393,185 @@ else
   echo "[skip] WIF setup not requested (GITHUB_USERNAME unset)"
 fi
 
+# ── Step 5.7: Neon branch + database-url Secret Manager ─────────────────
+#
+# Creates a per-attendee Neon branch and writes its pooled connection
+# string to the Secret Manager secret `database-url` in this GCP project.
+# Cloud Run mounts that secret as DATABASE_URL at runtime.
+#
+# Gated on NEON_API_KEY, NEON_PROJECT_ID, and NEON_BRANCH_NAME being set.
+# When any is unset, the step is skipped and the participant must create
+# the secret by hand (the script's "Next steps" footer notes this).
+#
+# Idempotency:
+#   - Branch already exists → fetch its pooled URI; do NOT recreate or
+#     reparent (per design decision: workshops are short-lived; drift
+#     against `main` is not checked).
+#   - Secret already exists with same value → no-op.
+#   - Secret exists with different value → add a new version.
+#
+# Connection URIs are sensitive (they include credentials). They are
+# never logged to stdout/stderr; only written to Secret Manager.
+
+if [[ -n "${NEON_API_KEY:-}" && -n "${NEON_PROJECT_ID:-}" && -n "${NEON_BRANCH_NAME:-}" ]]; then
+  NEON_API_BASE="https://console.neon.tech/api/v2"
+
+  # Helper: GET against Neon API. Body to stdout; error to stderr.
+  # Uses --fail-with-body so curl exits non-zero on 4xx/5xx but we still
+  # see the response.
+  neon_get() {
+    local path="$1"
+    curl --silent --show-error --fail-with-body \
+      -H "Authorization: Bearer $NEON_API_KEY" \
+      -H "Accept: application/json" \
+      "${NEON_API_BASE}${path}"
+  }
+
+  # Helper: POST. Same return semantics as neon_get. Captures HTTP code
+  # separately so 409 (branch exists) can be distinguished from real
+  # errors without --fail's cliff.
+  neon_post() {
+    local path="$1"
+    local body="$2"
+    local out_file="$3"
+    curl --silent --show-error \
+      --output "$out_file" \
+      --write-out '%{http_code}' \
+      -X POST \
+      -H "Authorization: Bearer $NEON_API_KEY" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      -d "$body" \
+      "${NEON_API_BASE}${path}"
+  }
+
+  # 5.7a: Find the project's main branch ID.
+  echo "[neon] looking up parent (main) branch in project $NEON_PROJECT_ID"
+  branches_json="$(neon_get "/projects/${NEON_PROJECT_ID}/branches")"
+  parent_branch_id="$(echo "$branches_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+branches = data.get('branches', [])
+for b in branches:
+    if b.get('default'):
+        print(b['id'])
+        sys.exit(0)
+sys.exit('no default branch found in project response')
+" 2>&1)"
+  if [[ -z "$parent_branch_id" || "$parent_branch_id" == *"no default branch"* ]]; then
+    echo "ERROR: could not find default (main) branch in Neon project $NEON_PROJECT_ID" >&2
+    echo "       response: $branches_json" >&2
+    exit 1
+  fi
+
+  # 5.7b: Try to create the attendee's branch.
+  echo "[neon] creating branch '$NEON_BRANCH_NAME' (parent: $parent_branch_id)"
+  create_response_file="$(mktemp)"
+  create_body="$(printf '{"branch":{"name":"%s","parent_id":"%s"},"endpoints":[{"type":"read_write"}]}' "$NEON_BRANCH_NAME" "$parent_branch_id")"
+  http_code="$(neon_post "/projects/${NEON_PROJECT_ID}/branches" "$create_body" "$create_response_file" || echo "000")"
+
+  if [[ "$http_code" == "201" || "$http_code" == "200" ]]; then
+    branch_id="$(python3 -c "import json,sys; print(json.load(open('$create_response_file'))['branch']['id'])")"
+    echo "[neon] branch created (id=$branch_id)"
+  elif [[ "$http_code" == "409" ]]; then
+    echo "[neon] branch '$NEON_BRANCH_NAME' already exists; reusing"
+    # Look up the existing branch's ID by name.
+    branch_id="$(echo "$branches_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+target = '$NEON_BRANCH_NAME'
+for b in data.get('branches', []):
+    if b.get('name') == target:
+        print(b['id'])
+        sys.exit(0)
+" 2>&1)"
+    if [[ -z "$branch_id" ]]; then
+      # The branch exists per Neon (409) but our cached branches_json from
+      # 5.7a didn't include it (race). Re-fetch.
+      branches_json="$(neon_get "/projects/${NEON_PROJECT_ID}/branches")"
+      branch_id="$(echo "$branches_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+target = '$NEON_BRANCH_NAME'
+for b in data.get('branches', []):
+    if b.get('name') == target:
+        print(b['id'])
+        sys.exit(0)
+sys.exit('branch not found after 409')
+" 2>&1)"
+    fi
+    if [[ -z "$branch_id" || "$branch_id" == *"branch not found"* ]]; then
+      echo "ERROR: Neon returned 409 for branch '$NEON_BRANCH_NAME' but lookup failed" >&2
+      exit 1
+    fi
+  else
+    echo "ERROR: Neon branch create returned HTTP $http_code" >&2
+    cat "$create_response_file" >&2
+    rm -f "$create_response_file"
+    exit 1
+  fi
+  rm -f "$create_response_file"
+
+  # 5.7c: Fetch the pooled connection URI for this branch.
+  echo "[neon] fetching pooled connection URI"
+  uri_response="$(neon_get "/projects/${NEON_PROJECT_ID}/connection_uri?branch_id=${branch_id}&database_name=neondb&role_name=neondb_owner&pooled=true")"
+  pooled_uri="$(echo "$uri_response" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+uri = data.get('uri', '')
+if not uri:
+    sys.exit('connection_uri response missing uri field')
+print(uri)
+" 2>&1)"
+  if [[ -z "$pooled_uri" || "$pooled_uri" == *"missing uri"* ]]; then
+    echo "ERROR: could not fetch pooled connection URI" >&2
+    exit 1
+  fi
+  # Sanity-check that we got the pooled host (sentinel: -pooler. in the host).
+  if [[ "$pooled_uri" != *"-pooler."* ]]; then
+    echo "WARN: connection URI does not contain '-pooler.'; is pooling enabled on this branch?" >&2
+  fi
+
+  # 5.7d: Write to Secret Manager. Idempotent: same value → no-op,
+  # different value → versions add.
+  if gcloud secrets describe database-url --project="$GCP_PROJECT_ID" >/dev/null 2>&1; then
+    current="$(gcloud secrets versions access latest --secret=database-url --project="$GCP_PROJECT_ID" 2>/dev/null || true)"
+    if [[ "$current" == "$pooled_uri" ]]; then
+      echo "[skip] database-url secret already current"
+    else
+      echo "[update] database-url secret (adding new version)"
+      printf '%s' "$pooled_uri" | gcloud secrets versions add database-url \
+        --data-file=- --project="$GCP_PROJECT_ID" >/dev/null
+    fi
+  else
+    echo "[create] database-url secret"
+    printf '%s' "$pooled_uri" | gcloud secrets create database-url \
+      --data-file=- --project="$GCP_PROJECT_ID" >/dev/null
+  fi
+
+  # 5.7e: Per-secret IAM binding for the deployer SA. Project-level
+  # secretAccessor in Step 5 already covers this; per-secret is
+  # defense-in-depth. Idempotent.
+  echo "[bind] roles/secretmanager.secretAccessor on database-url -> $SA_EMAIL"
+  gcloud secrets add-iam-policy-binding database-url \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="roles/secretmanager.secretAccessor" \
+    --project="$GCP_PROJECT_ID" \
+    --quiet >/dev/null
+
+  # Track that we ran for the footer.
+  NEON_BRANCH_PROVISIONED="true"
+else
+  if [[ -z "${NEON_API_KEY:-}" ]]; then
+    echo "[skip] Neon branch + database-url secret (NEON_API_KEY unset)"
+  elif [[ -z "${NEON_PROJECT_ID:-}" ]]; then
+    echo "[skip] Neon branch + database-url secret (NEON_PROJECT_ID unset)"
+  else
+    echo "[skip] Neon branch + database-url secret (NEON_BRANCH_NAME unset)"
+  fi
+  NEON_BRANCH_PROVISIONED="false"
+fi
+
 # ── Step 6: Service account key (workshop shortcut) ─────────────────────
 
 if [[ "$WITH_SA_KEY" == "true" ]]; then
@@ -421,18 +613,42 @@ else
   echo "   GCP_SERVICE_ACCOUNT    = $SA_EMAIL"
 fi
 echo ""
-echo "2. Sign up at https://neon.tech and create a project."
-echo "   Set these GitHub secrets from the Neon console:"
-echo ""
-echo "   NEON_API_KEY           = (from Neon Settings -> API Keys)"
-echo "   NEON_PROJECT_ID        = (from Neon Settings -> General)"
-echo ""
-echo "3. Create the production database secret:"
-echo ""
-echo "   echo -n 'postgresql://...' | gcloud secrets create database-url \\"
-echo "     --data-file=- --project=$GCP_PROJECT_ID"
-echo ""
-echo "4. (Optional) Set these repository variables (non-secret):"
+if [[ "${NEON_BRANCH_PROVISIONED:-false}" == "true" ]]; then
+  # Step 5.7 already created the Neon branch and database-url secret.
+  # Tell the participant what to set on their fork; no manual gcloud.
+  echo "2. Set these GitHub secrets from the Neon console (shared across cohort):"
+  echo ""
+  echo "   NEON_API_KEY           = (from Neon Settings -> API Keys)"
+  echo "   NEON_PROJECT_ID        = (from Neon Settings -> General)"
+  echo ""
+  echo "   The 'database-url' Secret Manager secret was created automatically"
+  echo "   from the attendee's Neon branch ('$NEON_BRANCH_NAME')."
+  echo ""
+  echo "3. (For PR previews — see #36) Set NEON_PARENT_BRANCH on the participant's"
+  echo "   fork so per-PR branches inherit from this attendee's branch:"
+  echo ""
+  echo "   NEON_PARENT_BRANCH     = $NEON_BRANCH_NAME"
+  echo ""
+  echo "4. (Optional) Set these repository variables (non-secret):"
+else
+  # Manual fallback: facilitator either skipped the env vars or is running
+  # the inner script standalone.
+  echo "2. Sign up at https://neon.tech and create a project."
+  echo "   Set these GitHub secrets from the Neon console:"
+  echo ""
+  echo "   NEON_API_KEY           = (from Neon Settings -> API Keys)"
+  echo "   NEON_PROJECT_ID        = (from Neon Settings -> General)"
+  echo ""
+  echo "3. Create the production database secret:"
+  echo ""
+  echo "   echo -n 'postgresql://...' | gcloud secrets create database-url \\"
+  echo "     --data-file=- --project=$GCP_PROJECT_ID"
+  echo ""
+  echo "   (Or set NEON_API_KEY + NEON_PROJECT_ID + NEON_BRANCH_NAME before"
+  echo "   running this script and Step 5.7 will create the secret automatically.)"
+  echo ""
+  echo "4. (Optional) Set these repository variables (non-secret):"
+fi
 echo ""
 echo "   GCP_REGION             = $GCP_REGION"
 echo "   ARTIFACT_REPO          = $ARTIFACT_REPO"

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -700,6 +700,276 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 15-17: Step 5.7 Neon branch + database-url Secret Manager ──────
+#
+# Step 5.7 has three branches:
+#   - NEON_API_KEY/PROJECT_ID/BRANCH_NAME unset → skipped
+#   - branch absent in Neon → POST /branches returns 201; secret created
+#   - branch already exists → POST returns 409; lookup existing; secret
+#     versions-add (when value differs) or no-op (when same)
+#
+# Stubs both curl (Neon API) and gcloud (Secret Manager) at PATH.
+
+run_step5_7_test() {
+  local neon_state="$1"   # "skip" | "absent" | "exists" | "exists-same-value"
+  local tmp; tmp=$(mktemp -d -t aflowtest-XXXX)
+  mkdir -p "$tmp/bin"
+
+  # Fake Neon API responses keyed by the URL path.
+  cat > "$tmp/bin/curl" <<EOF
+#!/usr/bin/env bash
+# Capture full args (each on its own line for grep'ability)
+printf '%s\n' "\$@" >> "$tmp/curl.log"
+
+# Find the URL — last positional arg containing /api/v2.
+url=""
+for a in "\$@"; do
+  case "\$a" in
+    *console.neon.tech/api/v2*) url="\$a" ;;
+  esac
+done
+
+# --output FILE writes the body to FILE; --write-out '%{http_code}' prints
+# the HTTP code on stdout. Detect both.
+out_file=""
+write_out=""
+prev=""
+for a in "\$@"; do
+  case "\$prev" in
+    --output)      out_file="\$a" ;;
+    --write-out)   write_out="\$a" ;;
+  esac
+  prev="\$a"
+done
+
+# Method: was -X POST passed?
+is_post=false
+for a in "\$@"; do
+  if [[ "\$a" == POST ]]; then is_post=true; fi
+done
+
+emit() {
+  # If --output present, write body there. Otherwise body to stdout.
+  if [[ -n "\$out_file" ]]; then
+    printf '%s' "\$1" > "\$out_file"
+  else
+    printf '%s' "\$1"
+  fi
+  # If --write-out present, print HTTP code on stdout.
+  if [[ -n "\$write_out" ]]; then
+    printf '%s' "\$2"
+  fi
+}
+
+case "\$url" in
+  *"/branches?"*|*"/branches "*)
+    # GET /branches
+    emit '{"branches":[{"id":"br-main","name":"main","default":true}]}' "200"
+    exit 0
+    ;;
+  *"/branches"*)
+    if \$is_post; then
+      # POST /branches  (create)
+      case "$neon_state" in
+        absent)
+          emit '{"branch":{"id":"br-alice","name":"alice"}}' "201"
+          exit 0
+          ;;
+        exists|exists-same-value)
+          emit '{"error":"branch already exists"}' "409"
+          exit 0
+          ;;
+      esac
+    else
+      # GET /branches (no query, the re-fetch path)
+      emit '{"branches":[{"id":"br-main","name":"main","default":true},{"id":"br-alice","name":"alice"}]}' "200"
+      exit 0
+    fi
+    ;;
+  *"/connection_uri"*)
+    emit '{"uri":"postgresql://user:pass@ep-xxx-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require"}' "200"
+    exit 0
+    ;;
+  *)
+    emit '{"error":"unhandled in stub"}' "500"
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$tmp/bin/curl"
+
+  # Fake gcloud — combines the Step 5.5 stub plus secrets handling.
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    if echo "\$*" | grep -q "projectNumber"; then
+      echo "12345"
+    elif echo "\$*" | grep -q "lifecycleState"; then
+      echo "ACTIVE"
+    else
+      exit 1
+    fi
+    exit 0
+    ;;
+  "projects create"|"projects get-iam-policy"|"projects add-iam-policy-binding") exit 0 ;;
+  "billing projects") exit 0 ;;
+  "resource-manager org-policies")
+    case "\$3" in
+      describe) exit 1 ;;
+      list)     exit 0 ;;
+    esac
+    ;;
+  "services enable") exit 0 ;;
+  "artifacts repositories")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+    esac
+    ;;
+  "iam service-accounts")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+      add-iam-policy-binding) exit 0 ;;
+    esac
+    ;;
+  "iam workload-identity-pools") exit 1 ;;  # skip WIF in 5.7 tests
+  "secrets describe")
+    case "$neon_state" in
+      exists-same-value) exit 0 ;;   # secret exists
+      *)                 exit 1 ;;   # secret does not exist
+    esac
+    ;;
+  "secrets versions")
+    # versions access latest — return what's currently in the secret
+    case "$neon_state" in
+      exists-same-value)
+        echo "postgresql://user:pass@ep-xxx-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require"
+        ;;
+    esac
+    exit 0
+    ;;
+  "secrets create"|"secrets add-iam-policy-binding") exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+
+  # Use ${var-default} (no colon) so an explicit empty string passed by
+  # the caller — like test 15's "" for NEON_API_KEY — stays empty.
+  # ${var:-default} would substitute on empty, which we don't want here.
+  set +e
+  PATH="$tmp/bin:$PATH" \
+    GCP_PROJECT_ID="af-step57-test" \
+    BILLING_ACCOUNT_ID="FAKE" \
+    NEON_API_KEY="${2-fake-api-key}" \
+    NEON_PROJECT_ID="${3-fake-project-id}" \
+    NEON_BRANCH_NAME="${4-alice}" \
+    "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
+  set -e
+
+  echo "$tmp"
+}
+
+# Test 15: NEON_API_KEY unset → step is skipped
+
+echo ""
+echo "Test 15: Step 5.7 skipped when NEON_API_KEY unset"
+
+T15=$(run_step5_7_test "skip" "" "fake-project-id" "alice")
+
+if grep -q "skip.*NEON_API_KEY unset" "$T15/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip]' message about NEON_API_KEY"
+  cat "$T15/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# When skipped, no curl calls to the Neon API should have happened
+neon_calls=0
+if [[ -f "$T15/curl.log" ]]; then
+  neon_calls="$(grep -c "console.neon.tech" "$T15/curl.log" || true)"
+fi
+assert_eq "0" "$neon_calls" "no Neon API calls when skipped"
+
+# Test 16: NEON_*  set, branch absent → branch created, secret created
+
+echo ""
+echo "Test 16: Step 5.7 creates branch + database-url secret when absent"
+
+T16=$(run_step5_7_test "absent")
+
+if grep -q "branch created" "$T16/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} branch-created log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'branch created' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "create.*database-url secret" "$T16/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} secret-create log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[create] database-url secret' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify gcloud secrets create was called (not versions add)
+if grep -q "secrets create database-url" "$T16/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud secrets create invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'gcloud secrets create database-url' in gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# IAM binding granted
+if grep -q "secrets add-iam-policy-binding database-url" "$T16/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} per-secret IAM binding granted"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'secrets add-iam-policy-binding database-url' in gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 17: branch exists, secret exists with SAME value → no-op skip
+
+echo ""
+echo "Test 17: Step 5.7 idempotent when branch + secret already current"
+
+T17=$(run_step5_7_test "exists-same-value")
+
+if grep -q "branch.*alice.*already exists" "$T17/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} branch-already-exists log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'branch already exists' in stdout"
+  cat "$T17/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "skip.*database-url secret already current" "$T17/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} secret-already-current log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] database-url secret already current' in stdout"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify gcloud secrets create was NOT called (since we used versions access path)
+if ! grep -q "secrets create database-url" "$T17/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud secrets create NOT called (idempotent)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} secrets create should NOT have been called when secret is current"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #33. **Workshop-blocking P0; depends on #35 (already merged).**

Adds Step 5.7 to `provision-gcp-project.sh` that creates a Neon branch and writes its pooled connection URI to a `database-url` Secret Manager secret. Cloud Run mounts the secret as `DATABASE_URL` at runtime. After this lands, fresh forks no longer need a manual `echo url | gcloud secrets create` step — the wrapper takes 8 attendees from zero to 8 isolated Postgres branches in one command.

## What the new step does

```
input env: NEON_API_KEY, NEON_PROJECT_ID, NEON_BRANCH_NAME, GCP_PROJECT_ID, SA_EMAIL

  GET /projects/{NEON_PROJECT_ID}/branches    → find default branch ID
  POST /projects/.../branches                  → create attendee branch (or 409)
  GET /projects/.../connection_uri?pooled=true → fetch pooled URI
  gcloud secrets describe database-url         → check existence
  gcloud secrets [create | versions add]       → write URI
  gcloud secrets add-iam-policy-binding        → per-secret IAM
```

When any of the three Neon env vars is unset, the step skips and the footer prints the manual fallback. Real-GCP smoke deferred to your next nuke-and-fork (consistent with the rest of today's chain).

## Design decisions (confirmed in the ticket discussion)

1. **Schema baseline on `main` is empty.** Attendees run `alembic upgrade head` as their first command — that's a teaching moment, not a setup chore.
2. **Idempotent re-runs reuse existing branches.** No drift check against `main`. Workshops are short-lived enough that drift isn't real.
3. **Connection URIs are never logged.** Only written to Secret Manager. The script doesn't even echo them in error messages.

## Implementation notes worth a re-read

### Curl + Python for Neon API

The Neon API is JSON-only. `jq` isn't a system dependency I want to take, so the script uses `python3 -c "import json,sys; ..."` for parsing. Macros are inline because shellcheck struggles with complex heredocs; one-liner Python is fine. The pattern is:

```bash
parent_branch_id="$(echo "$branches_json" | python3 -c "
import json, sys
data = json.load(sys.stdin)
for b in data.get('branches', []):
    if b.get('default'):
        print(b['id'])
        sys.exit(0)
sys.exit('no default branch found')
" 2>&1)"
```

### Distinguishing 409 from real errors

`curl --fail-with-body` exits non-zero on 4xx/5xx. For the branch-create call we *want* to know about 409 (branch already exists, fall through to lookup) without halting. So that one call uses `--write-out '%{http_code}'` instead of `--fail`, and we branch on the captured code. The other two calls (list branches, get connection URI) use `--fail-with-body` because any non-2xx there is a real error.

### Pooled URI sanity check

The script logs `WARN: connection URI does not contain '-pooler.'` if the returned URI doesn't have the pooler host fragment. This is a soft check — the Neon API might one day change the host shape — but it surfaces the most likely silent failure (pattern #9: pooled vs direct).

### Footer rewrite

The `if [[ "$NEON_BRANCH_PROVISIONED" == "true" ]]` branch in the footer:
- Drops the manual `gcloud secrets create database-url ...` snippet
- Mentions `NEON_PARENT_BRANCH = $NEON_BRANCH_NAME` as the value to set on the participant's fork (forward-reference to #36)
- Keeps the existing manual flow as the `else` branch

## Tests

`scripts/provision-gcp-project.test.sh` gains tests 15-17:

- **Test 15** (NEON_API_KEY unset): asserts the skip log line and zero Neon API calls
- **Test 16** (branch absent): asserts both `[neon] branch created` AND `[create] database-url secret`, plus that `gcloud secrets create` was invoked AND IAM binding was granted
- **Test 17** (branch + secret already current): asserts the idempotent path — both skip lines logged AND `gcloud secrets create` was NOT called

All three tests use new stubs:

- `curl` stub matches by URL path and returns parametric responses (404, 201, 409, 500). The stub correctly handles `--output FILE` (writes body to file) and `--write-out '%{http_code}'` (writes code to stdout).
- `gcloud` stub extends the Step 5.5 stub with `secrets describe`, `secrets versions access latest`, `secrets create`, and `secrets add-iam-policy-binding`.

**Total: 106/106 assertions pass** across all 4 test files (49 inner + 22 wrapper + 19 setup + 16 teardown).

## Test runtime note

Tests 15-17 each take ~30s because the script's SA-propagation probe (added in #16) waits 5×6 seconds when its describe stub returns failure. The probe is correct for real-GCP use; for these tests the wait is wasted. Worth a small follow-up: support `WIF_PROBE_SLEEP` or similar env override in test mode. Not blocking — it's just slow, not broken.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] 49/49 inner-script tests pass; 22/22 + 19/19 + 16/16 wrapper tests pass
- [x] markdownlint clean on PLATFORM-GUIDE.md
- [ ] CI green (will verify after push)
- [ ] Real-GCP smoke at user's next nuke-and-fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)