### PR TITLE
fix(provisioner): skip billing link when project is already linked

### DIFF
--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -210,9 +210,23 @@ if [[ "$CREATE_PROJECT" == "true" ]]; then
     gcloud projects create "$GCP_PROJECT_ID"
   fi
 
-  echo "[link] Billing account $BILLING_ACCOUNT_ID"
-  gcloud billing projects link "$GCP_PROJECT_ID" \
-    --billing-account="$BILLING_ACCOUNT_ID"
+  # Skip the link call when this project is already linked to the same
+  # billing account. Re-linking an already-linked project is unnecessary
+  # AND fails with `Cloud billing quota exceeded` once you're at the
+  # billing account's project-link cap (5 by default on free tiers) —
+  # `billing projects link` is metered against that quota even when the
+  # project in question is already linked. Idempotent re-runs would
+  # otherwise fail on every wrapper invocation after the cap is hit,
+  # even though the desired state is already satisfied.
+  current_billing="$(gcloud billing projects describe "$GCP_PROJECT_ID" \
+    --format='value(billingAccountName)' 2>/dev/null || true)"
+  if [[ "$current_billing" == "billingAccounts/${BILLING_ACCOUNT_ID}" ]]; then
+    echo "[skip] Billing account $BILLING_ACCOUNT_ID already linked"
+  else
+    echo "[link] Billing account $BILLING_ACCOUNT_ID"
+    gcloud billing projects link "$GCP_PROJECT_ID" \
+      --billing-account="$BILLING_ACCOUNT_ID"
+  fi
 fi
 
 # ── Step 1.5: Override Domain Restricted Sharing (workshop projects) ─────

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -330,6 +330,154 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 8b: Step 1 idempotent billing-link skip ────────────────────────
+# Reproduces the live bug observed during the 2026-04-29 dry-run: with 5
+# projects already linked to the billing account (the default cap), every
+# `billing projects link` call fails with `Cloud billing quota exceeded`
+# regardless of whether the project is already linked. Re-running the
+# wrapper on an already-provisioned project should detect the existing
+# link via `billing projects describe` and skip the link call.
+
+echo ""
+echo "Test 8b: Step 1 skips billing link when project already linked"
+
+T8B=$(mktemp -d -t aflowtest-XXXX)
+mkdir -p "$T8B/bin"
+
+# Stub: project exists + ACTIVE + own org; billing-describe returns the
+# expected billingAccountName so the new logic should take the [skip] path.
+# The link sub-command exits non-zero so an unwanted invocation surfaces.
+cat > "$T8B/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$T8B/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    if echo "\$*" | grep -q -- "--format"; then
+      echo "ACTIVE"
+    fi
+    exit 0
+    ;;
+  "projects get-iam-policy") exit 0 ;;
+  "billing projects")
+    case "\$3" in
+      describe)
+        # Mimic gcloud --format=value(billingAccountName) output for an
+        # already-linked project.
+        echo "billingAccounts/FAKE-BILLING-ID"
+        exit 0
+        ;;
+      link)
+        echo "FATAL: link should NOT be called when project already linked" >&2
+        exit 99
+        ;;
+    esac
+    ;;
+  "services enable") exit 1 ;;  # short-circuit past Step 2
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T8B/bin/gcloud"
+
+set +e
+PATH="$T8B/bin:$PATH" \
+  GCP_PROJECT_ID="af-already-linked" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING-ID" \
+  "$SCRIPT" --create-project > "$T8B/stdout.log" 2>&1
+set -e
+
+if grep -q "skip.*Billing account FAKE-BILLING-ID already linked" "$T8B/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} skip-link log line"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[skip] Billing account ... already linked' in stdout"
+  cat "$T8B/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Critical regression guard: link must NEVER be called when the project
+# is already linked to the same account. The fatal-stub on `link` would
+# fire if it did, but we also check the gcloud log to be explicit.
+if ! grep -q "billing projects link" "$T8B/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud billing projects link NOT invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} link should NOT have been called; this is the live-bug regression"
+  FAIL=$((FAIL + 1))
+fi
+
+# Sanity: describe SHOULD have been called to make the decision.
+if grep -q "billing projects describe" "$T8B/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud billing projects describe was the probe"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected billing projects describe to probe current link"
+  cat "$T8B/gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 8c: Step 1 still links when project linked to a DIFFERENT account ─
+# Edge case: the project exists and has billing enabled, but to a different
+# account than what BILLING_ACCOUNT_ID specifies. The script should still
+# call link to switch accounts (gcloud handles that case server-side).
+
+echo ""
+echo "Test 8c: Step 1 still links when project linked to a different account"
+
+T8C=$(mktemp -d -t aflowtest-XXXX)
+mkdir -p "$T8C/bin"
+
+cat > "$T8C/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$T8C/gcloud.log"
+case "\$1 \$2" in
+  "projects describe")
+    if echo "\$*" | grep -q -- "--format"; then
+      echo "ACTIVE"
+    fi
+    exit 0
+    ;;
+  "projects get-iam-policy") exit 0 ;;
+  "billing projects")
+    case "\$3" in
+      describe)
+        # Linked to a DIFFERENT billing account than BILLING_ACCOUNT_ID
+        echo "billingAccounts/SOME-OTHER-ACCOUNT"
+        exit 0
+        ;;
+      link) exit 0 ;;
+    esac
+    ;;
+  "services enable") exit 1 ;;  # short-circuit past Step 2
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T8C/bin/gcloud"
+
+set +e
+PATH="$T8C/bin:$PATH" \
+  GCP_PROJECT_ID="af-other-billing" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING-ID" \
+  "$SCRIPT" --create-project > "$T8C/stdout.log" 2>&1
+set -e
+
+if grep -q "link.*Billing account FAKE-BILLING-ID" "$T8C/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} [link] log line fired (different account)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[link] Billing account ...' when linked to a different account"
+  cat "$T8C/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "billing projects link af-other-billing" "$T8C/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} gcloud billing projects link was invoked"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected billing projects link to be called"
+  cat "$T8C/gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Test 9-11: Step 1.5 domain-restricted-sharing override ──────────────
 #
 # The script's Step 1.5 has TWO branches now (was three pre-2026-04-28).


