### PR TITLE
feat(infra): per-project billing budget cap (alerts only)

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -470,12 +470,54 @@ projects are gone). `roster.csv` (input) is preserved.
 > the `cohort` column in the roster (e.g. `2026-05` → `2026-05a`) so
 > new project IDs are generated.
 
+### Budget guardrails
+
+Set `BUDGET_CAP_USD` before running setup to attach a per-project billing
+budget to every attendee project. The provisioner's Step 5.6 creates a
+budget on the billing account, scoped to the single project via
+`--filter-projects=projects/<project_number>`, with thresholds at 50%,
+90%, and 100% of current spend plus 100% of forecasted spend.
+
+```bash
+BILLING_ACCOUNT_ID=XXXXXX-XXXXXX-XXXXXX \
+  BUDGET_CAP_USD=25 \
+  ./scripts/workshop-setup.sh roster.csv
+```
+
+Notification routing uses the billing account's default IAM recipients —
+anyone with `roles/billing.admin` or `roles/billing.user` on the account
+gets email at each threshold. No separate Cloud Monitoring notification
+channel needed. The facilitator already has Billing Admin to run the
+script, so emails route to them automatically.
+
+To create budgets, the facilitator (script runner) needs
+`roles/billing.costsManager` on the billing account. This is in addition
+to the `roles/billing.user` already required for `gcloud billing
+projects link` in Step 1.
+
+The step is idempotent: budgets are looked up by display-name
+`af-workshop-cap-<project_id>` before creation, so re-running the
+provisioner is a no-op for projects that already have a cap.
+
+When `BUDGET_CAP_USD` is unset (the non-workshop default), Step 5.6 is
+skipped silently — `provision-gcp-project.sh` for production deploys
+doesn't need a workshop-style cap.
+
+> **This step provides alerts only.** Auto-cutoff (disabling billing on
+> threshold breach) is tracked separately at
+> [#42](https://github.com/vibeacademy/agile-flow-gcp/issues/42) and is
+> intentionally out of scope here. For the May 2026 workshop's blast
+> radius (≤8 projects × $25 = ~$200 worst case), facilitator monitoring
+> is sufficient.
+
 ### What the lifecycle scripts do NOT do
 
 - Workload Identity Federation setup — currently manual per project
   (see "Step 5: Workload Identity Federation" above), or track ticket
   [#5](https://github.com/vibeacademy/agile-flow-gcp/issues/5).
-- Budget caps — see ticket [#6](https://github.com/vibeacademy/agile-flow-gcp/issues/6).
+- Budget auto-cutoff (Cloud Function disabling billing on threshold
+  breach) — see [#42](https://github.com/vibeacademy/agile-flow-gcp/issues/42).
+  Email alerts at 50/90/100% are wired up via Step 5.6 above.
 - Org-policy override for `iam.allowedPolicyMemberDomains` — currently
   manual per project (see [`PATTERN-LIBRARY.md` pattern #30](./PATTERN-LIBRARY.md)),
   or track ticket [#19](https://github.com/vibeacademy/agile-flow-gcp/issues/19).

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -31,6 +31,11 @@
 #   NEON_BRANCH_NAME     (optional) Same: required for Step 5.7.
 #                        Wrapper sets this from the CSV's neon_branch
 #                        column (defaults to handle).
+#   BUDGET_CAP_USD       (optional) Enables Step 5.6 (per-project billing
+#                        budget with 50/90/100% thresholds + forecast).
+#                        When set, BILLING_ACCOUNT_ID is also required.
+#                        The runner needs roles/billing.costsManager on
+#                        the billing account. When unset, step is skipped.
 #
 # Notes:
 # - This script is idempotent. Re-running skips resources that already exist.
@@ -239,6 +244,7 @@ gcloud services enable \
   secretmanager.googleapis.com \
   iam.googleapis.com \
   iamcredentials.googleapis.com \
+  billingbudgets.googleapis.com \
   --project="$GCP_PROJECT_ID"
 
 # ── Step 3: Artifact Registry repo ───────────────────────────────────────
@@ -407,6 +413,77 @@ if [[ -n "$WIF_OWNER" ]]; then
   WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WIF_POOL}/providers/${WIF_PROVIDER}"
 else
   echo "[skip] WIF setup not requested (GITHUB_OWNER and GITHUB_USERNAME unset)"
+fi
+
+# ── Step 5.6: Per-project billing budget cap ────────────────────────────
+#
+# Creates a budget on the billing account, scoped to this single project,
+# with thresholds at 50%/90%/100% of current spend plus 100% of forecasted
+# spend. Notifications are sent to the billing account's default IAM
+# recipients (Billing Account Admin/User) — no separate Cloud Monitoring
+# notification channel needed.
+#
+# Gated on BUDGET_CAP_USD being set. When unset, the step is skipped
+# silently — non-workshop callers don't need a budget.
+#
+# Idempotency: budgets list filtered by display-name. The display-name is
+# `af-workshop-cap-<project_id>` to keep it unique per attendee project.
+#
+# Auto-cutoff (disabling billing on threshold hit) is intentionally NOT
+# part of this step — see #42 for that follow-up. This step provides
+# alerts only.
+#
+# The runner needs roles/billing.costsManager on the billing account to
+# create budgets. Documented in PLATFORM-GUIDE.md.
+
+if [[ -n "${BUDGET_CAP_USD:-}" ]]; then
+  if [[ -z "${BILLING_ACCOUNT_ID:-}" ]]; then
+    echo "ERROR: BUDGET_CAP_USD is set but BILLING_ACCOUNT_ID is unset" >&2
+    echo "       Step 5.6 needs the billing account to create the budget." >&2
+    exit 1
+  fi
+
+  # Validate that BUDGET_CAP_USD is a positive integer or decimal.
+  if ! [[ "$BUDGET_CAP_USD" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "ERROR: BUDGET_CAP_USD must be a positive number (got: '$BUDGET_CAP_USD')" >&2
+    exit 1
+  fi
+
+  # PROJECT_NUMBER may already be cached from Step 5.5. If WIF was skipped
+  # (no GITHUB_OWNER), resolve it now.
+  if [[ -z "${PROJECT_NUMBER:-}" ]]; then
+    PROJECT_NUMBER="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')"
+  fi
+
+  BUDGET_DISPLAY_NAME="af-workshop-cap-${GCP_PROJECT_ID}"
+
+  # Look up existing budget by display name. `gcloud billing budgets list`
+  # has no server-side filter on displayName, so we fetch all on this
+  # account and grep client-side. For a workshop billing account with
+  # ~8 budgets that's fine; if this ever scales we can switch to the
+  # `--filter` flag (which does a regex match on display name).
+  existing_budget="$(gcloud billing budgets list \
+    --billing-account="$BILLING_ACCOUNT_ID" \
+    --filter="displayName=${BUDGET_DISPLAY_NAME}" \
+    --format='value(name)' 2>/dev/null | head -n 1)"
+
+  if [[ -n "$existing_budget" ]]; then
+    echo "[skip] budget '${BUDGET_DISPLAY_NAME}' already exists (\$${BUDGET_CAP_USD} USD)"
+  else
+    echo "[create] budget '${BUDGET_DISPLAY_NAME}' (\$${BUDGET_CAP_USD} USD, scoped to $GCP_PROJECT_ID)"
+    gcloud billing budgets create \
+      --billing-account="$BILLING_ACCOUNT_ID" \
+      --display-name="$BUDGET_DISPLAY_NAME" \
+      --budget-amount="${BUDGET_CAP_USD}USD" \
+      --filter-projects="projects/${PROJECT_NUMBER}" \
+      --threshold-rule=percent=0.50 \
+      --threshold-rule=percent=0.90 \
+      --threshold-rule=percent=1.0 \
+      --threshold-rule=percent=1.0,basis=forecasted-spend \
+      --quiet >/dev/null
+  fi
+else
+  echo "[skip] budget cap (BUDGET_CAP_USD unset)"
 fi
 
 # ── Step 5.7: Neon branch + database-url Secret Manager ─────────────────

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -1011,6 +1011,194 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 18-21: Step 5.6 budget cap ─────────────────────────────────────
+#
+# Step 5.6 has three branches:
+#   - BUDGET_CAP_USD unset → silently skipped, no billing calls
+#   - BUDGET_CAP_USD set, no existing budget → create called once
+#   - BUDGET_CAP_USD set, budget already exists (by display-name) → skip
+#
+# The harness stubs the full gcloud surface to keep the script running
+# through Step 6 without erroring out on unrelated commands.
+
+run_step5_6_test() {
+  local budget_state="$1"   # "skip-unset" | "absent" | "exists"
+  local budget_amount="${2-25}"
+  local tmp; tmp=$(mktemp -d -t aflowtest-XXXX)
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    if echo "\$*" | grep -q "projectNumber"; then
+      echo "12345"
+    elif echo "\$*" | grep -q "lifecycleState"; then
+      echo "ACTIVE"
+    else
+      exit 1
+    fi
+    exit 0
+    ;;
+  "projects create"|"projects get-iam-policy"|"projects add-iam-policy-binding") exit 0 ;;
+  "billing projects") exit 0 ;;
+  "billing accounts") exit 0 ;;
+  "billing budgets")
+    case "\$3" in
+      list)
+        # Emulate display-name filter by branching on the canned state.
+        case "$budget_state" in
+          exists) echo "billingAccounts/FAKE/budgets/abcdef" ;;
+          *)      ;;  # absent → empty output
+        esac
+        exit 0
+        ;;
+      create) exit 0 ;;
+    esac
+    ;;
+  "resource-manager org-policies")
+    case "\$3" in
+      describe) exit 1 ;;
+      list)     exit 0 ;;
+    esac
+    ;;
+  "services enable") exit 0 ;;
+  "artifacts repositories")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+    esac
+    ;;
+  "iam service-accounts")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+      add-iam-policy-binding) exit 0 ;;
+    esac
+    ;;
+  "iam workload-identity-pools") exit 1 ;;  # skip WIF
+  "secrets describe") exit 1 ;;             # skip Neon (no NEON_API_KEY anyway)
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+
+  set +e
+  PATH="$tmp/bin:$PATH" \
+    GCP_PROJECT_ID="af-step56-test" \
+    BILLING_ACCOUNT_ID="FAKE" \
+    BUDGET_CAP_USD="${budget_amount-}" \
+    "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
+  set -e
+
+  echo "$tmp"
+}
+
+# Test 18: BUDGET_CAP_USD unset → step skipped, no billing calls
+
+echo ""
+echo "Test 18: Step 5.6 skipped when BUDGET_CAP_USD unset"
+
+T18=$(run_step5_6_test "skip-unset" "")
+
+if grep -q "skip.*budget cap.*BUDGET_CAP_USD unset" "$T18/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] budget cap (BUDGET_CAP_USD unset)' in stdout"
+  cat "$T18/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+budget_calls=0
+if [[ -f "$T18/gcloud.log" ]]; then
+  budget_calls="$(grep -c 'billing budgets' "$T18/gcloud.log" || true)"
+fi
+assert_eq "0" "$budget_calls" "no billing budgets calls when BUDGET_CAP_USD unset"
+
+# Test 19: BUDGET_CAP_USD=25, no existing budget → create called
+
+echo ""
+echo "Test 19: Step 5.6 creates budget when BUDGET_CAP_USD set and absent"
+
+T19=$(run_step5_6_test "absent" "25")
+
+if grep -q "create.*af-workshop-cap-af-step56-test.*\$25 USD" "$T19/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} create log names display-name + amount"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[create] budget af-workshop-cap-... \$25 USD' in stdout"
+  cat "$T19/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "billing budgets create" "$T19/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud billing budgets create invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'billing budgets create' in gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Critical scoping assertion: budget MUST filter on the project, not the
+# whole billing account. Otherwise one participant's spend trips everyone.
+if grep -q "filter-projects=projects/12345" "$T19/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} budget scoped to project (--filter-projects=projects/12345)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected --filter-projects=projects/12345 on budgets create"
+  grep "budgets create" "$T19/gcloud.log" || echo "(no create call found)"
+  FAIL=$((FAIL + 1))
+fi
+
+# All four threshold rules must be present (50, 90, 100 current + 100 forecasted).
+# Each gcloud invocation lands on one line in gcloud.log, so grep -c counts
+# invocations, not flag occurrences. Use -o to count matches.
+threshold_count="$(grep -o 'threshold-rule=percent=' "$T19/gcloud.log" | wc -l | tr -d '[:space:]')"
+assert_eq "4" "$threshold_count" "four --threshold-rule flags present (50/90/100/100-forecast)"
+
+# Test 20: BUDGET_CAP_USD=25, budget already exists → skip (no create)
+
+echo ""
+echo "Test 20: Step 5.6 idempotent when budget already exists"
+
+T20=$(run_step5_6_test "exists" "25")
+
+if grep -q "skip.*af-workshop-cap-af-step56-test.*already exists" "$T20/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip-existing log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] budget ... already exists' in stdout"
+  cat "$T20/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if ! grep -q "billing budgets create" "$T20/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud billing budgets create NOT invoked (idempotent)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} budgets create should NOT have run when budget already exists"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 21: invalid BUDGET_CAP_USD → exit 1 with clear error
+
+echo ""
+echo "Test 21: Step 5.6 rejects non-numeric BUDGET_CAP_USD"
+
+T21=$(run_step5_6_test "absent" "twenty-five")
+ec=$?
+
+if grep -q "BUDGET_CAP_USD must be a positive number" "$T21/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} clear error on bad amount"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected error mentioning 'must be a positive number'"
+  cat "$T21/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -17,6 +17,9 @@
 #   PROVISION_SCRIPT     (default: scripts/provision-gcp-project.sh) — for tests
 #   NEON_API_KEY         optional; forwarded to inner script for branch creation
 #   NEON_PROJECT_ID      optional; forwarded to inner script for branch creation
