### PR TITLE
fix(app/workflow): preview deploys fail fast on missing DATABASE_URL; smoke test probes DB

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -202,21 +202,45 @@ jobs:
             exit 1
           fi
 
-          echo "Testing: $PREVIEW_URL/api/health"
+          # Phase 1: app readiness — /api/health does NOT touch the DB,
+          # so a passing probe means the container booted and is serving
+          # HTTP. Retry loop covers Cloud Run cold-start + Neon wake.
+          echo "Phase 1: $PREVIEW_URL/api/health"
 
+          health_passed=false
           for ATTEMPT in $(seq 1 10); do
             HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$PREVIEW_URL/api/health" || echo "000")
             if [ "$HTTP_STATUS" = "200" ]; then
               echo "Health check passed"
-              echo "result=passed" >> "$GITHUB_OUTPUT"
-              exit 0
+              health_passed=true
+              break
             fi
             echo "Attempt $ATTEMPT: HTTP $HTTP_STATUS, retrying in 6s..."
             sleep 6
           done
 
-          echo "result=failed" >> "$GITHUB_OUTPUT"
-          exit 1
+          if [ "$health_passed" != "true" ]; then
+            echo "::error::Container readiness probe failed after 10 attempts"
+            echo "result=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Phase 2: DB reachability — /api/health/db runs `SELECT 1`.
+          # Distinct from /api/health: catches the failure mode where
+          # the container is up but DATABASE_URL is empty/broken (added
+          # in #78 after a 2026-04-30 dry-run shipped a green-CI preview
+          # with no DB and an opaque 500 on the home route).
+          echo "Phase 2: $PREVIEW_URL/api/health/db"
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$PREVIEW_URL/api/health/db" || echo "000")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::DB health probe returned $HTTP_STATUS — DB connection or migrations may be broken"
+            echo "result=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "DB health check passed"
+          echo "result=passed" >> "$GITHUB_OUTPUT"
 
       # ── Comment on the PR with preview info ───────────────────────────
 

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,13 +1,26 @@
-"""Health check endpoint.
+"""Health check endpoints.
 
-Cloud Run uses this for container readiness checks. The preview-deploy
-workflow also hits this as the smoke test.
+`/api/health` — fast probe used by Cloud Run readiness checks. Does NOT
+touch the database (Neon cold-wake on every probe is expensive).
+
+`/api/health/db` — DB-backed probe used by the preview-deploy smoke test
+to verify the deploy actually has a working database connection. Added
+in #78 because preview deploys without Neon configured were passing
+the no-DB `/api/health` probe and shipping a broken URL.
 """
 
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.db import get_session
 
 router = APIRouter()
+
+SessionDep = Annotated[Session, Depends(get_session)]
 
 
 @router.get("/api/health")
@@ -17,4 +30,19 @@ async def health() -> JSONResponse:
     Deliberately does NOT touch the database — health checks must be
     fast and not wake up the Neon compute endpoint on every probe.
     """
+    return JSONResponse({"status": "ok"})
+
+
+@router.get("/api/health/db")
+def health_db(session: SessionDep) -> JSONResponse:
+    """Single-query DB probe — `SELECT 1`.
+
+    Used by preview-deploy.yml to validate that the deployed revision
+    can reach the database. Cheap (single round-trip, no schema), but
+    distinct from `/api/health`: a revision with `DATABASE_URL=""` or
+    a misconfigured Neon branch fails this and passes `/api/health`.
+    Uses SQLAlchemy's `session.execute(text(...))` because SQLModel's
+    typed `session.exec()` only accepts SQLModel statements.
+    """
+    session.execute(text("SELECT 1"))
     return JSONResponse({"status": "ok"})

--- a/app/config.py
+++ b/app/config.py
@@ -35,26 +35,31 @@ class Settings(BaseSettings):
         return v
 
     @model_validator(mode="after")
-    def _refuse_sqlite_in_production(self) -> Self:
+    def _refuse_sqlite_outside_dev(self) -> Self:
         # Defense-in-depth: the dev-default sqlite URL must never reach
