### PR TITLE
fix(deploy): replace --traffic=latest=100 with update-traffic --to-latest follow-up step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,15 +123,18 @@ jobs:
           # does — the asymmetry is easy to miss). Without this flag,
           # Cloud Run uses the legacy Compute Engine default SA at runtime,
           # which has none of the roles we provisioned (e.g. secretAccessor).
-          # --traffic=latest=100 routes all production traffic to the new
-          # revision after deploy. Without it, deploy-cloudrun@v2 leaves the
-          # existing traffic split intact — fine when traffic was already
-          # 100% to the previous latest, but a silent trap when the service
-          # was pre-created with a placeholder revision (Step 5.8 in the
-          # provisioner) that gcloud pinned 100% to. Without this flag, every
-          # deploy after the first leaves the placeholder serving traffic
-          # while the new revision sits at 0%. Symptom: green CI, service URL
-          # serves "Hello from Cloud Run!" forever. See #61.
+          # Traffic shift to the new revision happens in the follow-up
+          # step (Route traffic to latest revision) via
+          # `gcloud run services update-traffic --to-latest`. `gcloud
+          # run deploy` does NOT accept --traffic; passing it here fails
+          # the deploy with `unrecognized arguments: --traffic`. Without
+          # an explicit shift, deploy-cloudrun@v2 leaves the existing
+          # split intact — fine when traffic was already 100% to the
+          # previous latest, but a silent trap when the service was
+          # pre-created with a placeholder revision (Step 5.8 in the
+          # provisioner) that gcloud pinned 100% to. Symptom of getting
+          # this wrong: green CI, service URL serves "Hello from Cloud
+          # Run!" forever. See #61 / #76.
           flags: |
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }}
             --port=8080
@@ -140,7 +143,6 @@ jobs:
             --min-instances=0
             --max-instances=10
             --allow-unauthenticated
-            --traffic=latest=100
           # DATABASE_URL is set as a plain env var (not a Secret Manager
           # mount) so production and preview agree on the env-var TYPE. The
           # two workflows target the same Cloud Run service; Cloud Run
@@ -158,6 +160,19 @@ jobs:
           env_vars: |
             ENVIRONMENT=production
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
+
+      - name: Route traffic to latest revision
+        if: steps.check_secrets.outputs.skip != 'true'
+        run: |
+          # Migrate 100% of traffic to the just-deployed revision.
+          # Idempotent — when traffic is already on latest, this is a
+          # no-op. Required because the provisioner's Step 5.8 pre-creates
+          # the service with a placeholder revision pinned at 100%, and
+          # `gcloud run deploy` doesn't migrate traffic away from an
+          # existing pin. See #61 / #76.
+          gcloud run services update-traffic "${{ env.SERVICE_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --to-latest
 
       - name: Show deployed URL
         if: steps.check_secrets.outputs.skip != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,13 @@ jobs:
             DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
 
       - name: Route traffic to latest revision
-        if: steps.check_secrets.outputs.skip != 'true'
+        # success() gates on all prior steps succeeding — without it,
+        # GH Actions evaluates ONLY the listed condition and runs this
+        # step even when the deploy failed (default failure-skip is
+        # bypassed when ANY `if:` is present). Migrating traffic to a
+        # half-deployed or unhealthy revision would turn a recoverable
+        # deploy failure into a production outage. See #79 review.
+        if: steps.check_secrets.outputs.skip != 'true' && success()
         run: |
           # Migrate 100% of traffic to the just-deployed revision.
           # Idempotent — when traffic is already on latest, this is a

--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -1079,9 +1079,13 @@ revision. But once *any* explicit traffic split exists on the service,
 deploys preserve that split — even when the latest revision is
 healthier than what's currently serving.
 
-**Pattern:** When a deploy is meant to shift production to the new
-revision, pass `--traffic=latest=100` (or run
-`gcloud run services update-traffic --to-latest` post-deploy):
+**Pattern:** Use the canonical two-step pattern: deploy the revision,
+then run `gcloud run services update-traffic --to-latest` as a
+follow-up step. **`gcloud run deploy` does NOT accept `--traffic`** —
+the only traffic-related flags on `deploy` are `--no-traffic` and
+`--tag`. Passing `--traffic=latest=100` to `deploy-cloudrun@v2` (which
+forwards `flags:` verbatim to `gcloud run deploy`) fails with
+`unrecognized arguments: --traffic`.
 
 ```yaml
 # In .github/workflows/deploy.yml
@@ -1091,23 +1095,31 @@ revision, pass `--traffic=latest=100` (or run
     service: agile-flow-app
     image: ${{ env.IMAGE }}
     region: us-central1
-    flags: --traffic=latest=100
+    # Note: no --traffic flag here. `gcloud run deploy` rejects it.
+
+- name: Route traffic to latest revision
+  run: |
+    gcloud run services update-traffic agile-flow-app \
+      --region=us-central1 \
+      --to-latest
 ```
 
