### PR TITLE
fix(template): preview-deploy correctness chain (closes #B5/#B7/#B8/#B9 from intake)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -84,15 +84,15 @@ jobs:
       # ── Apply Alembic migrations to the Neon branch ──────────────────
 
       - name: Install uv
-        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_pooled != ''
+        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_with_pooler != ''
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.5.x"
 
       - name: Run Alembic migrations against branch database
-        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_pooled != ''
+        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_with_pooler != ''
         env:
-          DATABASE_URL: ${{ steps.neon.outputs.db_url_pooled }}
+          DATABASE_URL: ${{ steps.neon.outputs.db_url_with_pooler }}
         run: |
           uv sync --frozen
           uv run alembic upgrade head
@@ -140,10 +140,16 @@ jobs:
         run: |
           # Build the runtime env var list. DATABASE_URL comes from Neon
           # branch output if available, otherwise falls back to the default
-          # secret mount (production DB).
-          NEON_URL_FLAG=""
-          if [ -n "${{ steps.neon.outputs.db_url_pooled }}" ]; then
-            NEON_URL_FLAG="--update-env-vars=DATABASE_URL=${{ steps.neon.outputs.db_url_pooled }}"
+          # secret mount (production DB). We merge all env vars into a
+          # single --set-env-vars value because gcloud forbids combining
+          # --set-env-vars with --update-env-vars in one invocation.
+          # The ^;^ prefix changes gcloud's KEY=val separator from comma
+          # to ';'. Required because Neon URLs contain '@' (user@host) and
+          # may URL-encode commas in passwords; ';' is forbidden in URLs
+          # and not used by gcloud as a default separator anywhere else.
+          ENV_VARS="^;^ENVIRONMENT=preview;PR_NUMBER=${{ env.PR_NUMBER }}"
+          if [ -n "${{ steps.neon.outputs.db_url_with_pooler }}" ]; then
+            ENV_VARS="${ENV_VARS};DATABASE_URL=${{ steps.neon.outputs.db_url_with_pooler }}"
           fi
 
           # --service-account pins the runtime SA to the deployer SA so
@@ -151,6 +157,15 @@ jobs:
           # other resource the deployer SA already has access to. Without
           # this, Cloud Run uses the legacy Compute Engine default SA at
           # runtime, which has none of the roles provisioned in Step 5.
+          # Capture deploy stdout+stderr so we can extract the tagged
+          # revision URL directly. gcloud prints
+          #   "The revision can be reached directly at <url>"
+          # which is the canonical tagged URL — more reliable than a
+          # second `gcloud run services describe` call with --format
+          # filtering, which used to silently return empty.
+          # pipefail is required so gcloud failures aren't masked by tee.
+          set -o pipefail
+          DEPLOY_LOG=$(mktemp)
           gcloud run deploy "${{ env.SERVICE_NAME }}" \
             --image="${{ steps.build.outputs.image }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -163,13 +178,14 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --allow-unauthenticated \
-            --set-env-vars="ENVIRONMENT=preview,PR_NUMBER=${{ env.PR_NUMBER }}" \
-            $NEON_URL_FLAG
+            --set-env-vars="${ENV_VARS}" 2>&1 | tee "$DEPLOY_LOG"
 
-          # Fetch the tagged revision URL
-          PREVIEW_URL=$(gcloud run services describe "${{ env.SERVICE_NAME }}" \
-            --region="${{ env.GCP_REGION }}" \
-            --format="value(status.traffic[?tag='pr-${{ env.PR_NUMBER }}'].url)")
+          PREVIEW_URL=$(grep -oE 'https://pr-[0-9]+---[^ ]+\.run\.app' "$DEPLOY_LOG" | head -n1)
+
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "ERROR: deploy succeeded but no tagged URL found in gcloud output"
+            exit 1
+          fi
 
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
           echo "Preview URL: $PREVIEW_URL"
@@ -181,9 +197,9 @@ jobs:
           PREVIEW_URL="${{ steps.deploy.outputs.preview_url }}"
 
           if [ -z "$PREVIEW_URL" ]; then
-            echo "No preview URL available, skipping smoke test"
-            echo "result=skipped" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "ERROR: preview_url output is empty — deploy step should have failed already"
+            echo "result=failed" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           echo "Testing: $PREVIEW_URL/api/health"

--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ or Cloud Run Secret Manager mounts.
 
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,6 +23,15 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         extra="ignore",
     )
