### PR TITLE
fix(deploy): migrate traffic to latest revision; clear stale DATABASE_URL plain var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,22 @@ jobs:
           # does — the asymmetry is easy to miss). Without this flag,
           # Cloud Run uses the legacy Compute Engine default SA at runtime,
           # which has none of the roles we provisioned (e.g. secretAccessor).
+          # --traffic=latest=100 routes all production traffic to the new
+          # revision after deploy. Without it, deploy-cloudrun@v2 leaves the
+          # existing traffic split intact — fine when traffic was already
+          # 100% to the previous latest, but a silent trap when the service
+          # was pre-created with a placeholder revision (Step 5.8 in the
+          # provisioner) that gcloud pinned 100% to. Without this flag, every
+          # deploy after the first leaves the placeholder serving traffic
+          # while the new revision sits at 0%. Symptom: green CI, service URL
+          # serves "Hello from Cloud Run!" forever. See #61.
+          #
+          # --remove-env-vars=DATABASE_URL clears any stale plain-env-var of
+          # the same name BEFORE the secrets: mount applies. Cloud Run treats
+          # plain env vars and Secret Manager mounts as different types on
+          # the same key, and `--update-secrets` refuses to overwrite a plain
+          # var. The flag is idempotent (no-op when the var doesn't exist).
+          # See #62.
           flags: |
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
             --port=8080
@@ -131,6 +147,8 @@ jobs:
             --min-instances=0
             --max-instances=10
             --allow-unauthenticated
+            --traffic=latest=100
+            --remove-env-vars=DATABASE_URL
           env_vars: |
             ENVIRONMENT=production
           # Mount secrets from Secret Manager as env vars. The secret must


### PR DESCRIPTION
## Summary

Two-line, workshop-critical fix in `.github/workflows/deploy.yml` deploy step `flags:` block. Closes #61 (P0) and #62 (P1) together because they touch the same workflow file in the same context. Both bugs surfaced during the 2026-04-29 dry-run on `tck517/tck517-app` — see `tck517/tck517-app:reports/session-journals/2026-04-29.md` for the long-form analysis.

## #61 — `--traffic=latest=100` (P0, workshop-blocking)

**The trap:** `scripts/provision-gcp-project.sh` Step 5.8 pre-creates the Cloud Run service with a hello-world placeholder image. gcloud's default pins 100% traffic to that first revision. Then `deploy-cloudrun@v2` deploys subsequent revisions but does NOT migrate traffic — the action only sets traffic when the service is new. With traffic already pinned to a specific revision, the placeholder absorbs production traffic forever.

**Symptom:** green CI on every deploy, service URL serves "Hello from Cloud Run!" indefinitely.

**Reproducible:** fresh fork, run bootstrap, push to main, watch deploy go green, hit URL, see placeholder.

**Why this is the workshop critical-path bug:** every participant's first production deploy will appear successful in the GitHub Actions UI but serve the wrong content. The fork-author confirmed reproducibility on `tck517/tck517-app` and unblocked themselves with a manual `gcloud run services update-traffic --to-latest`. We can't ship the workshop with a guaranteed-broken-but-green-CI experience.

## #62 — `--remove-env-vars=DATABASE_URL` (P1, defensive)

**The trap:** Cloud Run treats plain env vars and Secret Manager secret mounts as different *types* on the same key. If `DATABASE_URL` is ever set as a plain env var (manual gcloud during debug, earlier workflow iteration, etc.), the next workflow run fails opaquely:

```
ERROR: (gcloud.run.deploy) Cannot update environment variable [DATABASE_URL] to the given type because it has already been set with a different type.
```

**Defense:** `--remove-env-vars=DATABASE_URL` is idempotent (no-op when the var doesn't exist) and clears any stale plain var BEFORE the `secrets:` mount applies. Type drift gets corrected on every deploy.

## What this PR does NOT do

- **Does not change `preview-deploy.yml`** for #62 — preview-deploy uses `--set-env-vars` to pass `DATABASE_URL` directly from the Neon action's per-PR branch URI, not a Secret Manager mount. No type-collision risk on the preview side.
- **Does not change `preview-deploy.yml`** for #61 — preview revisions intentionally use `--no-traffic --tag=pr-N` and shouldn't take production traffic. Correct as-is.
- **Does not address the architectural fix** in journal §A.2 ("stop pre-creating with placeholder, instead detect-on-first-run in preview-deploy.yml"). Larger change; deferred. This quick fix unblocks the workshop while the larger refactor is scoped.

## Tests

No new tests. Workflow YAML changes are validated end-to-end by participant fork deploys post-merge. The DoD on #61 specifies the manual verification:

- After merge, push to main on a participant fork
- Watch deploy go green
- Hit service URL → confirm FastAPI response (not placeholder)
- Verify via `gcloud run services describe ... --format='value(status.traffic)'` that 100% routes to the new revision

## Related work from the same dry-run

| Ticket | What | Priority | Status |
|--------|------|----------|--------|
| #61 | `--traffic=latest=100` | P0 | This PR |
| #62 | `--remove-env-vars=DATABASE_URL` | P1 | This PR |
| #63 | Fail fast on missing DATABASE_URL in production (defense-in-depth) | P1 | Filed, not started |
| #64 | `diagnose-cloudrun.sh` for one-shot diagnostics | P1 | Filed, not started |
| #65 | docs(patterns): add Cloud Run traffic + env-var entries | P2 | Filed, not started |

🤖 Generated with [Claude Code](https://claude.com/claude-code)