### PR TITLE
feat(agents): make worker/reviewer briefs solo-mode aware; relax linter rule (closes #82, #88)

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -44,26 +44,34 @@ Example fields to populate:
 
 **CRITICAL: GitHub Account Identity**
 
-This agent MUST operate as the designated worker bot account. Before ANY GitHub operations:
+Verify the active account before any GitHub mutation. Do **NOT** run
+`gh auth switch` — that command mutates global gh state visible to every
+terminal the user has open, and it is wrong in solo mode where no bot
+accounts exist.
 
 ```bash
-# Switch to worker bot account (replace {worker-bot} with your org's worker account)
-gh auth switch --user {worker-bot}
-
-# Verify correct account is active
-gh auth status
+gh auth status   # Verify; do not switch.
 ```
 
-**Why this matters:**
-- Git commits and PRs are properly attributed to the worker bot
-- Separation of duties: worker bot creates PRs, reviewer bot reviews, human merges
-- Human can distinguish between worker and reviewer actions in the audit trail
+If the active account is not appropriate for the operation:
+- **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the default for new forks):
+  the user's personal account IS the appropriate account — proceed.
+- **Multi-bot mode**: the `.claude/hooks/ensure-github-account.sh`
+  PreToolUse hook switches accounts automatically before `gh pr create`
+  and `gh pr review`. For other gh operations (issue create, label
+  create, branch protection), STOP and ask the user — do not change
+  the active account from agent context.
 
-<!--
-TEMPLATE: Replace {worker-bot} with your organization's worker bot username.
-Example: va-worker, myorg-worker, etc.
-See .claude/README.md for bot account setup instructions.
--->
+If `gh auth status` shows no authenticated account at all, STOP and
+ask the user to run `gh auth login` (solo) or
+`scripts/setup-accounts.sh` (multi-bot).
+
+**Why this matters:**
+- Git commits and PRs are properly attributed
+- Separation of duties: worker creates PRs, reviewer reviews, human merges
+- Human can distinguish actions in the audit trail
+- Solo-mode users have one personal account; the framework must not
+  attempt to switch to bots that don't exist
 
 **GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with issues, pull requests, and the project board. This is your **primary method** for all GitHub operations.
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -67,26 +67,34 @@ Your reviews must ensure that code is:
 
 **CRITICAL: GitHub Account Identity**
 
-This agent MUST operate as the designated reviewer bot account. Before ANY GitHub operations:
+Verify the active account before any GitHub mutation. Do **NOT** run
+`gh auth switch` — that command mutates global gh state visible to every
+terminal the user has open, and it is wrong in solo mode where no bot
+accounts exist.
 
 ```bash
-# Switch to reviewer bot account (replace {reviewer-bot} with your org's reviewer account)
-gh auth switch --user {reviewer-bot}
-
-# Verify correct account is active
-gh auth status
+gh auth status   # Verify; do not switch.
 ```
 
-**Why this matters:**
-- PR reviews are properly attributed to the reviewer bot
-- Separation of duties: worker bot creates PRs, reviewer bot reviews, human merges
-- Human can distinguish between worker and reviewer actions in the audit trail
+If the active account is not appropriate for posting the review:
+- **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the default for new forks):
+  the user's personal account IS the appropriate account — proceed.
+- **Multi-bot mode**: the `.claude/hooks/ensure-github-account.sh`
+  PreToolUse hook switches to the reviewer account automatically before
+  `gh pr review`. For other gh operations (commenting on issues, etc.),
+  STOP and ask the user — do not change the active account from agent
+  context.
 
-<!--
-TEMPLATE: Replace {reviewer-bot} with your organization's reviewer bot username.
-Example: va-reviewer, myorg-reviewer, etc.
-See .claude/README.md for bot account setup instructions.
--->
+If `gh auth status` shows no authenticated account at all, STOP and
+ask the user to run `gh auth login` (solo) or
+`scripts/setup-accounts.sh` (multi-bot).
+
+**Why this matters:**
+- PR reviews are properly attributed
+- Separation of duties: worker creates PRs, reviewer reviews, human merges
+- Human can distinguish actions in the audit trail
+- Solo-mode users have one personal account; the framework must not
+  attempt to switch to bots that don't exist
 
 **GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with pull requests, issues, and the project board. This is your **primary method** for all GitHub operations.
 

--- a/scripts/lint-agent-policies.sh
+++ b/scripts/lint-agent-policies.sh
@@ -214,23 +214,29 @@ echo ""
 # Check 6: Bot account identity instructions
 # =============================================================================
 
