### PR TITLE
feat(app): fail fast on missing/sqlite DATABASE_URL in production

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,8 +6,9 @@ or Cloud Run Secret Manager mounts.
 """
 
 from functools import lru_cache
+from typing import Self
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -32,6 +33,30 @@ class Settings(BaseSettings):
         if v.startswith("postgresql://"):
             return v.replace("postgresql://", "postgresql+psycopg://", 1)
         return v
+
+    @model_validator(mode="after")
+    def _refuse_sqlite_in_production(self) -> Self:
+        # Defense-in-depth: the dev-default sqlite URL must never reach
+        # a production runtime. If the secret-mounted DATABASE_URL is
+        # missing or the mount didn't override the default, fail at
+        # startup with a clear message rather than 500ing on the first
+        # DB query with `no such table: todo`. See #63 / #71.
+        if self.environment != "production":
+            return self
+        if not self.database_url:
+            raise ValueError(
+                "DATABASE_URL is empty in production. "
+                "Check that the Secret Manager secret 'database-url' is "
+                "mounted in deploy.yml and the Cloud Run service has "
+                "secretAccessor on it."
+            )
+        if self.database_url.startswith("sqlite"):
+            raise ValueError(
+                f"DATABASE_URL is SQLite in production: {self.database_url!r}. "
+                "Production must use Postgres. Likely cause: the secret-mounted "
+                "DATABASE_URL env var didn't override the dev default."
+            )
+        return self
 
 
 @lru_cache

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,14 @@
 """Tests for app.config.Settings.
 
-Pins the contract that database_url is normalized to use the psycopg3
-driver scheme. SQLAlchemy resolves the bare `postgresql://` scheme to
-psycopg2 (not installed in this project), so without normalization
-every Neon-backed deploy would ImportError on first DB use.
+Pins two contracts:
+  1. database_url is normalized to use the psycopg3 driver scheme.
+     SQLAlchemy resolves the bare `postgresql://` scheme to psycopg2
+     (not installed in this project), so without normalization every
+     Neon-backed deploy would ImportError on first DB use.
+  2. In production, an empty or sqlite-shaped DATABASE_URL fails fast
+     at Settings construction (model validator) — turns the silent
+     "first request 500s with no such table: todo" failure mode into
+     a loud ValueError at startup. See #63.
 """
 
 import pytest
@@ -45,3 +50,51 @@ def _make_settings(database_url: str | None = None):
 )
 def test_database_url_scheme_normalization(input_url: str, expected: str) -> None:
     assert _make_settings(input_url).database_url == expected
+
+
+def test_production_empty_database_url_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Reading the empty-string case requires going through env vars: a
+    # bare Settings(database_url="") would still trigger this, but the
+    # realistic failure mode is the secret mount producing an empty env
+    # var, so we exercise that path explicitly.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DATABASE_URL", "")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="DATABASE_URL is empty in production"):
+        Settings()
+
+
+def test_production_sqlite_database_url_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./dev.db")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="DATABASE_URL is SQLite in production"):
+        Settings()
+
+
+def test_development_empty_database_url_uses_sqlite_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Development is the local-dev path: missing DATABASE_URL must NOT
+    # raise — pydantic's default ("sqlite:///./dev.db") applies and the
+    # app boots against the local SQLite file.
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.database_url == "sqlite:///./dev.db"
+
+
+def test_production_postgres_url_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The happy path: real Neon URL in production. Field validator
+    # normalizes it to psycopg3; model validator sees a non-sqlite,
+    # non-empty URL and returns clean.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h.neon.tech/db")
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.database_url == "postgresql+psycopg://u:p@h.neon.tech/db"


### PR DESCRIPTION
## Summary

Closes #63. Adds a Pydantic `model_validator` to `Settings` that raises `ValueError` at construction time when `ENVIRONMENT=production` and `DATABASE_URL` is empty or sqlite-shaped.

## Why

The dev default `sqlite:///./dev.db` silently masks production config bugs. When a Secret Manager mount fails to override it, the runtime constructs a SQLite engine and the first DB-touching request 500s with `sqlite3.OperationalError: no such table: todo` — looks like a schema bug, is actually a config bug.

The 2026-04-29 dry-run on `tck517/tck517-app` burned ~30 min chasing this before finding the unmounted secret. Failing fast at startup with a named cause turns this into a 30-second diagnosis: a `ValueError` from config beats a `sqlite3.OperationalError` from a query handler every time.

## How this fits with #71

| Layer | Goal | Mechanism |
|---|---|---|
| #71 (already merged) | Make the bug unreachable | Auto-push `PRODUCTION_DATABASE_URL` so the secret mount has data |
| #63 (this PR) | Catch the bug if #71's preconditions are bypassed | Refuse to construct `Settings` with empty/sqlite URL in prod |

#63 is defense-in-depth — this validator should be unreachable in practice. It catches manual provisioning, drifted forks, secret rotation gone wrong, and any future regression in #71's auto-push path.

## What changed

| File | Change |
|---|---|
| `app/config.py` | New `_refuse_sqlite_in_production` `@model_validator(mode=\"after\")`. Gated on `environment == \"production\"`; non-production paths return `self` unchanged. Raises with a named cause ("Secret Manager secret 'database-url' is mounted in deploy.yml" / "didn't override the dev default") so the Cloud Run log entry points at the actual fix location. |
| `tests/test_config.py` | 4 new cases. Uses `monkeypatch` to control env vars per-test (no leakage between cases). |

## Tests

| Case | Expected |
|---|---|
| production + empty `DATABASE_URL` | `ValueError("DATABASE_URL is empty in production…")` |
| production + `sqlite:///./dev.db` | `ValueError("DATABASE_URL is SQLite in production…")` |
| development + empty `DATABASE_URL` | No raise — SQLite default applies |
| production + valid Postgres URL | No raise — normalized to `postgresql+psycopg://…` and accepted |

Existing 5 normalization tests still pass.

```
ruff   ✓
mypy   ✓ (10 source files)
pytest ✓ 17/17 (was 13)
```

## Test plan

- [ ] CI green
- [ ] After merge: deploy `main` to a fork with the secret intentionally unmounted. Confirm the Cloud Run revision exits at startup with the new `ValueError` in logs (not a `sqlite3.OperationalError` on first request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)