+#   BUDGET_CAP_USD       optional; forwarded to inner script for Step 5.6
+#                        (per-project billing budget). Default for workshop
+#                        usage is 25.
 #
 # CSV format (header required, accepts 4, 5, or 6 columns):
 #   handle,github_user,email,cohort
@@ -225,6 +228,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   NEON_BRANCH_NAME="$neon_branch" \
   NEON_API_KEY="${NEON_API_KEY:-}" \
   NEON_PROJECT_ID="${NEON_PROJECT_ID:-}" \
+  BUDGET_CAP_USD="${BUDGET_CAP_USD:-}" \
     "$PROVISION_SCRIPT" --create-project
 
   # Grant the participant editor on their own project. Idempotent.


### PR DESCRIPTION
## Summary

Closes #6 with a reduced scope: budget *alerts*, not auto-cutoff.

- Adds Step 5.6 to `provision-gcp-project.sh`. Gated on `BUDGET_CAP_USD`.
  When set, creates a billing budget scoped to the single project via
  `--filter-projects=projects/<project_number>`, with thresholds at
  50/90/100% (current spend) and 100% (forecast).
- Notifications: relies on the billing account's default IAM recipients
  (facilitator already has Billing Admin to run the script). No separate
  Cloud Monitoring channel — fewer moving parts, no extra API surface.
