### PR TITLE
feat(scripts): add github_full_repo column to roster.csv for org-fork support

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -130,20 +130,23 @@ either system — just secret values.
 
 **End-to-end for one participant (`bob`):**
 
-1. Facilitator runs `provision-workshop-roster.sh` → `af-bob-2026-05` exists with the deployer SA.
-2. Facilitator runs the WIF setup in Step 5 below, plugging in `bob-gh/agile-flow-gcp` as the GitHub repo. This creates the trust relationship: "GitHub Actions runs in `bob-gh/agile-flow-gcp` may impersonate `deployer@af-bob-2026-05`."
+1. Facilitator's roster has bob's row with `github_full_repo=acme/widget-shop` (or empty, defaulting to `bob-gh/agile-flow-gcp` for personal forks).
+2. Facilitator runs `provision-workshop-roster.sh` → `af-bob-2026-05` exists with the deployer SA, and Step 5.5 binds the WIF trust to whatever GitHub repo bob's row specified.
 3. Facilitator emails bob the four secret values. (Template in `agile-flow-meta/docs/workshops/gcp-facilitator-runbook.md` §7.)
-4. Bob forks `vibeacademy/agile-flow-gcp` to his account, pastes the four secrets, pushes a trivial change to `main`. The deploy workflow uses WIF to assume the deployer SA and ships the container to bob's project.
+4. Bob forks `vibeacademy/agile-flow-gcp` (to his account or his org), pastes the four secrets, pushes a trivial change to `main`. The deploy workflow uses WIF to assume the deployer SA and ships the container to bob's project.
 
-**The most common participant footgun:** if bob renames his fork (e.g.
-`bob-gh/my-cool-project`), WIF auth fails because the trust binding
-names `bob-gh/agile-flow-gcp` exactly. Tell participants in their
-day-1 email: do not rename the fork.
+**The most common participant footgun:** if the GitHub fork's owner/repo
+doesn't match what the roster said, WIF auth fails because the trust
+binding names a specific `<owner>/<repo>` exactly. Coordinate with
+participants before provisioning: where will they fork (personal vs
+org), and will they rename the repo? The `github_full_repo` column in
+the roster captures the answer.
 
-As of #5, WIF setup is automatic per-project — the four secrets above
-fall out of `provision-gcp-project.sh` Step 5.5 when `GITHUB_USERNAME`
-is set. The workshop wrapper exports it automatically per CSV row.
-See Step 5 below for details.
+As of #5/#40, WIF setup is automatic per-project — the four secrets
+above fall out of `provision-gcp-project.sh` Step 5.5 when
+`GITHUB_OWNER` (or its legacy alias `GITHUB_USERNAME`) is set. The
+workshop wrapper exports both `GITHUB_OWNER` and `GITHUB_REPO` per
+CSV row. See Step 5 below for details.
 
 ---
 
@@ -154,14 +157,24 @@ without storing a long-lived service account key. This is the best
 practice and should be your default.
 
 **As of `provision-gcp-project.sh` Step 5.5, this is automatic per
-project.** Set `GITHUB_USERNAME` and the script creates the pool, the
-OIDC provider, and the IAM binding scoped to
-`<github_user>/agile-flow-gcp`.
+project.** Set `GITHUB_OWNER` and `GITHUB_REPO` and the script creates
+the pool, the OIDC provider, and the IAM binding scoped to
+`<owner>/<repo>`. `GITHUB_USERNAME` continues to work as a legacy alias
+for `GITHUB_OWNER` so older callers don't need to change.
 
 ```bash
+# Personal fork
 GCP_PROJECT_ID=af-alice-2026-05 \
 BILLING_ACCOUNT_ID=XXX-XXXX-XXXX \
-GITHUB_USERNAME=alice-gh \
+GITHUB_OWNER=alice-gh \
+GITHUB_REPO=agile-flow-gcp \
+  ./scripts/provision-gcp-project.sh --create-project
+
+# Org fork with renamed repo
+GCP_PROJECT_ID=af-alice-2026-05 \
+BILLING_ACCOUNT_ID=XXX-XXXX-XXXX \
+GITHUB_OWNER=acme \
+GITHUB_REPO=widget-shop \
   ./scripts/provision-gcp-project.sh --create-project
 ```
 
@@ -169,17 +182,19 @@ The script's "Next steps" output prints the exact `GCP_WORKLOAD_IDENTITY_PROVIDE
 and `GCP_SERVICE_ACCOUNT` values to paste into the participant's fork
 secrets — no copying from this doc, no project-number arithmetic.
 
