### PR TITLE
fix(provision): auto-push PRODUCTION_DATABASE_URL GitHub secret

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -559,6 +559,11 @@ into the participant's fork after provisioning completes:
 - `GCP_SERVICE_ACCOUNT`
 - `GCP_WORKLOAD_IDENTITY_PROVIDER` (when WIF was set up in Step 5.5)
 - `NEON_PARENT_BRANCH` (when Neon was provisioned in Step 5.7)
+- `PRODUCTION_DATABASE_URL` (when Neon was provisioned in Step 5.7) — same
+  pooled URI written to the `database-url` Secret Manager secret. Required
+  by `deploy.yml` for the Alembic migration step and the Cloud Run runtime
+  env var. Without it, production starts with `DATABASE_URL=""` and 500s on
+  the first DB query.
 
 This eliminates the most common day-1 failure: facilitators copy SA
 emails or WIF provider paths between projects by hand and get them

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -838,6 +838,12 @@ if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
     fi
     if [[ "${NEON_BRANCH_PROVISIONED:-false}" == "true" ]]; then
       push_secret "NEON_PARENT_BRANCH" "$NEON_BRANCH_NAME"
+      # Same Neon pooled URI Step 5.7 wrote into the `database-url`
+      # Secret Manager secret. deploy.yml reads this in two places:
+      # the Alembic migration step (line 93) and the Cloud Run runtime
+      # env var (line 160, post-#68). Without it both fail silently —
+      # see #71.
+      push_secret "PRODUCTION_DATABASE_URL" "$pooled_uri"
     fi
 
     # SA key is intentionally NOT auto-pushed even when --with-sa-key
@@ -872,6 +878,7 @@ if [[ "$GH_SECRETS_PUSHED" == "true" ]]; then
   fi
   if [[ "${NEON_BRANCH_PROVISIONED:-false}" == "true" ]]; then
     echo "   - NEON_PARENT_BRANCH"
+    echo "   - PRODUCTION_DATABASE_URL"
   fi
   echo ""
   if [[ "$WITH_SA_KEY" == "true" ]]; then
@@ -911,7 +918,7 @@ if [[ "${NEON_BRANCH_PROVISIONED:-false}" == "true" ]]; then
     echo "   gh secret set NEON_API_KEY    --repo $GITHUB_REPOSITORY --body \"\$NEON_API_KEY\""
     echo "   gh secret set NEON_PROJECT_ID --repo $GITHUB_REPOSITORY --body \"\$NEON_PROJECT_ID\""
     echo ""
-    echo "   (NEON_PARENT_BRANCH was set automatically above.)"
+    echo "   (NEON_PARENT_BRANCH and PRODUCTION_DATABASE_URL were set automatically above.)"
     echo "   The 'database-url' Secret Manager secret was created automatically"
     echo "   from the attendee's Neon branch ('$NEON_BRANCH_NAME')."
   else
@@ -923,10 +930,13 @@ if [[ "${NEON_BRANCH_PROVISIONED:-false}" == "true" ]]; then
     echo "   The 'database-url' Secret Manager secret was created automatically"
     echo "   from the attendee's Neon branch ('$NEON_BRANCH_NAME')."
     echo ""
-    echo "3. Set NEON_PARENT_BRANCH on the participant's fork so per-PR previews"
-    echo "   inherit from this attendee's branch (otherwise they branch from main):"
+    echo "3. Set NEON_PARENT_BRANCH and PRODUCTION_DATABASE_URL on the"
+    echo "   participant's fork so production deploys can run migrations and"
+    echo "   per-PR previews inherit this attendee's branch:"
     echo ""
     echo "   NEON_PARENT_BRANCH     = $NEON_BRANCH_NAME"
