### PR TITLE
fix(scripts): pre-create Cloud Run service in provisioning script

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -516,6 +516,32 @@ doesn't need a workshop-style cap.
 > radius (≤8 projects × $25 = ~$200 worst case), facilitator monitoring
 > is sufficient.
 
+### Cloud Run service pre-create (Step 5.8)
+
+`preview-deploy.yml` calls `gcloud run deploy --no-traffic --tag=pr-N`
+to create per-PR preview revisions. That works after a project's first
+deploy, but on a brand-new project gcloud rejects the very first PR
+with:
+
+```
+ERROR: (gcloud.run.deploy) --no-traffic not supported when creating
+a new service.
+```
+
+To prevent this, the provisioner pre-creates the Cloud Run service with
+a placeholder image (Google's `us-docker.pkg.dev/cloudrun/container/hello`)
+during Step 5.8. The first real preview-deploy overwrites the
+placeholder revision with the participant's container.
+
+The step is idempotent — if the service already exists (re-runs, or
+because `deploy.yml` already shipped from the participant's fork), it
+logs `[skip]` and continues. The placeholder revision pins
+`--service-account` to the deployer SA and `--allow-unauthenticated` so
+the first real deploy doesn't change either property.
+
+Override the service name with `CLOUD_RUN_SERVICE=<name>`; defaults to
+`agile-flow-app`.
+
 ### What the lifecycle scripts do NOT do
 
 - Workload Identity Federation setup — currently manual per project

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -705,6 +705,48 @@ else
   NEON_BRANCH_PROVISIONED="false"
 fi
 
+# ── Step 5.8: Pre-create Cloud Run service ──────────────────────────────
+#
+# preview-deploy.yml calls `gcloud run deploy --no-traffic --tag=pr-N`
+# unconditionally. That works for any deploy after the first, but on the
+# very first deploy gcloud rejects with:
+#
+#   ERROR: (gcloud.run.deploy) --no-traffic not supported when creating a
+#   new service.
+#
+# A fresh fork's first ever PR preview always fails until the service
+# exists. Pre-creating it here with a placeholder image ("hello") makes
+# the workflow's assumption true from day 0. The first real preview-deploy
+# overwrites the placeholder revision.
+#
+# Idempotent: if the service already exists (re-runs, or because deploy.yml
+# already ran from the participant's fork), this step is a no-op.
+#
+# Pinned to:
+#   --service-account = the deployer SA created in Step 4
+#   --allow-unauthenticated = matches what preview-deploy.yml will produce,
+#                              so first real deploy doesn't change ACL
+#   --port=8080 = matches the FastAPI Dockerfile and preview-deploy config
+
+SERVICE_NAME="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+
+if gcloud run services describe "$SERVICE_NAME" \
+    --region="$GCP_REGION" \
+    --project="$GCP_PROJECT_ID" >/dev/null 2>&1; then
+  echo "[skip] Cloud Run service '$SERVICE_NAME' already exists"
+else
+  echo "[create] Cloud Run service '$SERVICE_NAME' (placeholder revision)"
+  retry_eventual_consistency "cloud run pre-create" -- \
+    gcloud run deploy "$SERVICE_NAME" \
+      --image=us-docker.pkg.dev/cloudrun/container/hello \
+      --region="$GCP_REGION" \
+      --service-account="$SA_EMAIL" \
+      --allow-unauthenticated \
+      --port=8080 \
+      --project="$GCP_PROJECT_ID" \
+      --quiet >/dev/null
+fi
+
 # ── Step 6: Service account key (workshop shortcut) ─────────────────────
 
 if [[ "$WITH_SA_KEY" == "true" ]]; then

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -1375,6 +1375,154 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 22-23: Step 5.8 Cloud Run service pre-create ───────────────────
+#
+# Step 5.8 has two branches:
+#   - service does not exist  → `gcloud run deploy` with hello placeholder
+#   - service already exists  → [skip] log line, no deploy call
+#
+# The harness stubs the full gcloud surface so the script runs through
+# Step 6 without erroring out elsewhere.
+
+run_step5_8_test() {
+  local service_state="$1"   # "absent" | "present"
+  local tmp; tmp=$(mktemp -d -t aflowtest-XXXX)
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    if echo "\$*" | grep -q "projectNumber"; then
+      echo "12345"
+    elif echo "\$*" | grep -q "lifecycleState"; then
+      echo "ACTIVE"
+    else
+      exit 1
+    fi
+    exit 0
+    ;;
+  "projects create"|"projects get-iam-policy"|"projects add-iam-policy-binding") exit 0 ;;
+  "billing projects") exit 0 ;;
+  "billing accounts") exit 0 ;;
+  "resource-manager org-policies")
+    case "\$3" in
+      describe) exit 1 ;;  # no policy at project level → apply override
+      set-policy) exit 0 ;;
+    esac
+    ;;
+  "services enable") exit 0 ;;
+  "artifacts repositories")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+    esac
+    ;;
+  "iam service-accounts")
+    case "\$3" in
+      describe) exit 1 ;;
+      create)   exit 0 ;;
+      add-iam-policy-binding) exit 0 ;;
+    esac
+    ;;
+  "iam workload-identity-pools") exit 1 ;;  # skip WIF
+  "secrets describe") exit 1 ;;             # skip Neon (no NEON_API_KEY)
+  "run services")
+    # describe is what Step 5.8 calls to detect existence
+    case "\$3" in
+      describe)
+        case "$service_state" in
+          present) exit 0 ;;   # service exists → skip path
+          absent)  exit 1 ;;   # service missing → create path
+        esac
+        ;;
+    esac
+    ;;
+  "run deploy") exit 0 ;;       # placeholder deploy succeeds
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gcloud"
+
+  set +e
+  PATH="$tmp/bin:$PATH" \
+    GCP_PROJECT_ID="af-step58-test" \
+    BILLING_ACCOUNT_ID="FAKE" \
+    "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
+  set -e
+
+  echo "$tmp"
+}
+
+# Test 22: service absent → placeholder deploy invoked
+
+echo ""
+echo "Test 22: Step 5.8 pre-creates Cloud Run service when absent"
+
+T22=$(run_step5_8_test "absent")
+
+if grep -q "create.*Cloud Run service.*agile-flow-app.*placeholder" "$T22/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} create log line names service + placeholder"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[create] Cloud Run service ... placeholder' in stdout"
+  cat "$T22/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "run deploy agile-flow-app" "$T22/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud run deploy invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'run deploy agile-flow-app' in gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Critical: must use Google's hello-world placeholder image, not a real image.
+if grep -q "image=us-docker.pkg.dev/cloudrun/container/hello" "$T22/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} placeholder image is the official Google hello-world"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected --image=us-docker.pkg.dev/cloudrun/container/hello"
+  grep "run deploy" "$T22/gcloud.log" || echo "(no run deploy call found)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Critical: --service-account must pin to deployer SA so first real deploy
+# doesn't drift the runtime SA from the placeholder revision.
+if grep -q "service-account=deployer@af-step58-test.iam.gserviceaccount.com" "$T22/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} --service-account pinned to deployer SA"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected --service-account=deployer@... in run deploy call"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 23: service present → [skip], no deploy call
+
+echo ""
+echo "Test 23: Step 5.8 idempotent when service already exists"
+
+T23=$(run_step5_8_test "present")
+
+if grep -q "skip.*Cloud Run service.*agile-flow-app.*already exists" "$T23/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip-existing log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] Cloud Run service ... already exists' in stdout"
+  cat "$T23/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if ! grep -q "run deploy" "$T23/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud run deploy NOT invoked (idempotent)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} run deploy should NOT have been called when service exists"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #51. Adds Step 5.8 to `provision-gcp-project.sh`: idempotently pre-create the Cloud Run service with Google's hello-world placeholder image during provisioning. This eliminates the "every fresh fork's first PR preview fails" bug that the dry-run intake (#48 epic) called out.