-The workshop wrapper (`provision-workshop-roster.sh`) reads `github_user`
-from each `roster.csv` row and exports `GITHUB_USERNAME` automatically,
-so a facilitator running the canonical workshop flow never needs to
-think about WIF setup at all. The wrapper also records the WIF provider
-resource string in `roster-output.csv` per row.
+The workshop wrapper (`provision-workshop-roster.sh`) splits the
+`github_full_repo` CSV column at the slash and exports `GITHUB_OWNER`
+and `GITHUB_REPO` automatically, so a facilitator running the canonical
+workshop flow never needs to think about WIF setup at all. The wrapper
+also records the WIF provider resource string in `roster-output.csv`
+per row.
 
-> **Don't rename the fork.** The IAM binding is pinned to
-> `<github_user>/agile-flow-gcp` exactly. If a participant renames their
-> fork (e.g. `bob-gh/my-cool-project`), WIF auth fails on first deploy
-> with a clear error from `google-github-actions/auth`. Tell participants
-> in their day-1 email: fork as-is, do not rename.
+> **The fork's owner/repo must match the roster.** The IAM binding is
+> pinned to `<github_owner>/<github_repo>` exactly. If a participant's
+> actual fork lives at a different path than the roster's
+> `github_full_repo` says, WIF auth fails on first deploy. Confirm
+> with each participant before provisioning: which GitHub
+> account/org will they fork into, and what will the repo be named?
 
 #### Manual fallback (rarely needed)
 
@@ -363,8 +378,8 @@ discovering a missing auth token mid-loop.
 
 ### Roster format
 
-`roster.csv` accepts two header shapes. Both have the same first four
-columns; the 5th is optional and used only by the Neon-branch automation.
+`roster.csv` accepts three header shapes. The first four columns are
+required; the 5th and 6th are optional automation columns.
 
 **Minimal (4 columns):**
 
@@ -374,7 +389,7 @@ alice,alice-gh,alice@example.com,2026-05
 bob,bob-gh,bob@example.com,2026-05
 ```
 
-**Extended (5 columns):**
+**With Neon branch override (5 columns):**
 
 ```csv
 handle,github_user,email,cohort,neon_branch
