### PR TITLE
feat(scripts): add diagnose-cloudrun.sh for one-shot Cloud Run diagnostics

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -640,6 +640,29 @@ gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.serv
   --format='value(timestamp,textPayload)'
 ```
 
+### Troubleshooting Cloud Run
+
+When something feels wrong (a deploy looks successful but the app
+returns 500s, traffic seems to be on the wrong revision, the
+placeholder `hello` image is still serving), use the one-shot
+diagnostic instead of composing gcloud queries by hand:
+
+```bash
+./scripts/diagnose-cloudrun.sh --project=YOUR_PROJECT_ID
+```
+
+The script is read-only and prints five sections in one go: service
+summary (URL, latest-ready vs latest-created revision), traffic split
+with stale-revision markers, currently-serving image with placeholder
+detection, latest revision conditions (Ready / Active /
+ContainerHealthy), and the last 50 log lines. Paste the full output
+into a help channel and someone else can diagnose without a
+back-and-forth.
+
+The script never mutates state — no traffic updates, no deploys, no
+deletes. For remediation see `Rolling Back` below or
+`docs/PATTERN-LIBRARY.md`.
+
 ### Rolling Back
 
 Cloud Run keeps every revision. To roll back:

--- a/scripts/diagnose-cloudrun.sh
+++ b/scripts/diagnose-cloudrun.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+#
+# diagnose-cloudrun.sh — One-shot Cloud Run diagnostic snapshot
+#
+# Read-only. Prints a structured summary of a Cloud Run service so a
+# facilitator can paste the output into a help channel and someone
+# else can diagnose without a back-and-forth.
+#
+# Sections (in order):
+#   1. Service summary (URL, latest-ready vs latest-created revision)
+#   2. Traffic split (which revisions get how much traffic)
+#   3. Currently-serving image (placeholder-image trap surfaces here)
+#   4. Latest revision conditions (Ready, Active, ContainerHealthy)
+#   5. Last 50 log lines from the service
+#
+# Usage:
+#   ./scripts/diagnose-cloudrun.sh                       # uses GCP_PROJECT_ID env
+#   ./scripts/diagnose-cloudrun.sh --project=af-xxx      # explicit project
+#   ./scripts/diagnose-cloudrun.sh --project=af-xxx --service=my-svc --region=us-central1
+#   ./scripts/diagnose-cloudrun.sh --help
+#
+# Required: GCP_PROJECT_ID env or --project=<id>
+# Optional: GCP_REGION (default: us-central1), CLOUD_RUN_SERVICE (default: agile-flow-app)
+#
+# Surfaced from the 2026-04-29 dry-run on tck517/tck517-app, where the
+# diagnostic command that cracked the case was a hand-composed multi-
+# field gcloud query. See #64.
+
+set -uo pipefail
+
+# ── Argument parsing ────────────────────────────────────────────────────
+
+PROJECT="${GCP_PROJECT_ID:-}"
+REGION="${GCP_REGION:-us-central1}"
+SERVICE="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+
+print_help() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --project=*)
+      PROJECT="${1#*=}"
+      ;;
+    --service=*)
+      SERVICE="${1#*=}"
+      ;;
+    --region=*)
+      REGION="${1#*=}"
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      echo "Run '$0 --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ── Pre-flight ──────────────────────────────────────────────────────────
+
+if [[ -z "$PROJECT" ]]; then
+  echo "ERROR: project is required." >&2
+  echo "  Set GCP_PROJECT_ID env or pass --project=<id>." >&2
+  echo "  (Refusing to fall back to 'gcloud config get project' to avoid" >&2
+  echo "   silently diagnosing the wrong project.)" >&2
+  exit 2
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "ERROR: gcloud CLI is not on PATH." >&2
+  echo "  Install: https://cloud.google.com/sdk/docs/install" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is not on PATH (needed for JSON parsing)." >&2
+  exit 2
+fi
+
+# ── Fetch service JSON (single round-trip) ──────────────────────────────
+
+SERVICE_JSON_FILE="$(mktemp -t diagnose-cloudrun-XXXXXX)"
+trap 'rm -f "$SERVICE_JSON_FILE" "${REV_JSON_FILE:-}"' EXIT
+
+if ! gcloud run services describe "$SERVICE" \
+  --region="$REGION" \
+  --project="$PROJECT" \
+  --format=json > "$SERVICE_JSON_FILE" 2>"$SERVICE_JSON_FILE.err"; then
+  echo "ERROR: could not describe service '$SERVICE' in $PROJECT/$REGION" >&2
+  cat "$SERVICE_JSON_FILE.err" >&2
+  rm -f "$SERVICE_JSON_FILE.err"
+  exit 1
+fi
+rm -f "$SERVICE_JSON_FILE.err"
+
+# Helper: run a python heredoc with the service JSON path as argv[1].
+parse_service_json() {
+  python3 - "$SERVICE_JSON_FILE"
+}
+
+# ── Section 1: Service summary ──────────────────────────────────────────
+
+echo "=== Cloud Run service: $SERVICE ==="
+
+parse_service_json <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+status = data.get("status", {})
+metadata = data.get("metadata", {})
+url = status.get("url", "(none)")
+latest_ready = status.get("latestReadyRevisionName", "(none)")
+latest_created = status.get("latestCreatedRevisionName", "(none)")
+namespace = metadata.get("namespace", "(unknown)")
+location = metadata.get("labels", {}).get("cloud.googleapis.com/location", "(unknown)")
+print(f"Project:              {namespace}")
+print(f"Region:               {location}")
+print(f"URL:                  {url}")
+print(f"Latest READY:         {latest_ready}")
+print(f"Latest CREATED:       {latest_created}")
+if latest_ready != latest_created:
+    print(f"  WARN latest-created differs from latest-ready — newest revision is not yet ready")
+PY
+
+# ── Section 2: Traffic split ────────────────────────────────────────────
+
+echo ""
+echo "=== Traffic split ==="
+
+parse_service_json <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+status = data.get("status", {})
+latest_ready = status.get("latestReadyRevisionName", "")
+traffic = status.get("traffic", [])
+if not traffic:
+    print("(no traffic entries returned)")
+else:
+    for entry in traffic:
+        pct = entry.get("percent", 0)
+        rev = entry.get("revisionName") or entry.get("latestRevision", "(latest)")
+        if entry.get("latestRevision"):
+            rev = f"{rev} (= latestRevision flag)"
+        marker = ""
+        if latest_ready and entry.get("revisionName") and entry.get("revisionName") != latest_ready:
+            marker = f"   <- STALE (latest-ready is {latest_ready})"
+        print(f"{pct:>3}% -> {rev}{marker}")
+PY
+
+# ── Section 3: Currently-serving image ──────────────────────────────────
+
+echo ""
+echo "=== Currently-serving image ==="
+
+parse_service_json <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+spec = data.get("spec", {}).get("template", {}).get("spec", {})
+containers = spec.get("containers", [])
+if not containers:
+    print("(no containers in template spec)")
+else:
+    for i, c in enumerate(containers):
+        image = c.get("image", "(unknown)")
+        marker = ""
+        if "cloudrun/container/hello" in image:
+            marker = "   <- PLACEHOLDER (Step 5.8 pre-create not yet replaced)"
+        prefix = "Image:                " if i == 0 else f"Image[{i}]:             "
+        print(f"{prefix}{image}{marker}")
+PY
+
+# ── Section 4: Latest revision conditions ───────────────────────────────
+
+echo ""
+echo "=== Latest revision conditions ==="
+
+LATEST_READY="$(parse_service_json <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data.get("status", {}).get("latestReadyRevisionName", ""))
+PY
+)"
+
+if [[ -n "$LATEST_READY" ]]; then
+  echo "$LATEST_READY:"
+  REV_JSON_FILE="$(mktemp -t diagnose-cloudrun-rev-XXXXXX)"
+  if gcloud run revisions describe "$LATEST_READY" \
+    --region="$REGION" \
+    --project="$PROJECT" \
+    --format=json > "$REV_JSON_FILE" 2>"$REV_JSON_FILE.err"; then
+    python3 - "$REV_JSON_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+conditions = data.get("status", {}).get("conditions", [])
+if not conditions:
+    print("  (no conditions reported)")
+else:
+    for c in conditions:
+        ctype = c.get("type", "?")
+        cstatus = c.get("status", "?")
+        cmsg = c.get("message", "")
+        line = f"  {ctype}: {cstatus}"
+        if cmsg:
+            line += f"  ({cmsg})"
+        print(line)
+PY
+  else
+    echo "  (could not describe revision: $(cat "$REV_JSON_FILE.err"))"
+  fi
+  rm -f "$REV_JSON_FILE.err"
+else
+  echo "(no latest-ready revision)"
+fi
+
+# ── Section 5: Last 50 log lines ────────────────────────────────────────
+
+echo ""
+echo "=== Last 50 log lines ==="
+
+# `gcloud logging read --order=desc` gives newest-first; reverse with awk
+# (portable across macOS/Linux — `tac` is GNU-only, `tail -r` is BSD-only).
+if ! gcloud logging read \
+  "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE" \
+  --project="$PROJECT" \
+  --limit=50 \
+  --order=desc \
+  --format='value(timestamp,severity,textPayload)' 2>/dev/null \
+  | awk '{ a[NR] = $0 } END { for (i = NR; i >= 1; i--) print a[i] }'; then
+  echo "(could not read logs)"
+fi
+
+echo ""
+echo "=== End of diagnostic ==="

--- a/scripts/diagnose-cloudrun.test.sh
+++ b/scripts/diagnose-cloudrun.test.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# Tests for diagnose-cloudrun.sh — the one-shot Cloud Run diagnostic.
+#
+# The harness stubs `gcloud` so each test fixes a synthetic service
+# and revision JSON shape, then asserts that the expected sections
+# render and that traps (missing project, placeholder image, stale
+# traffic, mismatched latest-ready/latest-created) are surfaced.
+#
+# Run: ./scripts/diagnose-cloudrun.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/diagnose-cloudrun.sh"
+
+new_tmp() { mktemp -d -t diagcrtest-XXXX; }
+
+# Stub builder. Writes a `gcloud` shim that:
+#   - For `run services describe`, prints the contents of $tmp/service.json
+#   - For `run revisions describe`, prints the contents of $tmp/revision.json
+#   - For `logging read`, prints synthetic log lines
+#   - Logs every call to $tmp/gcloud.log
+make_gcloud_stub() {
+  local tmp="$1"
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/gcloud" <<EOF
+#!/usr/bin/env bash
+echo "gcloud \$*" >> "$tmp/gcloud.log"
+case "\$1 \$2" in
+  "run services")
+    if [[ "\$3" == "describe" ]]; then
+      cat "$tmp/service.json"
+      exit 0
+    fi
+    ;;
+  "run revisions")
+    if [[ "\$3" == "describe" ]]; then
+      cat "$tmp/revision.json"
+      exit 0
+    fi
+    ;;
+  "logging read")
+    cat <<LOGS
+2026-04-29T20:14:02Z INFO Uvicorn running on http://0.0.0.0:8080
+2026-04-29T20:14:03Z ERROR psycopg.errors.UndefinedTable: relation "todo" does not exist
+LOGS
+    exit 0
+    ;;
+esac
+exit 1
+EOF
+  chmod +x "$tmp/bin/gcloud"
+}
+
+assert_contains() {
+  local needle="$1" haystack_file="$2" label="$3"
+  if grep -qF "$needle" "$haystack_file"; then
+    echo -e "  ${GREEN}OK${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $label  (expected to contain: $needle)"
+    cat "$haystack_file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1" haystack_file="$2" label="$3"
+  if ! grep -qF "$needle" "$haystack_file"; then
+    echo -e "  ${GREEN}OK${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $label  (should NOT contain: $needle)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}OK${NC} $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $label  (expected: $expected; got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Test 1: missing project → exit 2 with clear error ───────────────────
+
+echo ""
+echo "Test 1: no --project and no GCP_PROJECT_ID env → exit 2"
+
+T1=$(new_tmp)
+make_gcloud_stub "$T1"
+
+set +e
+PATH="$T1/bin:$PATH" \
+  GCP_PROJECT_ID="" \
+  bash "$SCRIPT" > "$T1/stdout.log" 2> "$T1/stderr.log"
+ec=$?
+set -e
+
+assert_eq "2" "$ec" "exit 2 when project unset"
+assert_contains "project is required" "$T1/stderr.log" "stderr names the missing input"
+assert_contains "Refusing to fall back" "$T1/stderr.log" "explains why no implicit fallback"
+
+# Verify gcloud was never called.
+gh_call_count=0
+if [[ -f "$T1/gcloud.log" ]]; then
+  gh_call_count="$(grep -c '.' "$T1/gcloud.log" 2>/dev/null || true)"
+fi
+assert_eq "0" "$gh_call_count" "no gcloud calls before pre-flight failure"
+
+# ── Test 2: full happy path → all 5 sections render ─────────────────────
+
+echo ""
+echo "Test 2: happy path with synthetic service JSON renders all sections"
+
+T2=$(new_tmp)
+make_gcloud_stub "$T2"
+
+cat > "$T2/service.json" <<'JSON'
+{
+  "metadata": {
+    "namespace": "af-test-2026-05x",
+    "labels": {"cloud.googleapis.com/location": "us-central1"}
+  },
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {"image": "us-central1-docker.pkg.dev/af-test/agile-flow/app:abc1234"}
+        ]
+      }
+    }
+  },
+  "status": {
+    "url": "https://agile-flow-app-xxx-uc.a.run.app",
+    "latestReadyRevisionName": "agile-flow-app-00005-abc",
+    "latestCreatedRevisionName": "agile-flow-app-00005-abc",
+    "traffic": [
+      {"percent": 100, "revisionName": "agile-flow-app-00005-abc"}
+    ]
+  }
+}
+JSON
+
+cat > "$T2/revision.json" <<'JSON'
+{
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "True"},
+      {"type": "Active", "status": "True"},
+      {"type": "ContainerHealthy", "status": "True"}
+    ]
+  }
+}
+JSON
+
+set +e
+PATH="$T2/bin:$PATH" \
+  bash "$SCRIPT" --project=af-test-2026-05x > "$T2/stdout.log" 2> "$T2/stderr.log"
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 on happy path"
+assert_contains "=== Cloud Run service: agile-flow-app ===" "$T2/stdout.log" "section 1 header"
+assert_contains "=== Traffic split ===" "$T2/stdout.log" "section 2 header"
+assert_contains "=== Currently-serving image ===" "$T2/stdout.log" "section 3 header"
+assert_contains "=== Latest revision conditions ===" "$T2/stdout.log" "section 4 header"
+assert_contains "=== Last 50 log lines ===" "$T2/stdout.log" "section 5 header"
+assert_contains "=== End of diagnostic ===" "$T2/stdout.log" "footer marker"
+
+# Section 1 fields
+assert_contains "URL:                  https://agile-flow-app-xxx-uc.a.run.app" "$T2/stdout.log" "URL line"
+assert_contains "Latest READY:         agile-flow-app-00005-abc" "$T2/stdout.log" "latest-ready line"
+
+# Section 2: 100% traffic, no STALE marker (latest-ready matches)
+assert_contains "100% -> agile-flow-app-00005-abc" "$T2/stdout.log" "traffic 100% to current"
+assert_not_contains "STALE" "$T2/stdout.log" "no STALE marker when traffic matches latest-ready"
+
+# Section 3: real image, no PLACEHOLDER marker
+assert_contains "us-central1-docker.pkg.dev/af-test/agile-flow/app:abc1234" "$T2/stdout.log" "real image rendered"
+assert_not_contains "PLACEHOLDER" "$T2/stdout.log" "no PLACEHOLDER marker for real image"
+
+# Section 4: revision conditions
+assert_contains "Ready: True" "$T2/stdout.log" "Ready condition"
+assert_contains "ContainerHealthy: True" "$T2/stdout.log" "ContainerHealthy condition"
+
+# Section 5: log lines (most-recent-last via `tac`)
+assert_contains "Uvicorn running" "$T2/stdout.log" "log line: Uvicorn"
+assert_contains "UndefinedTable" "$T2/stdout.log" "log line: error"
+
+# ── Test 3: stale traffic + placeholder image → both markers fire ───────
+
+echo ""
+echo "Test 3: stale traffic + placeholder image → STALE and PLACEHOLDER markers"
+
+T3=$(new_tmp)
+make_gcloud_stub "$T3"
+
+cat > "$T3/service.json" <<'JSON'
+{
+  "metadata": {
+    "namespace": "af-test-2026-05x",
+    "labels": {"cloud.googleapis.com/location": "us-central1"}
+  },
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {"image": "us-docker.pkg.dev/cloudrun/container/hello"}
+        ]
+      }
+    }
+  },
+  "status": {
+    "url": "https://agile-flow-app-xxx-uc.a.run.app",
+    "latestReadyRevisionName": "agile-flow-app-00005-abc",
+    "latestCreatedRevisionName": "agile-flow-app-00005-abc",
+    "traffic": [
+      {"percent": 100, "revisionName": "agile-flow-app-00001-q7w"}
+    ]
+  }
+}
+JSON
+
+cat > "$T3/revision.json" <<'JSON'
+{"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+JSON
+
+set +e
+PATH="$T3/bin:$PATH" \
+  bash "$SCRIPT" --project=af-test-2026-05x > "$T3/stdout.log" 2> "$T3/stderr.log"
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "STALE" "$T3/stdout.log" "STALE marker on traffic going to non-latest-ready revision"
+assert_contains "latest-ready is agile-flow-app-00005-abc" "$T3/stdout.log" "STALE marker names latest-ready"
+assert_contains "PLACEHOLDER" "$T3/stdout.log" "PLACEHOLDER marker on cloudrun/container/hello image"
+
+# ── Test 4: latest-created != latest-ready → WARN line fires ────────────
+
+echo ""
+echo "Test 4: latest-created != latest-ready → WARN line"
+
+T4=$(new_tmp)
+make_gcloud_stub "$T4"
+
+cat > "$T4/service.json" <<'JSON'
+{
+  "metadata": {"namespace": "p", "labels": {"cloud.googleapis.com/location": "us-central1"}},
+  "spec": {"template": {"spec": {"containers": [{"image": "img:tag"}]}}},
+  "status": {
+    "url": "https://x",
+    "latestReadyRevisionName": "rev-00004",
+    "latestCreatedRevisionName": "rev-00005",
+    "traffic": [{"percent": 100, "revisionName": "rev-00004"}]
+  }
+}
+JSON
+
+cat > "$T4/revision.json" <<'JSON'
+{"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+JSON
+
+set +e
+PATH="$T4/bin:$PATH" \
+  bash "$SCRIPT" --project=p > "$T4/stdout.log" 2> "$T4/stderr.log"
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "WARN latest-created differs from latest-ready" "$T4/stdout.log" "WARN line on latest-ready/created mismatch"
+assert_contains "Latest CREATED:       rev-00005" "$T4/stdout.log" "latest-created shown"
+assert_contains "Latest READY:         rev-00004" "$T4/stdout.log" "latest-ready shown"
+
+# ── Test 5: bad arg → exit 2, suggest --help ────────────────────────────
+
+echo ""
+echo "Test 5: unknown argument → exit 2"
+
+T5=$(new_tmp)
+make_gcloud_stub "$T5"
+
+set +e
+PATH="$T5/bin:$PATH" \
+  bash "$SCRIPT" --bogus > "$T5/stdout.log" 2> "$T5/stderr.log"
+ec=$?
+set -e
+
+assert_eq "2" "$ec" "exit 2 on unknown arg"
+assert_contains "unknown argument: --bogus" "$T5/stderr.log" "names the bad arg"
+# Use grep -F via the helper which already handles `--` poorly; switch to a
+# substring grep that tolerates the `--help` literal.
+if grep -qE -- "--help" "$T5/stderr.log"; then
+  echo -e "  ${GREEN}OK${NC} points at --help"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC} points at --help"
+  cat "$T5/stderr.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 6: --help exits 0 with usage info ──────────────────────────────
+
+echo ""
+echo "Test 6: --help renders usage and exits 0"
+
+T6=$(new_tmp)
+make_gcloud_stub "$T6"
+
+set +e
+bash "$SCRIPT" --help > "$T6/stdout.log" 2> "$T6/stderr.log"
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 on --help"
+assert_contains "Usage:" "$T6/stdout.log" "--help shows Usage"
+assert_contains "GCP_PROJECT_ID" "$T6/stdout.log" "--help mentions required env"
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #64. New read-only `scripts/diagnose-cloudrun.sh` that prints a 5-section diagnostic snapshot of a Cloud Run service in one go. Designed for the "paste into a help channel and let someone else diagnose" workflow workshop participants will need.

## Why

The 2026-04-29 dry-run on `tck517/tck517-app` cracked its incident with a hand-composed `gcloud run services describe --format='value(status.traffic,...)'` query. Workshop participants will hit similar Cloud Run weirdness — placeholder revisions, drifting traffic splits, env/secret type collisions — and a single command that prints the diagnostic snapshot converts most incidents from an investigation into a glance.

## What the script does

| Section | Contents |
|---|---|
| 1. Service summary | URL, latest-ready revision, latest-created revision, project, region. WARN line when latest-created != latest-ready. |
| 2. Traffic split | percent → revisionName per traffic entry. **STALE marker** when traffic goes to a non-latest-ready revision (the §A trap from the dry-run). |
| 3. Currently-serving image | image ref of each container in the template spec. **PLACEHOLDER marker** when `cloudrun/container/hello` is still serving (Step 5.8 pre-create wasn't replaced). |
| 4. Latest revision conditions | Ready / Active / ContainerHealthy with status + message. |
| 5. Last 50 log lines | `gcloud logging read --order=desc` reversed via portable `awk` so output reads chronologically. |

## Design notes

- **Read-only.** No `update-traffic`, no `deploy`, no `delete`. Three reads only: `gcloud run services describe`, `gcloud run revisions describe`, `gcloud logging read`.
- **Single round-trip on the service JSON.** One describe → tempfile → parsed by 4 python heredocs. Avoids brittle nested `--format=value(...)` queries that obscure what the script is doing.
- **Fails loudly on missing project.** No silent fall-back to `gcloud config get project` — that would diagnose whichever project the user happens to have selected, which is exactly the kind of trap this script exists to prevent.
- **Portable across macOS/Linux.** Uses `awk` to reverse log order (newest → chronological); `tac` is GNU-only and `tail -r` is BSD-only — caught by the local test run on macOS before push.

## Tests

New `scripts/diagnose-cloudrun.test.sh` — 6 tests / 35 assertions:

| Test | Coverage |
|---|---|
| 1 | Missing project → exit 2, error names the missing input, no `gcloud` calls before pre-flight |
| 2 | Happy path → all 5 section headers render, real fields populate, no false-positive STALE/PLACEHOLDER markers |
| 3 | Stale traffic + placeholder image → STALE marker names latest-ready, PLACEHOLDER marker fires |
| 4 | latest-created != latest-ready → WARN line in section 1 |
| 5 | Unknown argument → exit 2, points at `--help` |
| 6 | `--help` → exit 0 with Usage info |

| Suite | Before | After |
|---|---|---|
| `provision-gcp-project.test.sh` | 93 | 93 |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` | 8 | 8 |
| `diagnose-cloudrun.test.sh` (new) | 0 | **35** |
| **Total** | **172** | **207** |

shellcheck clean. pytest 17/17 green.

## Docs

`docs/PLATFORM-GUIDE.md` `Daily Operations` section gets a new `Troubleshooting Cloud Run` subsection between Viewing Logs and Rolling Back, pointing facilitators at the script.

## Test plan

- [ ] CI green
- [ ] After merge: run on a fresh fork's project to confirm output renders without errors. Bonus: re-run the 2026-04-29 incident scenario (deploy a revision but don't migrate traffic) and confirm STALE marker fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)