### PR DESCRIPTION
## Summary

Quick fix — no linked ticket. Surfaced during the 2026-04-29 dry-run.

`gcloud billing projects link` was being called unconditionally in Step 1 whenever `--create-project` was set, even when the existing project was already linked to the same billing account. That re-link call is metered against the billing account's project-link quota (default 5 projects on free tiers); once the cap is hit, every wrapper invocation fails with `Cloud billing quota exceeded` even though the desired state is already satisfied.

## Live reproduction

```
[skip] Project af-tck517-2026-05d already exists (ACTIVE, owned by you)
[link] Billing account 0114D1-7670CD-C32F71
ERROR: (gcloud.billing.projects.link) FAILED_PRECONDITION: Precondition check failed.
- '@type': type.googleapis.com/google.rpc.QuotaFailure
  violations:
  - description: 'Cloud billing quota exceeded: https://support.google.com/code/contact/billing_quota_increase'
    subject: billingAccounts/0114D1-7670CD-C32F71
```

The user had 5 projects from prior dry-run iterations linked to the same billing account, all in soft-delete grace periods that don't release the billing-link slot until the 30-day expiry. Even with a 1-row roster against a project that was *already provisioned*, the wrapper failed because the unconditional re-link counted against quota.

## Fix

```diff
-echo "[link] Billing account $BILLING_ACCOUNT_ID"
-gcloud billing projects link "$GCP_PROJECT_ID" \
-  --billing-account="$BILLING_ACCOUNT_ID"
+current_billing="$(gcloud billing projects describe "$GCP_PROJECT_ID" \
+  --format='value(billingAccountName)' 2>/dev/null || true)"
+if [[ "$current_billing" == "billingAccounts/${BILLING_ACCOUNT_ID}" ]]; then
+  echo "[skip] Billing account $BILLING_ACCOUNT_ID already linked"
+else
+  echo "[link] Billing account $BILLING_ACCOUNT_ID"
+  gcloud billing projects link "$GCP_PROJECT_ID" \
+    --billing-account="$BILLING_ACCOUNT_ID"
+fi
```

Probe via `billing projects describe` (which is *not* metered against link quota), compare the result to the configured billing account, and skip the link call when they match. Empty output or a different account still falls through to link, so account switches keep working.

## Tests

| Suite | Before | After |
|-------|--------|-------|
| `provision-gcp-project.test.sh` | 81 | 86 |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| **Total** | **152** | **157** |

Tests 8b and 8c added (5 new assertions):

- **Test 8b** (project linked to *same* account): asserts `[skip]` log line, that `gcloud billing projects link` was NOT called (regression guard for the live bug — fatal-stub on the link sub-command), and that `billing projects describe` was the probe.
- **Test 8c** (project linked to *different* account): asserts `[link]` log line and that `link` WAS called. Preserves the account-switch path.

shellcheck clean.

## Test plan

- [ ] CI green
- [ ] After merge: re-run the wrapper on `af-tck517-2026-05d` (already linked to `0114D1-7670CD-C32F71`). Confirm Step 1 logs `[skip] Billing account 0114D1-7670CD-C32F71 already linked` and the wrapper proceeds past Step 1 instead of failing on the re-link.
- [ ] In parallel, file a Google billing quota-increase request — the workshop's 8 attendees × multiple dry-run iterations will hit this again without the increase, fix or no fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)