Without this, preview-deploy.yml fails on the first PR after fork with:

```
ERROR: (gcloud.run.deploy) --no-traffic not supported when creating a new service.
```

After the service exists, every subsequent PR works fine — so this bug stays silent in the template's own CI and only fires on day 1 of any new fork.

## Implementation

- Inserted as Step 5.8 between Step 5.7 (Neon) and Step 6 (SA key generation)
- Placeholder image: `us-docker.pkg.dev/cloudrun/container/hello` (official Google)
- `--service-account` pinned to the deployer SA so the first real deploy doesn't drift the runtime SA
- `--allow-unauthenticated` matches what preview-deploy.yml produces, so service-level IAM doesn't drift either
- `--port=8080` matches the FastAPI Dockerfile and preview-deploy config
- Wrapped in `retry_eventual_consistency` for SA-propagation lag (same helper that wraps Step 5.5c WIF bindings, per #47)
- Service name overridable via `CLOUD_RUN_SERVICE` env var; defaults to `agile-flow-app`

## Tests

| Suite | Before | After |
|-------|--------|-------|
| `provision-gcp-project.test.sh` | 66 | 72 |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| **Total** | **137** | **143** |

Tests 22-23 added (6 new assertions):

- **Test 22** (service absent): asserts the `[create]` log line, that `gcloud run deploy` was called, that the placeholder image is the official Google hello-world (regression guard — dropping it would silently use a real image), and that `--service-account` is pinned to the deployer SA (regression guard — dropping it would mean the first real deploy boots as the legacy compute SA).
- **Test 23** (service present): asserts the `[skip]` log line and that `gcloud run deploy` was NOT called.

shellcheck clean.

## Docs

`docs/PLATFORM-GUIDE.md` gains a "Cloud Run service pre-create (Step 5.8)" subsection under "Workshop: Lifecycle".

## Test plan

- [ ] CI green
- [ ] After merge: dry-run on a fresh project. Confirm Step 5.8 logs `[create] Cloud Run service 'agile-flow-app' (placeholder revision)` and the subsequent gcloud call uses the hello-world image.
- [ ] Re-run the wrapper on the same project: Step 5.8 logs `[skip] Cloud Run service 'agile-flow-app' already exists`.
- [ ] Open a real PR on a participant fork against this newly-provisioned project. Confirm preview-deploy.yml succeeds on the first push (not after a re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)