-        # a production runtime. If the secret-mounted DATABASE_URL is
-        # missing or the mount didn't override the default, fail at
-        # startup with a clear message rather than 500ing on the first
-        # DB query with `no such table: todo`. See #63 / #71.
-        if self.environment != "production":
+        # any non-dev runtime (production, preview, staging). If
+        # DATABASE_URL is missing or doesn't override the default, fail
+        # at startup with a clear message rather than 500ing on the
+        # first DB query with `no such table: todo`. Originally only
+        # gated `production`; #78 generalized after a 2026-04-30 dry-run
+        # showed previews silently fell through to SQLite when Neon was
+        # unconfigured. See #63 / #71 / #78.
+        if self.environment in ("development", "test"):
             return self
         if not self.database_url:
             raise ValueError(
-                "DATABASE_URL is empty in production. "
-                "Check that the Secret Manager secret 'database-url' is "
-                "mounted in deploy.yml and the Cloud Run service has "
-                "secretAccessor on it."
+                f"DATABASE_URL is empty in {self.environment}. "
+                "Check that DATABASE_URL is set on the Cloud Run revision "
+                "(production reads from PRODUCTION_DATABASE_URL secret; "
+                "preview reads from the Neon branch action output)."
             )
         if self.database_url.startswith("sqlite"):
             raise ValueError(
-                f"DATABASE_URL is SQLite in production: {self.database_url!r}. "
-                "Production must use Postgres. Likely cause: the secret-mounted "
-                "DATABASE_URL env var didn't override the dev default."
+                f"DATABASE_URL is SQLite in {self.environment}: {self.database_url!r}. "
+                "Non-dev environments must use Postgres. Likely cause: the "
+                "DATABASE_URL env var didn't override the dev default — for "
+                "previews, NEON_API_KEY may be unconfigured so the Neon branch "
+                "step was skipped."
             )
         return self
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,3 +98,54 @@ def test_production_postgres_url_passes(monkeypatch: pytest.MonkeyPatch) -> None
 
     settings = Settings()
     assert settings.database_url == "postgresql+psycopg://u:p@h.neon.tech/db"
+
+
+def test_preview_sqlite_database_url_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The 2026-04-30 dry-run failure mode: Neon unconfigured, preview
+    # falls through to the dev-default `sqlite:///./dev.db`, app boots
+    # and 500s on the first DB query. The validator must catch this
+    # before the container starts, with the same loudness as production.
+    monkeypatch.setenv("ENVIRONMENT", "preview")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./dev.db")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="DATABASE_URL is SQLite in preview"):
+        Settings()
+
+
+def test_preview_postgres_url_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Happy path for preview: Neon branch URL flows through field
+    # validator psycopg3 normalization and is accepted by the model
+    # validator. Confirms #78 didn't accidentally break the preview
+    # happy path while widening the gate.
+    monkeypatch.setenv("ENVIRONMENT", "preview")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h.neon.tech/preview-pr-1")
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.database_url == "postgresql+psycopg://u:p@h.neon.tech/preview-pr-1"
+
+
+def test_unfamiliar_environment_treated_as_non_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Future-proofing: any environment name that isn't "development" or
+    # "test" is treated as a non-dev runtime. A staging deploy with
+    # ENVIRONMENT=staging gets the same SQLite refusal as production.
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="DATABASE_URL is SQLite in staging"):
+        Settings()
+
+
+def test_test_environment_allows_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The test fixtures explicitly use sqlite:// (in-memory) — so
+    # ENVIRONMENT=test must be in the allow list alongside development.
+    # Without this, every pytest run that sets ENVIRONMENT=test would
+    # fail at Settings() construction.
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    from app.config import Settings
+
+    settings = Settings()
+    assert settings.database_url == "sqlite://"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,4 @@
-"""Tests for the health check endpoint."""
+"""Tests for the health check endpoints."""
 
 from fastapi.testclient import TestClient
 
@@ -18,3 +18,10 @@ def test_health_does_not_touch_database(client: TestClient) -> None:
     for _ in range(100):
         response = client.get("/api/health")
         assert response.status_code == 200