@@ -382,24 +397,38 @@ alice,alice-gh,alice@example.com,2026-05,
 bob,bob-gh,bob@example.com,2026-05,bob_personal
 ```
 
+**With Neon + GitHub repo override (6 columns):**
+
+```csv
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
+carol,carol-gh,carol@example.com,2026-05,carol,
+```
+
 Columns:
 
 - `handle` — short, lowercase, stable identifier; appears in the GCP project ID
-- `github_user` — the participant's GitHub username; used to scope the
-  WIF binding to `<github_user>/agile-flow-gcp`
+- `github_user` — the participant's GitHub username; used as the default
+  GitHub owner for the WIF binding when `github_full_repo` is empty
 - `email` — Google identity granted `roles/editor` on the new project
-- `cohort` — `YYYY-MM` of the workshop date; appears in the project ID
-- `neon_branch` *(optional, 5-column shape only)* — Neon branch name for
-  this attendee. When empty or absent, defaults to `handle`. Use the
-  override when the same person needs a stable branch across cohorts
-  (different `cohort`, same `neon_branch`). Must be 1-63 chars,
-  alphanumeric + hyphen + underscore.
+- `cohort` — `YYYY-MM` of the workshop date; appears in the GCP project ID
+- `neon_branch` *(optional)* — Neon branch name for this attendee. When
+  empty or absent, defaults to `handle`. Use the override when the same
+  person needs a stable branch across cohorts (different `cohort`, same
+  `neon_branch`). Must be 1-63 chars, alphanumeric + hyphen + underscore.
+- `github_full_repo` *(optional, 6-column shape only)* — `<owner>/<repo>`
+  identifying the participant's fork. Use the override when attendees
+  fork into their organization's GitHub (e.g., `acme/widget-shop`) and
+  rename the repo to fit their product. When empty or absent, defaults
+  to `<github_user>/agile-flow-gcp` (the personal-fork pattern).
+  Validation: `^[A-Za-z0-9-]{1,39}/[A-Za-z0-9._-]{1,100}$`.
 
 Project IDs follow the pattern `af-{handle}-{cohort}`. This shape is
 referenced from the facilitator runbook, the participant day-1 doc, and
 the dry-run checklist — do not change it. A working example lives at
-`scripts/roster.example.csv` (uses the 5-column shape with one default
-and one explicit override).
+`scripts/roster.example.csv` (uses the 6-column shape with two org-fork
+rows and one personal-fork default).
 
 ### Setup behavior
 

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -15,12 +15,15 @@
 #   GCP_REGION           (default: us-central1)
 #   ARTIFACT_REPO        (default: agile-flow)
 #   BILLING_ACCOUNT_ID   (required if --create-project)
-#   GITHUB_USERNAME      (optional) Enables Step 5.5 (WIF setup). Pinned
-#                        to <user>/${WIF_REPO:-agile-flow-gcp}.
-#   WIF_REPO             (default: agile-flow-gcp) Override the repo name
-#                        WIF binds to. Workshop participants fork the
-#                        canonical template without renaming, so the
-#                        default fits.
+#   GITHUB_OWNER         (optional) GitHub owner of the participant's
+#                        fork. Personal username (alice-gh) or org (acme).
+#                        Required to enable Step 5.5 (WIF setup).
+#   GITHUB_REPO          (default: agile-flow-gcp) Repo name within
+#                        GITHUB_OWNER. Set when participants fork into
+#                        an org and rename the repo for their product.
+#   GITHUB_USERNAME      Legacy alias for GITHUB_OWNER. When GITHUB_OWNER
+#                        is unset, the script uses GITHUB_USERNAME as the
+#                        owner. Existing callers don't need to change.
 #   NEON_API_KEY         (optional) Enables Step 5.7 (Neon branch +
 #                        database-url Secret Manager). Required for
 #                        per-attendee branch automation.
@@ -302,31 +305,44 @@ for role in "${ROLES[@]}"; do
       --quiet >/dev/null
 done
 
-# ── Step 5.5: Workload Identity Federation (when GITHUB_USERNAME set) ────
+# ── Step 5.5: Workload Identity Federation (when GITHUB_OWNER set) ──────
 #
 # Trust GitHub Actions OIDC tokens from a specific repo so deploys can
 # impersonate the deployer SA without a long-lived JSON key. Gated on
-# GITHUB_USERNAME being set — when unset, this whole block is skipped
-# and the script's existing --with-sa-key path remains the auth fallback.
+# GITHUB_OWNER being set — when unset, this whole block is skipped and
+# the script's existing --with-sa-key path remains the auth fallback.
 #
-# WIF_REPO defaults to `agile-flow-gcp`. Workshop participants fork the
-# canonical template without renaming, so the binding pattern is always
-# <github_user>/agile-flow-gcp. Override WIF_REPO if you ever need a
-# different repo name (dry-run smoke, non-workshop callers).
+# Inputs (the wrapper sets these per row from roster.csv):
+#   GITHUB_OWNER     The GitHub owner of the participant's fork. May be
+#                    a personal username (alice-gh) or an organization
+#                    (acme). Required to enable Step 5.5.
+#   GITHUB_REPO      The repo name within the owner. Defaults to
+#                    'agile-flow-gcp' when unset.
+#   GITHUB_USERNAME  Legacy alias for GITHUB_OWNER. Used when GITHUB_OWNER
+#                    is unset, so external callers that set the older
+#                    name continue to work.
+#
+# Together they identify the GitHub repo whose Actions runs are trusted
+# to impersonate the deployer SA. Owners with org forks can rename their
+# repo (acme/widget-shop) and the binding still works because the
+# wrapper passes both fields explicitly.
 #
 # Google requires --attribute-condition on OIDC providers (it must
 # reference at least one provider claim). We use a trivially-true
 # condition (`assertion.repository != ''`) so the provider doesn't gate
-# access by org or repo — workshop participants fork under their
-# personal GitHub accounts, not the canonical org, and we cannot
-# enumerate every domain ahead of time. Trust scoping happens at the
-# IAM binding layer instead, where attribute.repository=<user>/<repo>
-# pins each binding to one specific repo.
+# access by org or repo — attendees may fork under any GitHub account
+# or org. Trust scoping happens at the IAM binding layer instead, where
+# attribute.repository=<owner>/<repo> pins each binding to one specific
+# repo.
 #
 # All three sub-steps (pool, provider, binding) are idempotent.
 
-if [[ -n "${GITHUB_USERNAME:-}" ]]; then
-  WIF_REPO="${WIF_REPO:-agile-flow-gcp}"
+# Resolve GITHUB_OWNER, falling back to GITHUB_USERNAME for backwards
+# compatibility with external callers from before #40.
+WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"
+WIF_REPO_NAME="${GITHUB_REPO:-agile-flow-gcp}"
+
+if [[ -n "$WIF_OWNER" ]]; then
   WIF_POOL="github"
   WIF_PROVIDER="github"
 
@@ -378,9 +394,9 @@ if [[ -n "${GITHUB_USERNAME:-}" ]]; then
   #
   # add-iam-policy-binding is idempotent — re-running with the same member
   # is a no-op.
-  WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/attribute.repository/${GITHUB_USERNAME}/${WIF_REPO}"
+  WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/attribute.repository/${WIF_OWNER}/${WIF_REPO_NAME}"
   for wif_role in roles/iam.workloadIdentityUser roles/iam.serviceAccountTokenCreator; do
-    echo "[bind] $wif_role <- ${GITHUB_USERNAME}/${WIF_REPO}"
+    echo "[bind] $wif_role <- ${WIF_OWNER}/${WIF_REPO_NAME}"
     gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
       --role="$wif_role" \
       --member="$WIF_MEMBER" \
@@ -390,7 +406,7 @@ if [[ -n "${GITHUB_USERNAME:-}" ]]; then
 
   WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/providers/${WIF_PROVIDER}"
 else
-  echo "[skip] WIF setup not requested (GITHUB_USERNAME unset)"
+  echo "[skip] WIF setup not requested (GITHUB_OWNER and GITHUB_USERNAME unset)"
 fi
 
 # ── Step 5.7: Neon branch + database-url Secret Manager ─────────────────

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -564,11 +564,17 @@ esac
 EOF
   chmod +x "$tmp/bin/gcloud"
 
+  # Args 2/3/4 are GITHUB_USERNAME / GITHUB_OWNER / GITHUB_REPO. Existing
+  # callers pass only GITHUB_USERNAME (legacy alias path); new callers
+  # can pass GITHUB_OWNER + GITHUB_REPO directly to test the modern path.
+  # Use ${var-default} (no colon) so explicit empty stays empty.
   set +e
   PATH="$tmp/bin:$PATH" \
     GCP_PROJECT_ID="af-wif-test" \
     BILLING_ACCOUNT_ID="FAKE" \
-    GITHUB_USERNAME="${2:-}" \
+    GITHUB_USERNAME="${2-}" \
+    GITHUB_OWNER="${3-}" \
+    GITHUB_REPO="${4-}" \
     "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
   set -e
 
@@ -697,6 +703,41 @@ if grep -q "bind.*workloadIdentityUser" "$T14/stdout.log"; then
   PASS=$((PASS + 1))
 else
   echo -e "  ${RED}✗${NC} expected binding step to log [bind]"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 14b: GITHUB_OWNER + GITHUB_REPO (org-fork path) ────────────────
+# Verifies the new env-var pair from #40. Owner is acme (an org); repo
+# name diverges from `agile-flow-gcp` because the participant renamed it.
+
+echo ""
+echo "Test 14b: Step 5.5 honors GITHUB_OWNER + GITHUB_REPO"
+
+# arg order: state, GITHUB_USERNAME, GITHUB_OWNER, GITHUB_REPO
+T14B=$(run_step5_5_test "absent" "" "acme" "widget-shop")
+
+if grep -q "bind.*<- acme/widget-shop" "$T14B/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} binding member is acme/widget-shop (not <user>/agile-flow-gcp)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[bind] ... <- acme/widget-shop' in stdout"
+  cat "$T14B/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 14c: WIF skipped when neither GITHUB_OWNER nor GITHUB_USERNAME set ──
+
+echo ""
+echo "Test 14c: Step 5.5 skipped when both GITHUB_OWNER and GITHUB_USERNAME unset"
+
+T14C=$(run_step5_5_test "absent" "" "" "")
+
+if grep -q "skip.*WIF setup not requested" "$T14C/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] WIF setup not requested' in stdout"
+  cat "$T14C/stdout.log"
   FAIL=$((FAIL + 1))
 fi
 

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -18,7 +18,7 @@
 #   NEON_API_KEY         optional; forwarded to inner script for branch creation
 #   NEON_PROJECT_ID      optional; forwarded to inner script for branch creation
 #
-# CSV format (header required, accepts either 4 or 5 columns):
+# CSV format (header required, accepts 4, 5, or 6 columns):
 #   handle,github_user,email,cohort
 #   alice,alice-gh,alice@example.com,2026-05
 #   bob,bob-gh,bob@example.com,2026-05
@@ -27,9 +27,20 @@
 #   alice,alice-gh,alice@example.com,2026-05,alice
 #   bob,bob-gh,bob@example.com,2026-05,bob_personal    (explicit branch override)
 #
+#   handle,github_user,email,cohort,neon_branch,github_full_repo   (6-column)
+#   alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+#   bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
+#   carol,carol-gh,carol@example.com,2026-05,carol,                (defaults)
+#
 # When the optional `neon_branch` column is empty or absent, NEON_BRANCH_NAME
 # defaults to the row's `handle`. Use the override when the same person needs
 # a stable Neon branch across cohorts (different `cohort` value, same branch).
+#
+# When the optional `github_full_repo` column is empty or absent,
+# defaults to `<github_user>/agile-flow-gcp`. Use the override when
+# attendees fork into an org and rename the repo to fit their product.
+# The wrapper splits the value at the slash and exports GITHUB_OWNER and
+# GITHUB_REPO to the inner script.
 #
 # Project IDs follow the pattern  af-{handle}-{cohort}  and are globally
 # unique. This is non-negotiable: the runbook, day-1 doc, and dry-run
@@ -91,12 +102,16 @@ fi
 
 EXPECTED_HEADER_4="handle,github_user,email,cohort"
 EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
+EXPECTED_HEADER_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
 
-if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" ]]; then
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_6" ]]; then
   echo "ERROR: roster CSV header must be one of:" >&2
   echo "       $EXPECTED_HEADER_4" >&2
   echo "       $EXPECTED_HEADER_5" >&2
+  echo "       $EXPECTED_HEADER_6" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -118,15 +133,16 @@ skipped=0
 # tail -n +2 skips header. Process substitution avoids subshell so counters
 # survive into the summary block.
 #
-# We read 5 fields. When the input is 4-column, neon_branch is empty; the
-# default-to-handle logic below covers it.
-while IFS=',' read -r handle github_user email cohort neon_branch; do
+# We read 6 fields. 4- and 5-column rows leave the trailing fields empty;
+# the default-fallback logic below covers them.
+while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo; do
   # Strip whitespace and CR (Windows line endings)
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
   email="$(echo "$email" | tr -d '[:space:]\r')"
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
   neon_branch="$(echo "${neon_branch:-}" | tr -d '[:space:]\r')"
+  github_full_repo="$(echo "${github_full_repo:-}" | tr -d '[:space:]\r')"
 
   if [[ -z "$handle" || -z "$cohort" ]]; then
     continue
@@ -145,6 +161,26 @@ while IFS=',' read -r handle github_user email cohort neon_branch; do
     echo "       must be 1-63 chars, alphanumeric + hyphen + underscore only" >&2
     exit 2
   fi
+
+  # Default github_full_repo to "<github_user>/agile-flow-gcp" when not set.
+  # That preserves today's behavior for personal-fork participants.
+  if [[ -z "$github_full_repo" ]]; then
+    github_full_repo="${github_user}/agile-flow-gcp"
+  fi
+
+  # Validate <owner>/<repo> shape. GitHub owner: alphanumeric + hyphens
+  # (1-39 chars). Repo: alphanumeric + dot + hyphen + underscore (1-100).
+  # Strict check rejects empty fragments, double slashes, leading/trailing
+  # whitespace (already stripped above), etc.
+  if ! [[ "$github_full_repo" =~ ^[A-Za-z0-9-]{1,39}/[A-Za-z0-9._-]{1,100}$ ]]; then
+    echo "ERROR: invalid github_full_repo '$github_full_repo' for handle '$handle'" >&2
+    echo "       must be <owner>/<repo> with allowed chars only" >&2
+    exit 2
+  fi
+
+  # Split into owner and repo for env-var passthrough.
+  github_owner="${github_full_repo%%/*}"
+  github_repo="${github_full_repo##*/}"
 
   total=$((total + 1))
   project_id="af-${handle}-${cohort}"
@@ -167,10 +203,15 @@ while IFS=',' read -r handle github_user email cohort neon_branch; do
   fi
 
   # Run the inner provisioner. It handles "already exists" internally;
-  # we just pass through the env it needs. GITHUB_USERNAME enables the
-  # WIF setup in Step 5.5 of the inner script — when empty, that step
-  # is skipped and the SA-key shortcut remains the auth fallback.
-  # NEON_BRANCH_NAME enables the Neon-branch-per-attendee step (#33).
+  # we just pass through the env it needs.
+  #
+  # GITHUB_OWNER + GITHUB_REPO together enable WIF setup (Step 5.5).
+  # Together they identify the GitHub repo whose Actions runs are
+  # trusted to impersonate the deployer SA. Empty owner skips the step.
+  # GITHUB_USERNAME is also exported as a legacy alias of GITHUB_OWNER
+  # for any external caller still relying on that env-var name.
+  #
+  # NEON_BRANCH_NAME enables the Neon-branch-per-attendee step (5.7).
   # NEON_API_KEY and NEON_PROJECT_ID are forwarded only if set in the
   # facilitator's environment; the inner script skips that step when
   # either is missing.
@@ -178,6 +219,8 @@ while IFS=',' read -r handle github_user email cohort neon_branch; do
   BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
   GCP_REGION="${GCP_REGION:-us-central1}" \
   ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}" \
+  GITHUB_OWNER="$github_owner" \
+  GITHUB_REPO="$github_repo" \
   GITHUB_USERNAME="$github_user" \
   NEON_BRANCH_NAME="$neon_branch" \
   NEON_API_KEY="${NEON_API_KEY:-}" \

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -64,7 +64,7 @@ EOF
 #!/usr/bin/env bash
 # Log every invocation along with the env vars the wrapper is supposed
 # to forward. Tests grep this log to verify per-row env passthrough.
-echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-} GITHUB_USERNAME=\${GITHUB_USERNAME:-} NEON_BRANCH_NAME=\${NEON_BRANCH_NAME:-}" >> "$tmp/provision.log"
+echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-} GITHUB_USERNAME=\${GITHUB_USERNAME:-} GITHUB_OWNER=\${GITHUB_OWNER:-} GITHUB_REPO=\${GITHUB_REPO:-} NEON_BRANCH_NAME=\${NEON_BRANCH_NAME:-}" >> "$tmp/provision.log"
 
 if [[ "$behavior" == "fail" ]]; then
   echo "fake provision failure" >&2
@@ -351,6 +351,109 @@ set -e
 
 assert_eq "2" "$exit_code" "wrapper exits 2 on invalid neon_branch"
 assert_contains "invalid neon_branch" "$T8/stdout.log" "error message names the field"
+
+# ── Test 9: 6-column header + explicit github_full_repo passes through ──
+#
+# Verifies that:
+#   - 6-column header is accepted
+#   - github_full_repo splits at slash; owner+repo exported separately
+#   - alice's row uses an org owner (acme); bob's row uses a different owner
+
+echo ""
+echo "Test 9: 6-column header forwards GITHUB_OWNER + GITHUB_REPO"
+
+T9=$(new_tmp)
+make_stubs "$T9" "ok"
+cat > "$T9/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
+EOF
+
+set +e
+PATH="$T9/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T9/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T9/roster-output.csv" \
+  "$WRAPPER" "$T9/roster.csv" > "$T9/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 6-column header"
+assert_contains "GCP_PROJECT_ID=af-alice-2026-05.*GITHUB_OWNER=acme.*GITHUB_REPO=agile-flow-alice" "$T9/provision.log" "alice row exports acme owner + alice repo"
+assert_contains "GCP_PROJECT_ID=af-bob-2026-05.*GITHUB_OWNER=acme.*GITHUB_REPO=widget-shop" "$T9/provision.log" "bob row exports acme owner + widget-shop repo"
+
+# ── Test 10: empty github_full_repo defaults to <github_user>/agile-flow-gcp ──
+
+echo ""
+echo "Test 10: empty github_full_repo defaults to <github_user>/agile-flow-gcp"
+
+T10=$(new_tmp)
+make_stubs "$T10" "ok"
+cat > "$T10/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+carol,carol-gh,carol@example.com,2026-05,carol,
+EOF
+
+set +e
+PATH="$T10/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T10/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T10/roster-output.csv" \
+  "$WRAPPER" "$T10/roster.csv" > "$T10/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with empty github_full_repo"
+assert_contains "GITHUB_OWNER=carol-gh.*GITHUB_REPO=agile-flow-gcp" "$T10/provision.log" "defaults to <github_user>/agile-flow-gcp"
+
+# ── Test 11: invalid github_full_repo fails fast ────────────────────────
+
+echo ""
+echo "Test 11: invalid github_full_repo fails the row fast"
+
+T11=$(new_tmp)
+make_stubs "$T11" "ok"
+# Use a value with double slash, which the regex rejects.
+cat > "$T11/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme//bad-repo
+EOF
+
+set +e
+PATH="$T11/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T11/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T11/roster-output.csv" \
+  "$WRAPPER" "$T11/roster.csv" > "$T11/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "2" "$exit_code" "wrapper exits 2 on invalid github_full_repo"
+assert_contains "invalid github_full_repo" "$T11/stdout.log" "error message names the field"
+
+# ── Test 12: 4-column legacy roster — github_full_repo defaults work ────
+
+echo ""
+echo "Test 12: 4-column header still works (defaults github_full_repo)"
+
+T12=$(new_tmp)
+make_stubs "$T12" "ok"
+write_roster "$T12/roster.csv"  # 4-column
+
+set +e
+PATH="$T12/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T12/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T12/roster-output.csv" \
+  "$WRAPPER" "$T12/roster.csv" > "$T12/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 4-column header"
+# alice/bob should both default to <user>/agile-flow-gcp
+assert_contains "GITHUB_OWNER=alice-gh.*GITHUB_REPO=agile-flow-gcp" "$T12/provision.log" "alice defaults to alice-gh/agile-flow-gcp"
+assert_contains "GITHUB_OWNER=bob-gh.*GITHUB_REPO=agile-flow-gcp" "$T12/provision.log" "bob defaults to bob-gh/agile-flow-gcp"
 
 # ── Summary ──────────────────────────────────────────────────────────────
 

--- a/scripts/roster.example.csv
+++ b/scripts/roster.example.csv
@@ -1,3 +1,4 @@
-handle,github_user,email,cohort,neon_branch
-alice,alice-gh,alice@example.com,2026-05,
-bob,bob-gh,bob@example.com,2026-05,bob_personal
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
+carol,carol-gh,carol@example.com,2026-05,,

--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -89,13 +89,17 @@ if [[ ! -f "$ROSTER_CSV" ]]; then
 else
   expected_header_4="handle,github_user,email,cohort"
   expected_header_5="handle,github_user,email,cohort,neon_branch"
+  expected_header_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
   actual_header="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
-  if [[ "$actual_header" == "$expected_header_4" || "$actual_header" == "$expected_header_5" ]]; then
+  if [[ "$actual_header" == "$expected_header_4" \
+     || "$actual_header" == "$expected_header_5" \
+     || "$actual_header" == "$expected_header_6" ]]; then
     echo "  [ok]   roster header is valid"
   else
     echo "  [fail] roster header must be one of:" >&2
     echo "           $expected_header_4" >&2
     echo "           $expected_header_5" >&2
+    echo "           $expected_header_6" >&2
     echo "         got: $actual_header" >&2
     fail=1
   fi

--- a/scripts/workshop-setup.test.sh
+++ b/scripts/workshop-setup.test.sh
@@ -240,6 +240,27 @@ ec=$?
 assert_eq "0" "$ec" "exit 0 with 5-column header"
 assert_contains "ok.*roster header is valid" "$T7/stdout.log" "logs header ok"
 
+# ── Test 8: 6-column header is accepted by pre-flight ───────────────────
+
+echo ""
+echo "Test 8: 6-column roster header passes pre-flight"
+
+T8=$(new_tmp)
+make_stubs "$T8" "ok"
+cat > "$T8/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+EOF
+
+PATH="$T8/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T8/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T8/roster.csv" > "$T8/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with 6-column header"
+assert_contains "ok.*roster header is valid" "$T8/stdout.log" "logs header ok"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""

--- a/scripts/workshop-teardown.sh
+++ b/scripts/workshop-teardown.sh
@@ -54,11 +54,15 @@ fi
 
 EXPECTED_HEADER_4="handle,github_user,email,cohort"
 EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
+EXPECTED_HEADER_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
-if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" ]]; then
+if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_6" ]]; then
   echo "ERROR: roster CSV header must be one of:" >&2
   echo "       $EXPECTED_HEADER_4" >&2
   echo "       $EXPECTED_HEADER_5" >&2
+  echo "       $EXPECTED_HEADER_6" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -66,12 +70,13 @@ fi
 # ── Build project ID list from roster ────────────────────────────────────
 
 declare -a project_ids=()
-# Reads up to 5 fields. 4-column rows leave neon_branch empty (which we
-# ignore here — teardown only deletes GCP projects). 5-column rows have
-# the 5th value captured in neon_branch and are ignored too. Without
-# this 5th name, a 5-column row would leak the branch value into cohort.
-# shellcheck disable=SC2034  # github_user, email, neon_branch unused; required per roster format
-while IFS=',' read -r handle github_user email cohort neon_branch; do
+# Reads up to 6 fields. 4- and 5-column rows leave the trailing fields
+# empty (we don't use them for teardown — only handle + cohort are
+# needed to compute project IDs). 6-column rows have github_full_repo
+# captured and ignored. Without these names, a 6-column row would leak
+# its trailing values into cohort.
+# shellcheck disable=SC2034  # github_user, email, neon_branch, github_full_repo unused; required per roster format
+while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo; do
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
   if [[ -z "$handle" || -z "$cohort" ]]; then

--- a/scripts/workshop-teardown.test.sh
+++ b/scripts/workshop-teardown.test.sh
@@ -242,6 +242,27 @@ ec=$?
 assert_eq "0" "$ec" "exit 0 with 5-column header"
 assert_eq "2" "$(grep -c 'projects delete' "$T7/gcloud.log")" "both rows still attempted (5th column ignored)"
 
+# ── Test 8: 6-column roster is accepted ─────────────────────────────────
+
+echo ""
+echo "Test 8: 6-column roster header is accepted"
+
+T8=$(new_tmp)
+make_stubs "$T8" "all-active"
+cat > "$T8/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
+bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
+EOF
+
+PATH="$T8/bin:$PATH" \
+  OUTPUT_CSV="$T8/roster-output.csv" \
+  "$SCRIPT" "$T8/roster.csv" --yes > "$T8/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with 6-column header"
+assert_eq "2" "$(grep -c 'projects delete' "$T8/gcloud.log")" "both rows still attempted (6th column ignored)"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #40. **P0 — workshop is in 8 days.**

Adds a 6th CSV column `github_full_repo` so attendees who fork the template into their company's GitHub org (and likely rename the repo to fit their product) get a correct WIF binding. Today's binding is hardcoded to `<github_user>/agile-flow-gcp` which works only for personal forks of the canonical name.

## Schema change

```csv
handle,github_user,email,cohort,neon_branch,github_full_repo
alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
carol,carol-gh,carol@example.com,2026-05,carol,
```

- 4-column and 5-column rosters continue to work — the 6th column is optional
- Empty `github_full_repo` defaults to `<github_user>/agile-flow-gcp` (preserves today's personal-fork behavior)
- Validation: `^[A-Za-z0-9-]{1,39}/[A-Za-z0-9._-]{1,100}$` (GitHub owner + repo charset)
- Wrapper splits at the slash; exports `GITHUB_OWNER` + `GITHUB_REPO` separately

## Backwards compatibility

- `GITHUB_USERNAME` env var continues to work as a legacy alias for `GITHUB_OWNER`. When `GITHUB_OWNER` is unset and `GITHUB_USERNAME` is set, the script uses the latter as the owner.
- `WIF_REPO` env knob is **removed**. Replaced by `GITHUB_REPO` env var (default `agile-flow-gcp`). Legacy callers that only set `GITHUB_USERNAME` still get the same behavior because `GITHUB_REPO` defaults to the canonical name.
- Existing test 13 (which uses `GITHUB_USERNAME` only) passes unchanged.

## Tests

| Suite | Before | After |
|---|---|---|
| `provision-workshop-roster.test.sh` | 22/22 | 32/32 (+10) |
| `workshop-setup.test.sh` | 19/19 | 21/21 (+2) |
| `workshop-teardown.test.sh` | 16/16 | 18/18 (+2) |
| `provision-gcp-project.test.sh` | 49/49 | 51/51 (+2) |
| **Total** | 106 | **122/122** |

New scenarios:
- 6-column header + explicit `acme/widget-shop` → correct env passthrough
- 6-column header + empty value → defaults to `<github_user>/agile-flow-gcp`
- Invalid value (e.g., `acme//bad-repo`) → row exits 2
- 4-column legacy roster → both attendees default to `<user>/agile-flow-gcp`
- Setup pre-flight accepts 6-column header
- Teardown accepts 6-column header (loop captures 6th field, ignores it)
- Inner script with `GITHUB_OWNER=acme GITHUB_REPO=widget-shop` produces correct binding
- Inner script with both `GITHUB_OWNER` and `GITHUB_USERNAME` unset → WIF skipped