-```bash
-# Or post-deploy, equivalent end state:
-gcloud run services update-traffic agile-flow-app \
-  --region=us-central1 \
-  --to-latest
-```
+`update-traffic --to-latest` is idempotent: when traffic is already on
+latest, it's a no-op. So the follow-up step is safe to run on every
+deploy without conditional logic.
 
 Preview revisions intentionally remain `--no-traffic --tag=pr-N` and
-are unaffected — the flag only applies to the production deploy job.
+are unaffected — only the production deploy job needs the traffic
+shift.
 
 Surfaced in the 2026-04-29 dry-run on a fresh fork: the placeholder
 service from Step 5.8 of the provision script absorbed 100% of
 traffic; six green CI runs later, the URL was still serving "Hello
-from Cloud Run!". Fixed in #66.
+from Cloud Run!". First fix attempt in #66 used `--traffic=latest=100`
+on the deploy step, which appeared to work in code review but never
+ran end-to-end; the 2026-04-30 dry-run on a fresh fork surfaced that
+the flag is invalid on `gcloud run deploy`. Replaced with the
+two-step pattern in #76.
 
 ---
 
@@ -1156,10 +1168,11 @@ inject the per-PR Neon branch URL).
     service: agile-flow-app
     image: ${{ env.IMAGE }}
     region: us-central1
-    flags: --traffic=latest=100
     env_vars: |
       ENVIRONMENT=production
       DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
+# (Production traffic shift to the new revision happens in a separate
+# `gcloud run services update-traffic --to-latest` step — see Pattern #31.)
 ```
 
 ```yaml

--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -1171,9 +1171,10 @@ inject the per-PR Neon branch URL).
     env_vars: |
       ENVIRONMENT=production
       DATABASE_URL=${{ secrets.PRODUCTION_DATABASE_URL }}
-# (Production traffic shift to the new revision happens in a separate
-# `gcloud run services update-traffic --to-latest` step — see Pattern #31.)
 ```
+
+Production traffic shift to the new revision happens in a separate
+`gcloud run services update-traffic --to-latest` step — see Pattern #31.
 
 ```yaml
 # .github/workflows/preview-deploy.yml — preview


### PR DESCRIPTION
## Summary

Closes #76. Drops `--traffic=latest=100` from the `deploy-cloudrun@v2` `flags:` block (which is not a valid `gcloud run deploy` flag) and replaces it with a follow-up `gcloud run services update-traffic --to-latest` step. Also updates PATTERN-LIBRARY pattern #31 in the same PR to reflect the corrected shape.

## Why

Every fresh fork's first production deploy was failing with:

```
Error: google-github-actions/deploy-cloudrun failed with: failed to deploy:
ERROR: (gcloud.run.deploy) unrecognized arguments:
  --traffic (did you mean '--no-traffic'?)
  latest=100
```

`gcloud run deploy` accepts `--no-traffic` and `--tag`, but not `--traffic`. The latter is valid on `gcloud run services update-traffic`, which is a different command. The intent (override the placeholder revision pinned at 100% by Step 5.8 of the provisioner) is correct; the implementation reached for an API that doesn't exist on the command being invoked.

Surfaced 2026-04-30 dry-run on `tck517/tck517-app` first push to main.

## What changed

| File | Change |
|---|---|
| `.github/workflows/deploy.yml` | Drop `--traffic=latest=100` from line 143; add `Route traffic to latest revision` step after `Deploy to Cloud Run`; rewrite the surrounding inline comment to describe the two-step pattern. |
| `docs/PATTERN-LIBRARY.md` Pattern #31 | YAML example now shows the corrected shape (deploy step without `--traffic`, followed by `update-traffic --to-latest`). Surfacing-history note appended explaining why the first-attempt #66 fix failed and how #76 corrected it. |
| `docs/PATTERN-LIBRARY.md` Pattern #32 | Removed leftover `--traffic=latest=100` from the env-var example (pattern #32 isn't about traffic; the line was unnecessary noise). Added a one-line cross-reference to #31. |

## Why pattern #31 needed updating in this PR

Pattern #31 was added in #75 and taught the same wrong shape. **My review on #75 approved the doc against the inline comment in `deploy.yml` without ever running the deploy end-to-end.** The 2026-04-30 dry-run was the first time this code path was exercised against a real fresh fork — exactly the failure mode I wrote into memory yesterday ("feature-complete requires a dry-run, not just merged-PR coverage"). Shipping the doc fix in the same PR as the code fix avoids leaving the wrong recommendation in the canonical pattern library.

## Tests

- `pytest` 17/17 green (no app-side changes)
- `markdownlint` clean
- shellcheck not applicable (workflow YAML, not shell)
- Workflow YAML changes are validated end-to-end by post-merge dry-run, per existing project convention

## Verification post-merge

- [ ] CI green on this PR
- [ ] After merge: re-run the 2026-04-30 dry-run scenario (provision a fresh project, push to main). Confirm `deploy.yml` succeeds end-to-end.
- [ ] Confirm `gcloud run services describe SERVICE` shows the new revision at `percent: 100`, not the placeholder.
- [ ] Confirm the URL serves the deployed app, not "Hello from Cloud Run!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)