### PR TITLE
fix(scripts): activate pre-push hook in provisioner; doctor fail on dormant hook

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,8 +57,14 @@ Now clone it locally:
 cd ~/projects   # or wherever you keep repos
 git clone https://github.com/your-name/my-app.git
 cd my-app
+git config --local core.hooksPath scripts/hooks
 npm install
 ```
+
+The `git config` line activates the pre-push quality gate. Without it,
+broken code can reach `main` and trigger a failing production deploy.
+The setting is per-clone, not stored in the repo, so every fresh clone
+needs this command once.
 
 **You should see:** Dependencies installed with no errors.
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -241,12 +241,16 @@ else
     fail "Git Config" "user.email not set" "git config --global user.email \"you@example.com\""
 fi
 
-# core.hooksPath (WARN)
+# core.hooksPath (FAIL when the hook file exists — pre-push gate dormant)
 hooks_path=$(git config --local core.hooksPath 2>/dev/null || true)
 if [ "$hooks_path" = "scripts/hooks" ]; then
     pass "Git Config" "core.hooksPath set to scripts/hooks"
+elif [ -f "scripts/hooks/pre-push" ]; then
+    # Hook exists but is dormant — quality gate is not running. See #77.
+    fail "Git Config" "core.hooksPath is '${hooks_path:-unset}'; pre-push hook is dormant" "git config --local core.hooksPath scripts/hooks"
 else
-    warn "Git Config" "core.hooksPath is '${hooks_path:-unset}' (expected scripts/hooks)" "git config --local core.hooksPath scripts/hooks"
+    # No hook file in repo — nothing to activate. Just note it.
+    warn "Git Config" "core.hooksPath is '${hooks_path:-unset}' (no scripts/hooks/pre-push present)" "git config --local core.hooksPath scripts/hooks"
 fi
 
 # pre-push exists + executable (WARN)

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -141,6 +141,30 @@ retry_eventual_consistency() {
   return 1
 }
 
+# ── Step 0: Activate the in-repo pre-push hook ──────────────────────────
+#
+# `core.hooksPath` is per-clone, not versioned with the repo. Without
+# this, the working pre-push hook at `scripts/hooks/pre-push` is dormant
+# on every fresh clone — `git push` skips lint and tests silently. The
+# CLAUDE.md rule "Never use `git push --no-verify`" is unenforceable
+# when there is no hook to skip.
+#
+# Run this BEFORE arg-parsing, input validation, and any GCP call so
+# that a partial run — including the most common day-1 failure path,
+# `provision-gcp-project.sh` invoked without GCP_PROJECT_ID set — still
+# leaves the quality gate active. Idempotent: no-op when already set.
+# Uses --local so a user's global hooksPath (e.g. for husky) is
+# overridden only inside this repo. See #77.
+
+if [[ -d .git ]] && [[ -f scripts/hooks/pre-push ]]; then
+  current_hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
+  if [[ "$current_hooks_path" != "scripts/hooks" ]]; then
+    git config --local core.hooksPath scripts/hooks
+    echo "[hook] Activated pre-push hook (lint + tests will run before every push)"
+    echo ""
+  fi
+fi
+
 CREATE_PROJECT=false
 WITH_SA_KEY=false
 
@@ -171,28 +195,6 @@ echo "  Repo:     $ARTIFACT_REPO"
 echo "  Create:   $CREATE_PROJECT"
 echo "  SA key:   $WITH_SA_KEY"
 echo ""
-
-# ── Step 0: Activate the in-repo pre-push hook ──────────────────────────
-#
-# `core.hooksPath` is per-clone, not versioned with the repo. Without
-# this, the working pre-push hook at `scripts/hooks/pre-push` is dormant
-# on every fresh clone — `git push` skips lint and tests silently. The
-# CLAUDE.md rule "Never use `git push --no-verify`" is unenforceable
-# when there is no hook to skip.
-#
-# Run this BEFORE any failable GCP call so even a partial provisioner
-# run leaves the quality gate active. Idempotent: no-op when already
-# set. Uses --local so a user's global hooksPath (e.g. for husky) is
-# overridden only inside this repo. See #77.
-
-if [[ -d .git ]] && [[ -f scripts/hooks/pre-push ]]; then
-  current_hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
-  if [[ "$current_hooks_path" != "scripts/hooks" ]]; then
-    git config --local core.hooksPath scripts/hooks
-    echo "[hook] Activated pre-push hook (lint + tests will run before every push)"
-    echo ""
-  fi
-fi
 
 # ── Step 1: Create project (optional) ────────────────────────────────────
 

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -172,6 +172,28 @@ echo "  Create:   $CREATE_PROJECT"
 echo "  SA key:   $WITH_SA_KEY"
 echo ""
 
+# ── Step 0: Activate the in-repo pre-push hook ──────────────────────────
+#
+# `core.hooksPath` is per-clone, not versioned with the repo. Without
+# this, the working pre-push hook at `scripts/hooks/pre-push` is dormant
+# on every fresh clone — `git push` skips lint and tests silently. The
+# CLAUDE.md rule "Never use `git push --no-verify`" is unenforceable
+# when there is no hook to skip.
+#
+# Run this BEFORE any failable GCP call so even a partial provisioner
+# run leaves the quality gate active. Idempotent: no-op when already
+# set. Uses --local so a user's global hooksPath (e.g. for husky) is
+# overridden only inside this repo. See #77.
+
+if [[ -d .git ]] && [[ -f scripts/hooks/pre-push ]]; then
+  current_hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
+  if [[ "$current_hooks_path" != "scripts/hooks" ]]; then
+    git config --local core.hooksPath scripts/hooks
+    echo "[hook] Activated pre-push hook (lint + tests will run before every push)"
+    echo ""
+  fi
+fi
+
 # ── Step 1: Create project (optional) ────────────────────────────────────
 
 if [[ "$CREATE_PROJECT" == "true" ]]; then

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -2127,6 +2127,97 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 28: Step 0 activates core.hooksPath when pre-push hook exists ──
+#
+# Per #77: every fresh fork must leave the pre-push hook active after the
+# provisioner runs. core.hooksPath is per-clone and not auto-set by git
+# clone, so without this step the working hook is dormant. Run the
+# provisioner in a temp dir that simulates a fresh fork (real `.git`,
+# placeholder `scripts/hooks/pre-push`), and assert:
+#   1. After the run, `git config --local core.hooksPath` returns
+#      `scripts/hooks`
+#   2. The activation message was logged
+#   3. Re-running is a no-op (idempotent — message NOT logged again)
+#
+# We don't need the script to succeed end-to-end here. Step 0 runs
+# before any GCP call; we just need it to fire.
+
+echo ""
+echo "Test 28: Step 0 activates core.hooksPath in a fresh fork"
+
+T28=$(mktemp -d -t aflowtest-XXXX)
+
+# Build the simulated fork tree
+git init -q -b main "$T28"
+mkdir -p "$T28/scripts/hooks"
+echo '#!/usr/bin/env bash' > "$T28/scripts/hooks/pre-push"
+chmod +x "$T28/scripts/hooks/pre-push"
+
+# Stub gcloud so the script's later steps fail fast — we only care that
+# Step 0 ran. A bare `false`-returning gcloud forces an early failure
+# inside the project-create path, but Step 0 fires first.
+mkdir -p "$T28/bin"
+cat > "$T28/bin/gcloud" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$T28/bin/gcloud"
+
+# First invocation
+set +e
+PATH="$T28/bin:$PATH" GCP_PROJECT_ID="af-step0-test" \
+  bash -c "cd '$T28' && '$SCRIPT'" > "$T28/run1.log" 2>&1
+set -e
+
+# Assertion 1: hooksPath is now set in the temp repo
+hooks_path=$(git -C "$T28" config --local --get core.hooksPath 2>/dev/null || echo "(unset)")
+assert_eq "scripts/hooks" "$hooks_path" "core.hooksPath set after Step 0"
+
+# Assertion 2: activation message logged on first run
+if grep -q "\[hook\] Activated pre-push hook" "$T28/run1.log"; then
+  echo -e "  ${GREEN}✓${NC} activation message logged on first run"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[hook] Activated' message in stdout"
+  cat "$T28/run1.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Second invocation — should be a no-op (idempotent)
+set +e
+PATH="$T28/bin:$PATH" GCP_PROJECT_ID="af-step0-test" \
+  bash -c "cd '$T28' && '$SCRIPT'" > "$T28/run2.log" 2>&1
+set -e
+
+# Assertion 3: no activation message on second run (already configured)
+if ! grep -q "\[hook\] Activated pre-push hook" "$T28/run2.log"; then
+  echo -e "  ${GREEN}✓${NC} idempotent — no activation message on second run"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} activation re-fired on second run; should be no-op"
+  cat "$T28/run2.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Assertion 4: when scripts/hooks/pre-push is absent, Step 0 silently skips
+T28b=$(mktemp -d -t aflowtest-XXXX)
+git init -q -b main "$T28b"
+# Note: NO scripts/hooks/pre-push file here
+
+set +e
+PATH="$T28/bin:$PATH" GCP_PROJECT_ID="af-step0-test" \
+  bash -c "cd '$T28b' && '$SCRIPT'" > "$T28b/run.log" 2>&1
+set -e
+
+if ! grep -q "\[hook\]" "$T28b/run.log"; then
+  echo -e "  ${GREEN}✓${NC} no [hook] log when pre-push hook is absent"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} should not log [hook] activation when no hook file present"
+  cat "$T28b/run.log"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -2218,6 +2218,39 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Assertion 5: activation fires even before the GCP_PROJECT_ID required-
+# check fails. This is the regression guard for Step 0's placement —
+# without it, a future refactor that pushes Step 0 below the input
+# validation would silently break the most common day-1 failure path
+# (user runs script without setting GCP_PROJECT_ID).
+T28c=$(mktemp -d -t aflowtest-XXXX)
+git init -q -b main "$T28c"
+mkdir -p "$T28c/scripts/hooks"
+echo '#!/usr/bin/env bash' > "$T28c/scripts/hooks/pre-push"
+chmod +x "$T28c/scripts/hooks/pre-push"
+
+set +e
+# Note: NO GCP_PROJECT_ID set — script must exit 1, but Step 0 should
+# still have run.
+PATH="$T28/bin:$PATH" \
+  bash -c "cd '$T28c' && '$SCRIPT'" > "$T28c/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "script exits 1 when GCP_PROJECT_ID is unset (precondition for Assertion 5)"
+
+hooks_path=$(git -C "$T28c" config --local --get core.hooksPath 2>/dev/null || echo "(unset)")
+assert_eq "scripts/hooks" "$hooks_path" "core.hooksPath set even when GCP_PROJECT_ID is unset (Step 0 fires before input validation)"
+
+if grep -q "\[hook\] Activated pre-push hook" "$T28c/run.log"; then
+  echo -e "  ${GREEN}✓${NC} activation message logged before exit (Step 0 ran before GCP_PROJECT_ID check)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected '[hook] Activated' before the GCP_PROJECT_ID error"
+  cat "$T28c/run.log"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #77. The pre-push hook at `scripts/hooks/pre-push` was correct, but `core.hooksPath` is per-clone (not versioned with the repo) and nothing in the bootstrap path activated it. Result: every fresh fork shipped with its quality gate dormant — `git push origin main` skipped lint and tests silently.

## Why

Surfaced 2026-04-30 dry-run on `tck517/tck517-app` while pushing the #76 fix. `git push` succeeded with no "Running pre-push checks…" output; `git config --get core.hooksPath` confirmed empty. The CLAUDE.md rule "Never use `git push --no-verify`" was structurally unenforceable when there was no hook to skip.

The hook itself doesn't need changes — well-written, language-detecting, defense-in-depth-aware. Pure activation gap.

## What changed

| File | Change |
|---|---|
| `scripts/provision-gcp-project.sh` | New **Step 0** between the banner and Step 1, BEFORE any failable GCP call. Runs `git config --local core.hooksPath scripts/hooks` when `.git/` and `scripts/hooks/pre-push` both exist. Idempotent (skips when already set). Position guarantees that even a partial provisioner run (failing later on missing GCP creds) still leaves the quality gate active. |
| `scripts/doctor.sh` lines 244-253 | Split the existing single `warn` into two branches: **FAIL** when the hook file is present but `core.hooksPath` is unset (dormant gate, the case #77 cares about); **WARN** when the hook file is also absent (fork that legitimately disabled the hook). Pre-existing `pass`-when-set branch unchanged. |
| `docs/GETTING-STARTED.md` Step 1 | Adds the `git config` command immediately after `cd my-app` in the clone block, with a one-paragraph explanation. Covers users who clone but bypass the provisioner. |

## Tests

New **Test 28** in `scripts/provision-gcp-project.test.sh` (4 assertions):

- `core.hooksPath` is `scripts/hooks` after the script runs in a fresh git repo
- Activation message `[hook] Activated pre-push hook` is logged on first run
- Idempotent: no activation message on re-run when already set
- Silent skip when `scripts/hooks/pre-push` is absent (no spurious log)

The test creates a temp git repo, places a placeholder `scripts/hooks/pre-push`, runs the provisioner with a stub `gcloud` (Step 0 fires before any GCP call so the stub doesn't matter for the assertion).

| Suite | Before | After |
|---|---|---|
| `provision-gcp-project.test.sh` | 93 | **97** |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` | 8 | 8 |
| `diagnose-cloudrun.test.sh` | 35 | 35 |
| **Total** | **207** | **211** |

`pytest` 17/17 green. shellcheck clean on the three changed shell files. (One pre-existing SC2034 warning in `doctor.sh:199` is unrelated to this PR; CI excludes SC2034 via `validate-scripts.sh`.)

## Verification post-merge

- [ ] CI green on this PR
- [ ] After merge: re-run the 2026-04-30 dry-run scenario. `git config --local --get core.hooksPath` returns `scripts/hooks` after `provision-gcp-project.sh` runs.
- [ ] Make a trivial change that breaks ruff. `git push` fails with "Pre-push checks failed".
- [ ] `scripts/doctor.sh` reports the hook check as `[PASS]`. (When deliberately unset for testing: reports `[FAIL]` with the actionable command.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)