### PR TITLE
feat(agents): add AGILE_FLOW_SOLO_MODE env var to skip bot-account switching

### DIFF
--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -17,6 +17,10 @@ the user if any check fails — do not continue with partial tooling.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
+   **Solo mode exception:** if `AGILE_FLOW_SOLO_MODE=true` is set, this check
+   is skipped — the participant uses one personal account for both worker and
+   reviewer roles. This is the workshop/tutorial path. The bot-account
+   separation is the production architecture.
 3. **Claude hooks are registered** — Check that hook files referenced in
    `.claude/settings.local.json` exist and are executable. WARN if any hook is
    missing or not executable.

--- a/.claude/hooks/ensure-github-account.sh
+++ b/.claude/hooks/ensure-github-account.sh
@@ -15,6 +15,15 @@
 
 set -euo pipefail
 
+# Solo mode: when AGILE_FLOW_SOLO_MODE=true (set via env or shell rc),
+# the hook is a no-op. Used for workshops and tutorials where one
+# attendee plays both worker and reviewer roles under their own
+# GitHub identity. Production teams that want separation-of-duties
+# leave this unset and rely on the worker/reviewer bot accounts below.
+if [[ "${AGILE_FLOW_SOLO_MODE:-false}" == "true" ]]; then
+  exit 0
+fi
+
 WORKER_ACCOUNT="${AGILE_FLOW_WORKER_ACCOUNT:-va-worker}"
 REVIEWER_ACCOUNT="${AGILE_FLOW_REVIEWER_ACCOUNT:-va-reviewer}"
 

