### PR TITLE
fix(provisioner): surface budget-list errors instead of swallowing them

### DIFF
--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -462,10 +462,34 @@ if [[ -n "${BUDGET_CAP_USD:-}" ]]; then
   # account and grep client-side. For a workshop billing account with
   # ~8 budgets that's fine; if this ever scales we can switch to the
   # `--filter` flag (which does a regex match on display name).
+  #
+  # Capture stderr to a tempfile and check the exit code explicitly. The
+  # earlier `2>/dev/null | head` pattern swallowed permission errors and
+  # let `set -euo pipefail` kill the script silently — facilitators saw
+  # the wrapper exit "without error" partway through row 1, leaving the
+  # remaining roster rows untouched. The most common cause is the
+  # facilitator account lacking `roles/billing.costsManager` on the
+  # billing account; we surface that with a pointer to the runbook.
+  budget_list_err="$(mktemp)"
+  budget_list_ec=0
   existing_budget="$(gcloud billing budgets list \
     --billing-account="$BILLING_ACCOUNT_ID" \
     --filter="displayName=${BUDGET_DISPLAY_NAME}" \
-    --format='value(name)' 2>/dev/null | head -n 1)"
+    --format='value(name)' 2> "$budget_list_err" | head -n 1)" || budget_list_ec=$?
+  if (( budget_list_ec != 0 )); then
+    echo "" >&2
+    echo "ERROR: gcloud billing budgets list failed (exit $budget_list_ec)" >&2
+    echo "       billing account: $BILLING_ACCOUNT_ID" >&2
+    echo "" >&2
+    cat "$budget_list_err" >&2
+    echo "" >&2
+    echo "  The facilitator account needs roles/billing.costsManager on the" >&2
+    echo "  billing account. See docs/PLATFORM-GUIDE.md > Budget guardrails." >&2
+    echo "  To skip this step, unset BUDGET_CAP_USD and re-run." >&2
+    rm -f "$budget_list_err"
+    exit 1
+  fi
+  rm -f "$budget_list_err"
 
   if [[ -n "$existing_budget" ]]; then
     echo "[skip] budget '${BUDGET_DISPLAY_NAME}' already exists (\$${BUDGET_CAP_USD} USD)"

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -1050,6 +1050,10 @@ case "\$1 \$2" in
         # Emulate display-name filter by branching on the canned state.
         case "$budget_state" in
           exists) echo "billingAccounts/FAKE/budgets/abcdef" ;;
+          permission-denied)
+            echo "ERROR: (gcloud.billing.budgets.list) [teddy@example.com] does not have permission to access billingAccounts instance [FAKE] (or it may not exist): missing roles/billing.costsManager" >&2
+            exit 1
+            ;;
           *)      ;;  # absent → empty output
         esac
         exit 0
@@ -1179,6 +1183,43 @@ if ! grep -q "billing budgets create" "$T20/gcloud.log"; then
   PASS=$((PASS + 1))
 else
   echo -e "  ${RED}✗${NC} budgets create should NOT have run when budget already exists"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 20b: budget list fails (permission denied) → surface the error,
+# don't swallow it. This is the silent-failure path that bit the dry-run
+# on 2026-04-28 — `2>/dev/null | head` plus `set -euo pipefail` killed
+# the wrapper mid-row-1 with no diagnostic, leaving the remaining roster
+# rows un-provisioned and `roster-output.csv` empty.
+
+echo ""
+echo "Test 20b: Step 5.6 surfaces gcloud billing list errors instead of swallowing them"
+
+T20B=$(run_step5_6_test "permission-denied" "25")
+
+if grep -q "gcloud billing budgets list failed" "$T20B/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} explicit error message logged"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'gcloud billing budgets list failed' in stderr"
+  cat "$T20B/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "roles/billing.costsManager" "$T20B/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} error names the missing role"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected error to mention roles/billing.costsManager"
+  FAIL=$((FAIL + 1))
+fi
+
+# The original gcloud stderr must reach the user, not be swallowed.
+if grep -q "does not have permission to access billingAccounts" "$T20B/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} underlying gcloud error is visible to the user"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected the underlying gcloud error to be relayed"
   FAIL=$((FAIL + 1))
 fi
 


### PR DESCRIPTION
## Summary

Quick fix — no linked ticket. Surfaced during the 2026-04-28 dry-run.

The Step 5.6 budget lookup ate its own error output (`2>/dev/null | head -n 1`).
Combined with `set -euo pipefail`, a permission failure on
`gcloud billing budgets list` killed the wrapper silently mid-row-1,
leaving rows 2 and 3 unprocessed and \`roster-output.csv\` empty of
data rows. The wrapper looked like it had completed successfully.

## Real-world reproduction (post-fix)

```
[bind] roles/iam.serviceAccountTokenCreator <- tck517/agile-flow-gcp
ERROR: gcloud billing budgets list failed (exit 1)
       billing account: 0114D1-7670CD-C32F71

ERROR: (gcloud.billing.budgets.list) [teddy@vibe.academy] does not have
permission to access billingAccounts instance [0114D1-7670CD-C32F71]
(...)  reason: USER_PROJECT_DENIED

  The facilitator account needs roles/billing.costsManager on the
  billing account. See docs/PLATFORM-GUIDE.md > Budget guardrails.
  To skip this step, unset BUDGET_CAP_USD and re-run.
```

The underlying \`USER_PROJECT_DENIED\` is now visible. The framing
message tells the facilitator (a) what role to grant, (b) where in the
runbook to look, and (c) the env-var workaround.

## Tests

Adds Test 20b with three assertions:
- explicit framing message logged
- error message names \`roles/billing.costsManager\`
- underlying gcloud stderr is preserved (not swallowed)

| Suite | Before | After |
|-------|--------|-------|
| \`provision-gcp-project.test.sh\` | 60 | 63 |
| \`provision-workshop-roster.test.sh\` | 32 | 32 |
| \`workshop-setup.test.sh\` | 21 | 21 |
| \`workshop-teardown.test.sh\` | 18 | 18 |
| **Total** | **131** | **134** |

shellcheck clean.

## Test plan

- [ ] CI green
- [ ] After merge: re-run the dry-run wrapper. Confirm that when the
      facilitator lacks \`roles/billing.costsManager\`, the script exits
      with the framing message + the gcloud error, instead of dying
      silently after the WIF token-creator binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)