+
+
+def test_health_db_returns_200_with_working_session(client: TestClient) -> None:
+    """The DB health endpoint runs `SELECT 1` and returns ok."""
+    response = client.get("/api/health/db")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

Closes #78. Two-layer defense for the 2026-04-30 dry-run failure mode: preview deploys without Neon configured were silently falling through to the dev-default `sqlite:///./dev.db`, booting cleanly, passing the no-DB `/api/health` smoke test, and 500ing on the home route with `no such table: todo`. Looked like a schema bug; was a config bug.

## Why

The validator added in #63 only fired for `ENVIRONMENT=production`. Previews send `ENVIRONMENT=preview` and bypass the guard. The smoke test at `preview-deploy.yml:193-219` only probes `/api/health` — which deliberately doesn't touch the DB — so a totally broken database connection still passes. PR comment reads "Smoke test: passed". Human opens the URL → 500.

Surfaced 2026-04-30 on `tck517/tck517-app` PR #1.

## What changed

### Validator generalization (`app/config.py`)

Was gated on `environment != "production"`. Now gates on `environment in ("development", "test")` — so **preview, staging, and any other non-dev environment** fail fast at `Settings()` construction when `DATABASE_URL` is empty or sqlite-shaped.

```diff
-    def _refuse_sqlite_in_production(self) -> Self:
-        if self.environment != "production":
+    def _refuse_sqlite_outside_dev(self) -> Self:
+        if self.environment in ("development", "test"):
             return self
```

Error messages now name the actual environment ("DATABASE_URL is empty in preview" rather than always "in production") and call out the most likely cause for previews specifically (NEON_API_KEY unset so the Neon branch step was skipped).

### New endpoint (`app/api/health.py`)

```python
@router.get("/api/health/db")
def health_db(session: SessionDep) -> JSONResponse:
    """Single-query DB probe — `SELECT 1`."""
    session.execute(text("SELECT 1"))
    return JSONResponse({"status": "ok"})
```

Distinct from `/api/health`: catches the revision-up-but-DB-broken case. Uses the project's existing `SessionDep` Annotated alias pattern (matches `todos.py`) to keep the FastAPI dependency-injection idiom consistent and satisfy ruff `B008`. `session.execute(text(...))` is the right call because SQLModel's typed `session.exec()` only accepts SQLModel statements, not raw text.

### Smoke test restructure (`.github/workflows/preview-deploy.yml`)

Two-phase probe replacing the original single-phase loop:

- **Phase 1**: retry loop against `/api/health` (Cloud Run cold-start + Neon wake — original behavior, preserved)
- **Phase 2**: single-shot probe against `/api/health/db` — must return 200 for green

Both must pass.

## Tests

| File | Cases added |
|---|---|
| `tests/test_config.py` | `preview + sqlite → ValueError`; `preview + postgres → normalized + accepted`; `staging + sqlite → ValueError` (future-proofing for unfamiliar environments); `test + sqlite → accepted` (explicit allow case for pytest fixtures) |
| `tests/test_health.py` | `/api/health/db` returns 200 with a working session |

Total pytest: 17 → **22** (+5). ruff + format + mypy clean.

## What this PR does NOT include

The original handoff doc proposed a third fix — a "Verify preview has a database URL" workflow step before deploy. After verifying the workflow logic at `preview-deploy.yml:151`, that fix is unnecessary: the existing `if [ -n "..." ]` guard does correctly skip the `DATABASE_URL=` append when Neon output is empty. The actual failure point is purely the app-side validator gap. Adding a workflow step would duplicate what the validator does and create two places to keep in sync.

## Verification post-merge

- [ ] CI green
- [ ] After merge: open a PR on a fork without `NEON_API_KEY`. Confirm preview-deploy fails (either at container startup with the validator's `ValueError` in Cloud Run logs, or at the smoke test's Phase 2 — either is acceptable; the failure is loud either way).
- [ ] After merge: open a PR on a fork WITH Neon configured. Confirm preview-deploy succeeds, both phases pass, URL serves FastAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)