### PR TITLE
fix(deploy): unify DATABASE_URL env-var type between production and preview

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,13 +132,6 @@ jobs:
           # deploy after the first leaves the placeholder serving traffic
           # while the new revision sits at 0%. Symptom: green CI, service URL
           # serves "Hello from Cloud Run!" forever. See #61.
-          #
-          # --remove-env-vars=DATABASE_URL clears any stale plain-env-var of
-          # the same name BEFORE the secrets: mount applies. Cloud Run treats
-          # plain env vars and Secret Manager mounts as different types on
-          # the same key, and `--update-secrets` refuses to overwrite a plain
-          # var. The flag is idempotent (no-op when the var doesn't exist).
-          # See #62.
           flags: |
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
             --port=8080
@@ -148,14 +141,23 @@ jobs:
             --max-instances=10
             --allow-unauthenticated
             --traffic=latest=100
-            --remove-env-vars=DATABASE_URL
+          # DATABASE_URL is set as a plain env var (not a Secret Manager
+          # mount) so production and preview agree on the env-var TYPE. The
+          # two workflows target the same Cloud Run service; Cloud Run
+          # permits one type per env-var name, never alternating. If
+          # production mounts as secret and preview sets as literal (or
+          # vice-versa), every deploy after the first fails with:
+          #   ERROR: (gcloud.run.deploy) Cannot update environment variable
+          #   [DATABASE_URL] to <type> because it has already been set with
+          #   a different type.
+          # Both workflows now write DATABASE_URL as a literal. The
+          # connection string is on the revision instead of in Secret
+          # Manager — acceptable trade-off because preview already exposes
+          # Neon URLs as literals; consistency between the pipelines is
+          # more valuable than asymmetric hardening of just one. See #67.
           env_vars: |
             ENVIRONMENT=production
-          # Mount secrets from Secret Manager as env vars. The secret must
-          # exist in Secret Manager in the same project and point at the
-          # production Neon pooled connection string.
-          secrets: |
-            DATABASE_URL=database-url:latest
+            DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
 
       - name: Show deployed URL
         if: steps.check_secrets.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Closes #67. Workshop-critical follow-up to PR #66 (#62), which addressed the surface but not the structural alternating-type bug.

`deploy.yml` and `preview-deploy.yml` target the same Cloud Run service but were writing `DATABASE_URL` two different *types*:

- `deploy.yml` (production) → Secret Manager mount via `secrets:`
- `preview-deploy.yml` (preview) → string literal via `--set-env-vars`

Cloud Run permits one type per env-var name per service. Whichever workflow ran last "wins" the type; the next run of the other workflow fails with:

```
ERROR: (gcloud.run.deploy) Cannot update environment variable [DATABASE_URL] to <type> because it has already been set with a different type.
```

PR #66's `--remove-env-vars=DATABASE_URL` defense fixed the prod-after-prod case but couldn't address the cross-workflow alternating cases. The 2026-04-29 downstream re-analysis (`tck517/tck517-app:reports/session-journals/2026-04-29-upstream-handoff.md` Bug 2) made this explicit: *"A naive defensive fix — adding `--remove-env-vars` and `--remove-secrets` — does not solve this. It only patches one direction at a time."*

## Fix

Both workflows now write `DATABASE_URL` as a literal. Production reads from `secrets.PRODUCTION_DATABASE_URL` (already referenced for the Alembic migration step at `deploy.yml:93`).

```diff
       flags: |
         --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
         ...
         --traffic=latest=100
-        --remove-env-vars=DATABASE_URL
       env_vars: |
         ENVIRONMENT=production
+        DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
-      secrets: |
-        DATABASE_URL=database-url:latest
```

After this lands, the failure mode is closed in all four directions: prod→prod, prod→preview, preview→prod, preview→preview. Operator-side `--remove-env-vars` / `--remove-secrets` workarounds are no longer needed.

## Trade-off

Connection string is now a plain env var on the Cloud Run revision instead of a Secret Manager mount. **Acceptable** because preview already exposes Neon URLs as literals; consistency between the two pipelines is more valuable than asymmetric hardening of just one.

A future improvement (see journal §B Option 2 / Option 3) would be:
- Per-PR Secret Manager secrets (`database-url-pr-N`), or
- Separate Cloud Run services per environment (`agile-flow-app-prod`, `agile-flow-app-pr-N`)

Both are larger changes; deferred for post-workshop.

## Tests

No new tests — workflow YAML changes are validated end-to-end by participant fork deploys post-merge. The DoD specifies the manual verification: prod → open PR → preview → close PR → push to main → prod, all five steps without operator intervention.

`pytest` 13/13 still pass (sanity).

## Related

- #61 (placeholder traffic, P0) — closed by PR #66
- #62 (state-drift surface, P1) — closed by PR #66 but didn't fix the structural bug; cross-reference comment posted
- #63 (fail-fast on missing DATABASE_URL, P1) — open
- #64 (`diagnose-cloudrun.sh`, P1) — open
- #65 (pattern-library entries, P2) — open

🤖 Generated with [Claude Code](https://claude.com/claude-code)