--- a/.claude/hooks/ensure-github-account.test.sh
+++ b/.claude/hooks/ensure-github-account.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Tests for ensure-github-account.sh — the PreToolUse hook that switches
+# `gh` accounts before PR creation/review. Focuses on the solo-mode
+# escape hatch (#69) and verifies the hook is a no-op when
+# AGILE_FLOW_SOLO_MODE=true.
+#
+# The harness invokes the hook with stubbed `gh` and `jq` on PATH.
+# `jq` is real (the hook uses it for stdin parsing); `gh` is a stub
+# whose calls get logged so we can assert on what the hook attempted.
+#
+# Run: ./.claude/hooks/ensure-github-account.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/ensure-github-account.sh"
+
+new_tmp() { mktemp -d -t aflowhook-XXXX; }
+
+# Stub gcloud-irrelevant; we only need a `gh` stub. Logs every call.
+make_gh_stub() {
+  local tmp="$1"
+  local active_account="${2:-some-account}"
+  mkdir -p "$tmp/bin"
+
+  cat > "$tmp/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$tmp/gh.log"
+case "\$1 \$2" in
+  "auth status")
+    cat <<STATUS
+github.com
+  ✓ Logged in to github.com account $active_account (keyring)
+  - Active account: true
+  - Git operations protocol: https
+STATUS
+    exit 0 ;;
+  "auth switch") exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$tmp/bin/gh"
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}✓${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: Solo mode → no-op, no `gh` calls ────────────────────────────
+
+echo ""
+echo "Test 1: AGILE_FLOW_SOLO_MODE=true → hook exits 0 with no gh calls"
+
+T1=$(new_tmp)
+make_gh_stub "$T1"
+
+# Solo-mode invocation against a `gh pr create` Bash command — the path
+# that would normally trigger the worker switch.
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T1/bin:$PATH" \
+  AGILE_FLOW_SOLO_MODE=true \
+  bash "$HOOK" <<< "$input" > "$T1/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+
+# Critical regression guard: gh must NOT be called when solo mode is on.
+gh_call_count=0
+if [[ -f "$T1/gh.log" ]]; then
+  gh_call_count="$(grep -c '.' "$T1/gh.log" 2>/dev/null || true)"
+fi
+assert_eq "0" "$gh_call_count" "no gh calls made in solo mode"
+
+# ── Test 2: Solo mode unset (default) → bot-switching path runs ─────────
+
+echo ""
+echo "Test 2: solo mode unset → hook still calls gh auth status"
+
+T2=$(new_tmp)
+make_gh_stub "$T2" "va-worker"  # already on the worker account → no switch
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T2/bin:$PATH" \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T2/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 when already on correct account"
+
+# Should have called auth status to check current account.
+if [[ -f "$T2/gh.log" ]] && grep -q "auth status" "$T2/gh.log"; then
+  echo -e "  ${GREEN}✓${NC} gh auth status was called"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected gh auth status call when solo mode unset"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 3: Solo mode + non-PR command → no-op (fast path) ─────────────
+
+echo ""
+echo "Test 3: AGILE_FLOW_SOLO_MODE=true + non-PR command → no gh calls"
+
+T3=$(new_tmp)
+make_gh_stub "$T3"
+
+input='{"tool_name":"Bash","tool_input":{"command":"git status"}}'
+
+set +e
+PATH="$T3/bin:$PATH" \
+  AGILE_FLOW_SOLO_MODE=true \
+  bash "$HOOK" <<< "$input" > "$T3/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+
+gh_call_count=0
+if [[ -f "$T3/gh.log" ]]; then
+  gh_call_count="$(grep -c '.' "$T3/gh.log" 2>/dev/null || true)"
+fi
+assert_eq "0" "$gh_call_count" "no gh calls (solo short-circuit fires before command-pattern match)"
+
+# ── Test 4: AGILE_FLOW_SOLO_MODE=false → bot-switching runs ─────────────
+# Verifies the env-var comparison is exact (only "true" disables;
+# any other value falls through to normal flow).
+
+echo ""
+echo "Test 4: AGILE_FLOW_SOLO_MODE=false → hook still does bot switching"
+
+T4=$(new_tmp)
+make_gh_stub "$T4" "va-worker"
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T4/bin:$PATH" \
+  AGILE_FLOW_SOLO_MODE=false \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T4/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+
+if [[ -f "$T4/gh.log" ]] && grep -q "auth status" "$T4/gh.log"; then
+  echo -e "  ${GREEN}✓${NC} gh auth status was called (false != true; falls through)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected bot-switching path when SOLO_MODE=false"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 2. **All tests must pass before pushing.** Never use `git push --no-verify`. Fix the failing checks instead.
 3. **Conventional commits required.** Format: `<type>(<scope>): <subject>`. See `.claude/skills/commit.md` for types and scopes.
 4. **Only humans merge PRs.** Agents create PRs and review them. Humans approve and merge.
-5. **Switch accounts before PR operations.** The `.claude/hooks/ensure-github-account.sh` hook handles this automatically.
+5. **Switch accounts before PR operations.** The `.claude/hooks/ensure-github-account.sh` hook handles this automatically. Set `AGILE_FLOW_SOLO_MODE=true` to skip — recommended for workshops and tutorials where one person plays both worker and reviewer roles.
 6. **No emojis in ASCII tables.** They break column alignment. Emojis OK in prose and headings.
 7. **One canonical location per fact.** Don't duplicate content across CLAUDE.md, agent files, and skills.
 8. **Never hardcode application URLs.** Use `window.location.origin` (client-side) or request headers (server-side) so code works in both production and PR preview environments.
@@ -67,6 +67,8 @@ The `.claude/hooks/ensure-github-account.sh` hook auto-switches accounts:
 
 - **Worker** (`AGILE_FLOW_WORKER_ACCOUNT`, default: `va-worker`) — PR creation
 - **Reviewer** (`AGILE_FLOW_REVIEWER_ACCOUNT`, default: `va-reviewer`) — PR reviews
+
+**Solo mode** — set `AGILE_FLOW_SOLO_MODE=true` to make the hook a no-op. One personal account plays both worker and reviewer roles. Use for workshops and tutorials; the production architecture is the bot-account separation above.
 
 ### GitHub CLI (`gh`)
 

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -382,6 +382,39 @@ has data rows) and then hands off to the underlying provisioning logic.
 Pre-flight failures exit 2 with actionable messages — far better than
 discovering a missing auth token mid-loop.
 