+
+    @field_validator("database_url")
+    @classmethod
+    def _force_psycopg3_driver(cls, v: str) -> str:
+        # Neon emits postgresql:// URLs, which SQLAlchemy resolves to the
+        # psycopg2 driver. We ship psycopg3 only, so rewrite the scheme.
+        if v.startswith("postgresql://"):
+            return v.replace("postgresql://", "postgresql+psycopg://", 1)
+        return v
 
 
 @lru_cache

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for app.config.Settings.
+
+Pins the contract that database_url is normalized to use the psycopg3
+driver scheme. SQLAlchemy resolves the bare `postgresql://` scheme to
+psycopg2 (not installed in this project), so without normalization
+every Neon-backed deploy would ImportError on first DB use.
+"""
+
+import pytest
+
+
+def _make_settings(database_url: str | None = None):
+    # Import inside the helper so each call sees the patched env. The
+    # @lru_cache on get_settings is process-level; we instantiate
+    # Settings() directly to bypass it.
+    from app.config import Settings
+
+    if database_url is None:
+        return Settings()
+    return Settings(database_url=database_url)
+
+
+@pytest.mark.parametrize(
+    "input_url,expected",
+    [
+        # The live-bug case: Neon emits postgresql://, must become postgresql+psycopg://
+        (
+            "postgresql://u:p@h/db",
+            "postgresql+psycopg://u:p@h/db",
+        ),
+        # Already-normalized URLs pass through unchanged
+        (
+            "postgresql+psycopg://u:p@h/db",
+            "postgresql+psycopg://u:p@h/db",
+        ),
+        # Non-postgres schemes are untouched
+        ("sqlite:///./dev.db", "sqlite:///./dev.db"),
+        ("sqlite://", "sqlite://"),
+        # Only the scheme is rewritten; query string + path preserved
+        (
+            "postgresql://user:pa%40ss@host:5432/db?sslmode=require",
+            "postgresql+psycopg://user:pa%40ss@host:5432/db?sslmode=require",
+        ),
+    ],
+)
+def test_database_url_scheme_normalization(input_url: str, expected: str) -> None:
+    assert _make_settings(input_url).database_url == expected


### PR DESCRIPTION
## Summary

Cherry-picks 4 ready-to-ship fixes from a real-world bring-up of the template at `tck517/agile-flow-gcp` (private fork). Each fix was diagnosed during a fresh-fork dry-run on 2026-04-29 and is proven on a working preview deploy. Together they take a brand-new fork's first-PR preview from "ships HTTP 500 silently" to "either works or fails loudly."

The 4 fixes form a chain — earlier ones unmasked later ones:

### B7 — `db_url_pooled` → `db_url_with_pooler` (5-character workflow rename)

`neondatabase/create-branch-action@v5` declares a `db_url_pooled` output in its action.yml but only writes `db_url_with_pooler` to `\$GITHUB_OUTPUT`. The workflow read the documented name (always empty), causing every Alembic migration and every `DATABASE_URL` flag to silently skip. Previews booted with the app's SQLite default and returned HTTP 500 while the workflow reported SUCCESS.

### B5 — psycopg3 driver scheme normalization (8-line app/config.py validator + tests)

\`pyproject.toml\` ships psycopg3 only, but Neon emits `postgresql://` URLs which SQLAlchemy resolves to the psycopg2 driver. Result: \`ModuleNotFoundError: No module named 'psycopg2'\` on the first DB op. Added a Pydantic field_validator that rewrites the scheme at the single source of truth (\`Settings.database_url\`), so every consumer (\`app/db.py\`, \`alembic/env.py\`) gets the corrected URL automatically.

Added \`tests/test_config.py\` with 5 parametrized assertions as a regression guard.

### B8 — single \`--set-env-vars\` with \`^;^\` delimiter

Deploy step previously combined \`--set-env-vars\` with conditional \`--update-env-vars\`. gcloud forbids that combo. Hidden by B7 — when DATABASE_URL was empty, the second flag was empty so gcloud accepted. Once B7 was fixed, this surfaced. The \`^;^\` delimiter avoids the \`@\` collision with Neon URLs (user@host) that bit the first attempted fix.

### B9 — capture preview URL from gcloud stdout, fail-loud smoke test

The deploy step's \`--format='value(status.traffic[?tag=...].url)'\` is invalid JMESPath syntax for gcloud resource projection — it silently returns empty. The smoke test then skipped on empty URL, the PR comment said "Not deployed," and a working revision was invisible. Now: parse the URL from \`gcloud run deploy\`'s own stdout, exit 1 if empty, treat empty \`preview_url\` in the smoke test as a deploy bug rather than a skip signal.

## Source

- **Long-form analysis:** \`tck517/agile-flow-gcp:docs/TEMPLATE-FEEDBACK.md\` (635 lines)
- **Draft issues + handoff doc:** \`tck517/agile-flow-gcp:docs/UPSTREAM-INTAKE.md\` (1222 lines)
- **Cherry-picked from:**
  - tck517 commit \`4e7ffb1\` (B7)
  - tck517 commit \`a838fb1\` (B5)
  - tck517 commit \`28d6cde\` + \`f469d4c\` (B8 + delimiter fix)
  - tck517 commit \`8f2c8f8\` (B9, from open PR #3 in tck517)

## Tests

- \`tests/test_config.py\` — 5 parametrized assertions on URL normalization (Neon → psycopg3, idempotent on already-normalized, untouched on sqlite, query string + auth preserved)
- \`pytest -q tests/\` — 13 pass (was 8)
- \`ruff check\` — clean
- \`mypy app/\` — clean

## Filed sibling issues for the rest of the intake

The 6 findings without proof-of-fix patches are filed as separate tickets under epic #48:

- #48 — epic: Day-1 bring-up correctness for downstream forks
- #49 — fix(scripts): provision-gcp-project.sh should set GitHub secrets directly (B1, P1)
- #50 — docs: clarify GCP_WORKLOAD_IDENTITY_PROVIDER secret format (B2, P2)
- #51 — fix(scripts): pre-create Cloud Run service in provisioning script (B3, P1)
- #52 — fix(workflows): convert silent-skip guards to fail-loud (B4, P1)
- #53 — fix(scripts): bootstrap should invite bot accounts as collaborators (B6, P2)
- #54 — chore(workflows): bump actions off Node 20 (B10, P3)

This PR closes B5, B7, B8, and B9 from the intake doc.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: validate on a fresh GCP project + fresh fork: open a PR, confirm the preview deploy succeeds and the PR comment shows the actual URL (not "Not deployed"). Curl the URL and confirm HTTP 200.
- [ ] If the preview returns 500 with a different error than the intake described, that's a new bug — file as a follow-up under #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)