-echo "Checking for bot account identity instructions..."
+echo "Checking for account-identity instructions..."
 MISSING_IDENTITY=0
 
+# Workflow agents must address account identity. Either pattern is acceptable:
+#   - "gh auth status" / "active account" — verify-only (solo-mode-aware, #82)
+#   - "gh auth switch" / "GitHub Account Identity" / "bot...account" — multi-bot
+# The verify-only patterns are preferred (don't mutate global gh state); the
+# bot-account patterns are accepted for backward compatibility with multi-bot
+# setups that pre-date #82.
 for file in .claude/agents/pr-reviewer.md .claude/agents/github-ticket-worker.md; do
   if [ -f "$file" ]; then
-    if ! grep -qi "gh auth switch\|GitHub Account Identity\|bot.*account" "$file"; then
-      echo -e "${YELLOW}WARNING: $file may be missing bot account identity instructions${NC}"
+    if ! grep -qi "gh auth status\|gh auth switch\|active.*account\|GitHub Account Identity\|bot.*account" "$file"; then
+      echo -e "${YELLOW}WARNING: $file may be missing account-identity instructions${NC}"
       WARNINGS=$((WARNINGS + 1))
       MISSING_IDENTITY=1
     else
-      verbose_log "Found bot account instructions in $(basename "$file")"
+      verbose_log "Found account-identity instructions in $(basename "$file")"
     fi
   fi
 done
 
 if [ $MISSING_IDENTITY -eq 0 ]; then
-  echo -e "${GREEN}Bot account identity instructions found in workflow agent files${NC}"
+  echo -e "${GREEN}Account-identity instructions found in workflow agent files${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Closes **#82** (agent briefs solo-mode aware) and **#88** (linter rule).

The agent definition files at `.claude/agents/github-ticket-worker.md` and `.claude/agents/pr-reviewer.md` previously instructed `gh auth switch --user {worker-bot}` (or `{reviewer-bot}`) as their first step. The 2026-04-30 dry-run on `tck517/tck517-app` flagged this as Workaround G in the upstream-handoff doc:

- **Wrong in solo mode**: solo-mode users have no bot accounts. The instruction fails or silently switches to a stale leftover bot.
- **Dangerous in any mode**: `gh auth switch` mutates global gh state visible to every terminal the user has open. A worker subagent that runs it can flip identity for the user's other shells mid-session.

## What changed

| File | Change |
|---|---|
| `.claude/agents/github-ticket-worker.md` | Replace the `gh auth switch` block with a verify-only block. Lists solo-mode and multi-bot guidance separately so the LLM knows when to STOP-and-ask vs proceed. |
| `.claude/agents/pr-reviewer.md` | Same shape, symmetric. |
| `scripts/lint-agent-policies.sh` | Widen the required-pattern set from `gh auth switch \| GitHub Account Identity \| bot.*account` to also accept `gh auth status \| active.*account`. The new set is a superset — pre-#82 multi-bot agent files still lint clean. |

## Why both tickets in one PR

#88 is a strict prerequisite for #82: the linter would fail CI on the post-#82 agent files. They have to ship together (or #88 lands first). Bundling avoids a meaningless intermediate state.

## Tests / verification

- `bash scripts/lint-agent-policies.sh` against the new agent files — passes
- `bash scripts/lint-agent-policies.sh` against pre-#82-shape agent files (synthetic check) — still passes (backward compat)
- `bash scripts/lint-agent-policies.sh` against an agent file with NO identity block (synthetic regression guard) — still WARNs as expected (the linter's intent is preserved)
- `shellcheck scripts/lint-agent-policies.sh` clean
- `uv run pytest` 22/22 (sanity — no app changes)

## What this does NOT do

- The hook (`.claude/hooks/ensure-github-account.sh`) is **unchanged**. It still switches accounts for `gh pr create` and `gh pr review` in multi-bot mode. The boundary is correct: hook handles the switch for the operations it's gated on; agents only verify.
- Solo-mode bootstrap (`scripts/setup-solo-mode.sh`) is filed separately as #83 and is a follow-up to this PR.
- The hook's own self-healing behavior (#85) is also a follow-up.

## Verification post-merge

- [ ] CI green on this PR
- [ ] After merge: in solo mode, run `/work-ticket` — agent reads `gh auth status`, proceeds as the personal account, does not attempt `gh auth switch`
- [ ] After merge: in multi-bot mode, run `/work-ticket` — agent verifies, hook switches to worker before `gh pr create`, hook switches to reviewer before `gh pr review` (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)