- `billingbudgets.googleapis.com` added to Step 2's API enable list.
- `provision-workshop-roster.sh` forwards `BUDGET_CAP_USD` so one env var
  on `workshop-setup.sh` covers every attendee project.
- Idempotent: budgets looked up by display name `af-workshop-cap-<project_id>`
  before creation.

## Why scope reduction

The original #6 spec called for a full Pub/Sub-triggered Cloud Function
+ auto-cutoff. Three days before the May 2026 workshop dry-run, that's
too many novel moving parts (function deploy, cross-project IAM for
`cloudbilling.projects.updateBillingInfo`, 5-min lag between breach and
cutoff, irreversible-after-trip footgun). For ≤8 projects × $25 cap = ~$200
worst case, alerts plus facilitator monitoring is sufficient. Auto-cutoff
is filed as #42 (post-workshop).

User confirmed scope reduction (Option B) before implementation.

## Tests

| Suite | Result |
|-------|--------|
| `provision-gcp-project.test.sh` | 60/60 (4 new — Tests 18-21) |
| `provision-workshop-roster.test.sh` | 32/32 |
| `workshop-setup.test.sh` | 21/21 |
| `workshop-teardown.test.sh` | 18/18 |
| `shellcheck` (all 5 scripts) | clean |

New tests cover:
- **18** — skip when `BUDGET_CAP_USD` unset; no `gcloud billing budgets` calls
- **19** — create when set + absent; verifies `--filter-projects=projects/<num>` scoping AND all four `--threshold-rule` flags
- **20** — idempotent skip when budget exists
- **21** — rejection of non-numeric `BUDGET_CAP_USD`

## Test plan

- [ ] Verify on real GCP during the 2026-05-01 dry-run that running with
      `BUDGET_CAP_USD=25` produces a budget visible in the Cloud Console
      and that re-runs are no-ops.
- [ ] Confirm an email reaches the facilitator inbox at the 50% threshold
      (manual: spend $12.50 in a test project, or temporarily set the cap
      lower).
- [ ] Confirm `provision-gcp-project.sh` still works for single-project
      (non-workshop) callers — when `BUDGET_CAP_USD` is unset the step
      logs `[skip] budget cap (BUDGET_CAP_USD unset)` and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)