## Implementation notes

- **Single source of truth for the binding member.** Inner script computes `WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"` and `WIF_REPO_NAME="${GITHUB_REPO:-agile-flow-gcp}"` once at the top of Step 5.5, then uses both throughout. Comment names the legacy-alias intent explicitly.
- **Validation strictness.** Whitespace is stripped (already done for `handle`/`cohort`), then the regex runs against the stripped value. Invalid characters fail fast on the offending row, preventing the inner script's mid-API call from erroring less clearly.
- **Stub log extension.** Wrapper test stub now logs `GITHUB_OWNER` and `GITHUB_REPO` alongside the existing `GITHUB_USERNAME`. Tests assert on the new env vars; legacy tests still grep for `GITHUB_USERNAME`.
- **Roster example.** Updated to 6-column shape with two org-fork rows and one personal-fork default. `PLATFORM-GUIDE.md` documents all three shapes.

## Test plan

- [x] `bash -n` and `shellcheck` clean on all 4 modified scripts
- [x] `markdownlint` clean on `docs/PLATFORM-GUIDE.md`
- [x] All 4 test suites pass: 122/122 assertions
- [x] No regression on existing 106 assertions
- [ ] CI green (will verify after push)
- [ ] Real-GCP smoke at user's next nuke-and-fork — first attendees who fork into their org with a renamed repo

## Forward references

- `agile-flow-meta`#89 (facilitator runbook updates) — needs to mention `github_full_repo` and the org-fork instructions in the email template. Out of scope here; follow up after this lands.
- #36 (preview-deploy parent branch) — independent of this ticket; doesn't depend on the repo name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)