+    echo "   PRODUCTION_DATABASE_URL = (the same value already in"
+    echo "                              the 'database-url' Secret Manager secret)"
   fi
   echo ""
   echo "4. (Optional) Set these repository variables (non-secret):"

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -2095,8 +2095,22 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Per-attendee secret added by #71: PRODUCTION_DATABASE_URL must be
+# auto-pushed alongside NEON_PARENT_BRANCH whenever Neon was provisioned.
+# Without it, deploy.yml's migration step skips silently and Cloud Run
+# starts with DATABASE_URL="" (post-#68 plain env var), which 500s on
+# the first DB query — the bug surfaced in the 2026-04-29 dry-run.
+if grep -q "gh secret set PRODUCTION_DATABASE_URL --repo acme/widget-shop" "$T27/gh.log"; then
+  echo -e "  ${GREEN}✓${NC} PRODUCTION_DATABASE_URL pushed (Neon-provisioned per-attendee secret)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected PRODUCTION_DATABASE_URL push when Neon provisioned"
+  cat "$T27/gh.log"
+  FAIL=$((FAIL + 1))
+fi
+
 # The footer must NOT actually push these — they're cohort-shared, not
-# per-attendee. gh.log should only contain the 4 per-attendee secrets.
+# per-attendee. gh.log should only contain the per-attendee secrets.
 if ! grep -q "gh secret set NEON_API_KEY" "$T27/gh.log"; then
   echo -e "  ${GREEN}✓${NC} cohort-shared NEON_API_KEY was NOT auto-pushed"
   PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary

Closes #71. The provisioner now auto-pushes `PRODUCTION_DATABASE_URL` to the participant's fork as a GitHub Actions secret whenever Step 5.7 provisioned a Neon branch. Reuses the existing `pooled_uri` so the GitHub secret matches the `database-url` Secret Manager secret exactly.

## Why

Third workshop-blocker from the 2026-04-29 dry-run cycle (after #61 and #67). The fork's first production load looked like a schema bug — `psycopg.errors.UndefinedTable: relation \"todo\" does not exist` — but was actually a CI-secrets gap:

- `deploy.yml` line 93: Alembic migration step gated on `PRODUCTION_DATABASE_URL` being set; previously exited 0 with "skipping migrations" so the prod Neon branch never got the schema.
- `deploy.yml` line 160 (post-#68): Cloud Run revision uses `PRODUCTION_DATABASE_URL` as a plain `DATABASE_URL` env var. Empty value → 500 on first DB query.

Both paths are now fed by the same auto-pushed secret.

## What changed

| File | Change |
|---|---|
| `scripts/provision-gcp-project.sh` Step 7 | New `push_secret "PRODUCTION_DATABASE_URL" "$pooled_uri"` inside the existing `NEON_BRANCH_PROVISIONED=true` gate. One push call; reuses the variable Step 5.7 already minted. |
| `scripts/provision-gcp-project.sh` footers | The auto-push footer now lists `PRODUCTION_DATABASE_URL` among "set automatically above"; the manual-fallback footer (Neon provisioned, `gh` missing) tells the facilitator to set it from the same value already in the `database-url` Secret Manager secret. The no-Neon path is unchanged. |
| `scripts/provision-gcp-project.test.sh` Test 27 | New assertion: `gh secret set PRODUCTION_DATABASE_URL --repo acme/widget-shop` must appear in `gh.log` when Neon was provisioned. |
| `docs/PLATFORM-GUIDE.md` | "Auto-pushed GitHub secrets" list adds `PRODUCTION_DATABASE_URL` with a note explaining why both deploy paths depend on it. |

## Tests

| Suite | Before | After |
|-------|--------|-------|
| `provision-gcp-project.test.sh` | 92 | **93** |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` | 8 | 8 |
| **Total** | **171** | **172** |

shellcheck clean.

## Test plan

- [ ] CI green
- [ ] After merge: re-run `provision-workshop-roster.sh` against a fresh fork. Confirm `PRODUCTION_DATABASE_URL` appears in the fork's `gh secret list` output and that the next push to `main` runs the migration step + boots Cloud Run with a populated `DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)