+### Solo mode (workshops and tutorials)
+
+Production teams using this template separate "the agent that opens
+PRs" from "the agent that reviews them" by giving each its own GitHub
+bot account (the `va-worker` / `va-reviewer` pair documented in
+`CLAUDE.md`). For a workshop, that adds 10–15 minutes of per-attendee
+setup (PAT distribution, two `gh auth login` calls, hook debugging
+when an account isn't authed) without teaching anything an attendee
+can't learn another way.
+
+**Solo mode** disables the bot-account split: each attendee uses their
+own personal GitHub account for both worker and reviewer roles. The
+agent flow demos cleanly (open → review → merge as one identity),
+errors are unambiguous (every "can't do X" is about the participant,
+not "which bot am I supposed to be?"), and setup goes from ~15
+min/person to ~3 min/person.
+
+**To enable:** the attendee adds one line to `~/.zshrc` (macOS) or
+`~/.bashrc` (Linux):
+
+```bash
+export AGILE_FLOW_SOLO_MODE=true
+```
+
+After restarting Claude Desktop (so the new shell picks up the env),
+the `.claude/hooks/ensure-github-account.sh` hook short-circuits and
+no longer tries to switch accounts. The attendee operates entirely
+under their own `gh auth login` identity.
+
+**Trade-off** — solo mode loses the audit-trail benefit of bot-account
+separation. Use it for learning environments. Production teams should
+leave the env var unset and run with the full bot-account architecture.
+
 ### Roster format
 
 `roster.csv` accepts three header shapes. The first four columns are


### PR DESCRIPTION
## Summary

Closes #69. Workshop-prep blocker: the pre-work checklist that ships to attendees expects this env var to be a recognized opt-out from bot-account switching.

## Why

Production teams using this template separate "the agent that opens PRs" from "the agent that reviews them" by giving each a dedicated GitHub bot account. That's the right architecture for production. For workshops it adds 10–15 minutes of per-attendee setup (PAT distribution, two `gh auth login` calls, hook debugging when an account isn't authed) without teaching anything an attendee couldn't learn another way.

Solo mode lets one personal account play both roles. Setup drops from ~15 min/person to ~3 min/person. Production teams keep the bot-account flow by leaving `AGILE_FLOW_SOLO_MODE` unset (default).

## What changed

| File | Change |
|---|---|
| `.claude/hooks/ensure-github-account.sh` | 6-line short-circuit at the top: `if [[ "${AGILE_FLOW_SOLO_MODE:-false}" == "true" ]]; then exit 0; fi`. Runs before any inspection — true no-op (no gh calls, no env reads). |
| `.claude/commands/work-ticket.md` | Pre-flight check #2 documents the solo-mode exception so the agent doesn't STOP on missing bot accounts. |
| `CLAUDE.md` | Critical rule #5 calls out the escape hatch inline. Account Switching section adds a Solo mode block. |
| `docs/PLATFORM-GUIDE.md` | New "Solo mode" subsection under Workshop: Lifecycle. Covers when to use it, how to enable, and the trade-off. |
| `.claude/hooks/ensure-github-account.test.sh` (new) | 8 assertions across 4 tests. Test 4 is the regression guard for exact-match env-var comparison. |

## Tests

| Suite | Before | After |
|-------|--------|-------|
| `provision-gcp-project.test.sh` | 92 | 92 |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` (new) | 0 | 8 |
| **Total** | **163** | **171** |

shellcheck clean.

## Test plan

- [ ] CI green
- [ ] After merge: workshop attendee adds `export AGILE_FLOW_SOLO_MODE=true` to `~/.zshrc`, runs `/work-ticket` in Claude Code with their personal `gh` auth — agent doesn't STOP on missing bot accounts and proceeds to ticket work.
- [ ] Same attendee runs `/review-pr` on their own PR — review posts as their identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)