### PR TITLE
feat(scripts): add setup-solo-mode.sh first-class bootstrap (closes #83)

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,14 +57,35 @@ Now clone it locally:
 cd ~/projects   # or wherever you keep repos
 git clone https://github.com/your-name/my-app.git
 cd my-app
-git config --local core.hooksPath scripts/hooks
+bash scripts/setup-solo-mode.sh
 npm install
 ```
 
-The `git config` line activates the pre-push quality gate. Without it,
-broken code can reach `main` and trigger a failing production deploy.
-The setting is per-clone, not stored in the repo, so every fresh clone
-needs this command once.
+`scripts/setup-solo-mode.sh` is the recommended bootstrap for solo mode
+(one personal account plays all roles — workshop attendees, individual
+learners, framework evaluators). It activates the pre-push quality
+gate, persists `AGILE_FLOW_SOLO_MODE=true` to your shell rc, audits
+stale `GITHUB_PERSONAL_ACCESS_TOKEN*` env vars (which silently override
+`gh auth switch`), verifies your gh token has the required scopes, and
+confirms you have admin access on the fork. It does NOT cache tokens
+to disk and does NOT modify your shell rc to remove tokens — it
+surfaces them with the exact removal command.
+
+After it completes, **restart your shell or Claude Code** so the new
+`AGILE_FLOW_SOLO_MODE` env var is picked up by agent subprocesses.
+
+If you prefer the minimal manual path (no env-var management, no scope
+verification), the single command the script wraps for activating the
+hook is:
+
+```bash
+git config --local core.hooksPath scripts/hooks
+```
+
+For multi-bot setups (worker + reviewer + human merger, with
+provisioned bot accounts), use `scripts/setup-accounts.sh` instead.
+Solo mode is the default for new forks; multi-bot mode is the
+production opt-in.
 
 **You should see:** Dependencies installed with no errors.
 

--- a/scripts/setup-solo-mode.sh
+++ b/scripts/setup-solo-mode.sh
@@ -1,0 +1,375 @@
+#!/bin/bash
+#
+# Agile Flow — Solo Mode Setup
+#
+# One-shot bootstrap for solo mode: one personal GitHub account plays
+# all roles (worker, reviewer, human merger). Recommended for workshops,
+# tutorials, individual learners, and anyone evaluating the framework
+# without provisioning bot accounts.
+#
+# What this script does (and does not):
+#
+#   ✓ Persists `AGILE_FLOW_SOLO_MODE=true` to your shell profile.
+#   ✓ Audits stale `GITHUB_PERSONAL_ACCESS_TOKEN*` env vars (which
+#     silently override `gh auth switch` and break agent workflows).
+#   ✓ Verifies your active gh account has the required scopes
+#     (repo, project, workflow, read:project) and refreshes if not.
+#   ✓ Activates the in-repo pre-push hook (`core.hooksPath`).
+#   ✓ Verifies you have admin access on the current fork.
+#
+#   ✗ Does NOT cache tokens to disk. Tokens stay in gh's keyring.
+#   ✗ Does NOT auto-modify your shell rc to remove tokens — surfaces
+#     them and tells you the exact removal command.
+#   ✗ Does NOT touch multi-bot env vars (AGILE_FLOW_WORKER_ACCOUNT /
+#     AGILE_FLOW_REVIEWER_ACCOUNT) without explicit confirmation —
+#     preserves multi-bot setups that may have a fallback pattern.
+#
+# Usage:
+#   bash scripts/setup-solo-mode.sh
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated (`gh auth login`)
+#   - Run from the repo root (where `.git/` and `scripts/hooks/` live)
+#
+# After this script completes, RESTART Claude Code so the agent
+# subprocesses pick up the new env var. The hook checks
+# `AGILE_FLOW_SOLO_MODE` from its own env, which is a snapshot from
+# the agent session start — without a restart, the hook keeps reading
+# the old (unset) value.
+#
+# Exit codes:
+#   0 — solo mode is configured (or already configured)
+#   1 — a check failed (gh missing, no admin access, etc.)
+#   2 — user declined a required prompt
+#
+# See also: docs/PLATFORM-GUIDE.md "Solo mode" section, #83.
+
+set -uo pipefail
+
+# Ensure bash even if invoked as `zsh scripts/setup-solo-mode.sh`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Colors + print helpers (copied from setup-accounts.sh shape)
+# ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+print_error() { echo -e "${RED}✗ $1${NC}"; }
+print_info() { echo -e "${BLUE}→ $1${NC}"; }
+
+# ───────────────────────────────────────────────────────────────────
+#  Detect the user's shell profile file
+# ───────────────────────────────────────────────────────────────────
+detect_shell_profile() {
+    if [ -n "${ZSH_VERSION:-}" ] || [ "${SHELL:-}" = "/bin/zsh" ] || [ "${SHELL:-}" = "/usr/bin/zsh" ] || [ "${SHELL:-}" = "/opt/homebrew/bin/zsh" ]; then
+        echo "$HOME/.zshrc"
+    elif [[ "${SHELL:-}" == */fish ]]; then
+        echo "$HOME/.config/fish/config.fish"
+    elif [ -n "${BASH_VERSION:-}" ] || [ "${SHELL:-}" = "/bin/bash" ] || [ "${SHELL:-}" = "/usr/bin/bash" ]; then
+        if [ -f "$HOME/.bash_profile" ]; then
+            echo "$HOME/.bash_profile"
+        else
+            echo "$HOME/.bashrc"
+        fi
+    else
+        if [ -f "$HOME/.zshrc" ]; then
+            echo "$HOME/.zshrc"
+        elif [ -f "$HOME/.bashrc" ]; then
+            echo "$HOME/.bashrc"
+        else
+            echo "$HOME/.profile"
+        fi
+    fi
+}
+
+# ───────────────────────────────────────────────────────────────────
+#  Persist an env var to shell profile (idempotent)
+#  Handles bash/zsh `export` and fish `set -Ux`.
+# ───────────────────────────────────────────────────────────────────
+persist_env_var() {
+    local var_name=$1
+    local var_value=$2
+    local profile
+    profile=$(detect_shell_profile)
+
+    export "$var_name=$var_value"
+
+    if [[ "$profile" == */fish/* ]]; then
+        # fish: `set -Ux NAME value` (universal, exported)
+        if grep -q "^set -Ux ${var_name} " "$profile" 2>/dev/null; then
+            if [[ "$OSTYPE" == darwin* ]]; then
+                sed -i '' "s|^set -Ux ${var_name} .*|set -Ux ${var_name} ${var_value}|" "$profile"
+            else
+                sed -i "s|^set -Ux ${var_name} .*|set -Ux ${var_name} ${var_value}|" "$profile"
+            fi
+            print_info "Updated ${var_name} in ${profile}"
+        else
+            mkdir -p "$(dirname "$profile")"
+            {
+                echo ""
+                echo "# Added by Agile Flow setup-solo-mode"
+                echo "set -Ux ${var_name} ${var_value}"
+            } >> "$profile"
+            print_info "Added ${var_name} to ${profile}"
+        fi
+    else
+        # bash/zsh: `export NAME=value`
+        if grep -q "^export ${var_name}=" "$profile" 2>/dev/null; then
+            if [[ "$OSTYPE" == darwin* ]]; then
+                sed -i '' "s|^export ${var_name}=.*|export ${var_name}=\"${var_value}\"|" "$profile"
+            else
+                sed -i "s|^export ${var_name}=.*|export ${var_name}=\"${var_value}\"|" "$profile"
+            fi
+            print_info "Updated ${var_name} in ${profile}"
+        else
+            {
+                echo ""
+                echo "# Added by Agile Flow setup-solo-mode"
+                echo "export ${var_name}=\"${var_value}\""
+            } >> "$profile"
+            print_info "Added ${var_name} to ${profile}"
+        fi
+    fi
+}
+
+# ───────────────────────────────────────────────────────────────────
+#  Pre-flight: gh present + repo root + already authed
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}=== Agile Flow — Solo Mode Setup ===${NC}"
+echo ""
+
+if ! command -v gh >/dev/null 2>&1; then
+    print_error "gh CLI not found on PATH"
+    print_info "Install: https://cli.github.com/"
+    exit 1
+fi
+
+if [ ! -d ".git" ]; then
+    print_error "Not in a git repo (no .git/ here)"
+    print_info "cd to the repo root, then re-run this script"
+    exit 1
+fi
+
+# Note: `gh auth status` (without --active) exits non-zero if ANY account
+# in the keyring has an invalid token, even when valid accounts exist.
+# Use --active to check that there's at least one working active account.
+if ! gh auth status --active >/dev/null 2>&1; then
+    print_error "No active gh account (or all accounts have invalid tokens)"
+    print_info "Run: gh auth login"
+    exit 1
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 1/8: Detect shell + show current state
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 1/8: Detect shell ---${NC}"
+echo ""
+
+profile=$(detect_shell_profile)
+print_success "Detected shell profile: ${profile}"
+
+active_account=$(gh auth status --active 2>&1 | grep "Logged in to" | sed 's/.*account \([^ ]*\).*/\1/' | head -1)
+print_info "Active gh account: ${active_account:-(none detected)}"
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 2/8: Persist AGILE_FLOW_SOLO_MODE
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 2/8: Persist AGILE_FLOW_SOLO_MODE=true ---${NC}"
+echo ""
+
+if [ "${AGILE_FLOW_SOLO_MODE:-}" = "true" ] && grep -qE "(^export AGILE_FLOW_SOLO_MODE=|^set -Ux AGILE_FLOW_SOLO_MODE )" "$profile" 2>/dev/null; then
+    print_success "AGILE_FLOW_SOLO_MODE=true already set in ${profile}"
+else
+    persist_env_var "AGILE_FLOW_SOLO_MODE" "true"
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 3/8: Audit GITHUB_PERSONAL_ACCESS_TOKEN* env vars
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 3/8: Audit GITHUB_PERSONAL_ACCESS_TOKEN env vars ---${NC}"
+echo ""
+
+# In solo mode, ANY of these env vars override `gh auth switch` silently.
+# Detection is from the current shell environment (what gh sees right now)
+# AND from the shell rc file (so the user knows what to remove permanently).
+token_env_vars=()
+while IFS= read -r line; do
+    [ -n "$line" ] && token_env_vars+=("$line")
+done < <(env | grep -E "^(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN)" | cut -d= -f1 || true)
+
+token_rc_lines=()
+if [ -f "$profile" ]; then
+    while IFS= read -r line; do
+        [ -n "$line" ] && token_rc_lines+=("$line")
+    done < <(grep -nE "^(export\s+)?GITHUB_PERSONAL_ACCESS_TOKEN|^(export\s+)?GH_TOKEN|^set -Ux\s+GITHUB_PERSONAL_ACCESS_TOKEN|^set -Ux\s+GH_TOKEN" "$profile" 2>/dev/null || true)
+fi
+
+env_count=${#token_env_vars[@]}
+rc_count=${#token_rc_lines[@]}
+if [ "$env_count" -eq 0 ] && [ "$rc_count" -eq 0 ]; then
+    print_success "No token env vars detected (gh keyring is the source of truth)"
+else
+    print_warning "Found token env vars that override gh auth switch:"
+    echo ""
+    if [ "$env_count" -gt 0 ]; then
+        for v in "${token_env_vars[@]}"; do
+            echo "    in current shell: ${v}"
+        done
+    fi
+    if [ "$rc_count" -gt 0 ]; then
+        for line in "${token_rc_lines[@]}"; do
+            echo "    in ${profile}: ${line}"
+        done
+    fi
+    echo ""
+    print_warning "These vars cause gh to authenticate with the env-var token instead of the keyring."
+    print_warning "In solo mode, that breaks agent workflows because gh auth switch silently has no effect."
+    echo ""
+    print_info "Recommended manual cleanup:"
+    print_info "  1. Edit ${profile} and remove the lines above"
+    print_info "  2. Rotate the affected tokens at https://github.com/settings/tokens"
+    print_info "  3. Restart your shell (or open a new terminal)"
+    echo ""
+    print_warning "Continuing without removing — the rest of this script may surface inconsistencies."
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 4/8: Verify scopes
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 4/8: Verify gh token scopes ---${NC}"
+echo ""
+
+required_scopes=(repo project workflow read:project)
+auth_status_output=$(gh auth status 2>&1 || true)
+token_scopes=$(echo "$auth_status_output" | grep -E "Token scopes:" | head -1 | sed -E "s/.*Token scopes: //; s/['\"]//g; s/, /,/g")
+
+missing_scopes=()
+for s in "${required_scopes[@]}"; do
+    if ! echo ",${token_scopes}," | grep -q ",${s},"; then
+        missing_scopes+=("$s")
+    fi
+done
+
+if [ ${#missing_scopes[@]} -eq 0 ]; then
+    print_success "All required scopes present (${required_scopes[*]})"
+else
+    print_warning "Missing scopes: ${missing_scopes[*]}"
+    print_info "Running: gh auth refresh -h github.com -s ${missing_scopes[*]}"
+    echo ""
+    if gh auth refresh -h github.com -s "$(IFS=,; echo "${missing_scopes[*]}")"; then
+        # Verify active account did not flip during refresh (known gh quirk).
+        new_active=$(gh auth status --active 2>&1 | grep "Logged in to" | sed 's/.*account \([^ ]*\).*/\1/' | head -1)
+        if [ "$new_active" != "$active_account" ]; then
+            print_warning "gh auth refresh flipped active account from '$active_account' to '$new_active'"
+            print_info "Restoring active account..."
+            if gh auth switch --user "$active_account" >/dev/null 2>&1; then
+                print_success "Restored active account to '$active_account'"
+            else
+                print_error "Could not restore active account; please run: gh auth switch --user $active_account"
+                exit 1
+            fi
+        fi
+        print_success "Scope refresh complete"
+    else
+        print_error "gh auth refresh failed"
+        exit 1
+    fi
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 5/8: Activate pre-push hook
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 5/8: Activate pre-push hook ---${NC}"
+echo ""
+
+if [ -f "scripts/hooks/pre-push" ]; then
+    current_hooks_path=$(git config --local --get core.hooksPath 2>/dev/null || true)
+    if [ "$current_hooks_path" = "scripts/hooks" ]; then
+        print_success "core.hooksPath already set to scripts/hooks"
+    else
+        git config --local core.hooksPath scripts/hooks
+        print_success "Activated pre-push hook (lint + tests will run before every push)"
+    fi
+else
+    print_warning "scripts/hooks/pre-push not found; skipping hook activation"
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 6/8: Verify admin access on this fork
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 6/8: Verify admin access on this fork ---${NC}"
+echo ""
+
+remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
+if [ -z "$remote_url" ]; then
+    print_warning "No 'origin' remote configured; skipping admin check"
+    print_info "(If this is a fresh clone, the remote should be set automatically)"
+else
+    # Convert SSH or HTTPS URL to owner/repo
+    repo=$(echo "$remote_url" | sed -E 's|^git@github\.com:|/|; s|^https://github\.com/||; s|\.git$||; s|^/||')
+    if [ -z "$repo" ]; then
+        print_warning "Could not parse owner/repo from remote URL: $remote_url"
+    else
+        admin=$(gh api "repos/${repo}" --jq '.permissions.admin // false' 2>/dev/null || echo "false")
+        if [ "$admin" = "true" ]; then
+            print_success "${active_account} has admin access on ${repo}"
+        else
+            print_error "${active_account} does NOT have admin access on ${repo}"
+            print_info "Solo mode requires admin access (to write secrets, manage branches, configure project boards)"
+            print_info "Either: (a) you are not the fork owner — fork the repo first, OR"
+            print_info "        (b) you are operating in a multi-bot setup — solo mode does not apply"
+            exit 1
+        fi
+    fi
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 7/8: Multi-bot env-var sanity check
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 7/8: Multi-bot env-var sanity check ---${NC}"
+echo ""
+
+if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
+    print_warning "Multi-bot env vars detected:"
+    [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ]   && echo "    AGILE_FLOW_WORKER_ACCOUNT=${AGILE_FLOW_WORKER_ACCOUNT}"
+    [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ] && echo "    AGILE_FLOW_REVIEWER_ACCOUNT=${AGILE_FLOW_REVIEWER_ACCOUNT}"
+    echo ""
+    print_info "These are harmless in solo mode (the hook short-circuits on AGILE_FLOW_SOLO_MODE=true)"
+    print_info "but they may confuse readers of doctor.sh output. Consider unsetting them."
+else
+    print_success "No multi-bot env vars set"
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 8/8: Done — restart prompt
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 8/8: Done ---${NC}"
+echo ""
+
+print_success "Solo mode is configured."
+echo ""
+print_info "Next steps:"
+print_info "  1. Restart Claude Code (or open a new shell)"
+print_info "     so agent subprocesses pick up AGILE_FLOW_SOLO_MODE."
+print_info "  2. Run scripts/doctor.sh to verify the full setup."
+print_info "  3. Open a ticket and run /work-ticket — agents now operate"
+print_info "     as ${active_account} without bot-account switching."
+echo ""
+exit 0

--- a/scripts/setup-solo-mode.test.sh
+++ b/scripts/setup-solo-mode.test.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+#
+# Tests for setup-solo-mode.sh — solo-mode bootstrap.
+#
+# Stubs `gh` minimally so we can exercise the script's decision logic
+# without touching real auth state or the user's shell rc. Each test
+# runs in a fresh tempdir with a fake HOME and a fresh git repo +
+# scripts/hooks tree.
+#
+# Run: ./scripts/setup-solo-mode.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/setup-solo-mode.sh"
+
+new_sandbox() {
+    local tmp
+    tmp=$(mktemp -d -t solomode-test-XXXX)
+    mkdir -p "$tmp/bin" "$tmp/sandbox-home" "$tmp/repo/scripts/hooks"
+
+    touch "$tmp/sandbox-home/.zshrc"
+
+    (cd "$tmp/repo" && git init -q -b main && git remote add origin https://github.com/test-owner/test-repo.git)
+    echo '#!/usr/bin/env bash' > "$tmp/repo/scripts/hooks/pre-push"
+    chmod +x "$tmp/repo/scripts/hooks/pre-push"
+
+    # Active-account state is persisted to a file so the stub can mutate
+    # it across calls (env-var mutation in the stub doesn't propagate).
+    echo "${STUB_INITIAL_ACCOUNT:-}" > "$tmp/active-account"
+
+    echo "$tmp"
+}
+
+# gh stub. Reads active account from $STUB_STATE/active-account on each
+# call. Writes a log to $STUB_STATE/gh.log. Behavior controlled by
+# STUB_TOKEN_SCOPES, STUB_REFRESH_FLIPS_TO, STUB_API_ADMIN.
+make_gh_stub() {
+    local tmp="$1"
+    cat > "$tmp/bin/gh" <<'STUB_EOF'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_STATE/gh.log"
+
+active=$(cat "$STUB_STATE/active-account" 2>/dev/null)
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+# Match the first two args verbatim
+case "$cmd1 $cmd2" in
+    "auth status")
+        # --active flag → return success only when active account is set
+        for arg in "$@"; do
+            if [[ "$arg" == "--active" ]]; then
+                if [[ -n "$active" ]]; then
+                    echo "github.com"
+                    echo "  ✓ Logged in to github.com account ${active} (keyring)"
+                    echo "  - Active account: true"
+                    echo "  - Token scopes: ${STUB_TOKEN_SCOPES:-'repo, project, workflow, read:project'}"
+                    exit 0
+                fi
+                exit 1
+            fi
+        done
+        # Without --active
+        if [[ -n "$active" ]]; then
+            echo "github.com"
+            echo "  ✓ Logged in to github.com account ${active} (keyring)"
+            echo "  - Active account: true"
+            echo "  - Token scopes: ${STUB_TOKEN_SCOPES:-'repo, project, workflow, read:project'}"
+            exit 0
+        fi
+        exit 1
+        ;;
+    "auth refresh")
+        if [[ -n "${STUB_REFRESH_FLIPS_TO:-}" ]]; then
+            echo "$STUB_REFRESH_FLIPS_TO" > "$STUB_STATE/active-account"
+        fi
+        exit "${STUB_REFRESH_EXIT:-0}"
+        ;;
+    "auth switch")
+        # argv: --user <name>
+        prev=""
+        for arg in "$@"; do
+            if [[ "$prev" == "--user" ]]; then
+                echo "$arg" > "$STUB_STATE/active-account"
+                exit 0
+            fi
+            prev="$arg"
+        done
+        exit 1
+        ;;
+esac
+
+# Fall through: match `api repos/<owner>/<repo>` regardless of trailing args
+if [[ "$cmd1" == "api" ]] && [[ "$cmd2" == repos/* ]]; then
+    echo "${STUB_API_ADMIN:-true}"
+    exit 0
+fi
+
+# Default: succeed quietly
+exit 0
+STUB_EOF
+    chmod +x "$tmp/bin/gh"
+}
+
+# Run script in a clean env (no token vars from parent).
+# Pass any STUB_* and required vars explicitly via env.
+run_script() {
+    local sandbox="$1"
+    shift
+    # Use env -i to clear, then re-establish only what the script needs.
+    env -i \
+        HOME="$sandbox/sandbox-home" \
+        SHELL=/bin/zsh \
+        PATH="$sandbox/bin:/usr/bin:/bin:/usr/local/bin" \
+        STUB_STATE="$sandbox" \
+        TERM="${TERM:-dumb}" \
+        "$@" \
+        bash -c "cd '$sandbox/repo' && '$SCRIPT'"
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $expected; got: $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local needle="$1" file="$2" label="$3"
+    if grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected to contain: $needle)"
+        echo "  --- file content ---"
+        sed -e 's/^/  /' "$file"
+        echo "  --------------------"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" file="$2" label="$3"
+    if ! grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (should NOT contain: $needle)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: happy path — no token vars, scopes complete, admin true ───
+
+echo ""
+echo "Test 1: happy path"
+
+T1=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T1"
+
+set +e
+run_script "$T1" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    > "$T1/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 on happy path"
+assert_contains "Solo mode is configured" "$T1/run.log" "success message"
+assert_contains "AGILE_FLOW_SOLO_MODE" "$T1/sandbox-home/.zshrc" "AGILE_FLOW_SOLO_MODE persisted to .zshrc"
+assert_contains "Activated pre-push hook" "$T1/run.log" "hook activated on first run"
+assert_not_contains "auth refresh" "$T1/gh.log" "no gh auth refresh on happy path"
+
+# ── Test 2: missing scopes → refresh runs ────────────────────────────
+
+echo ""
+echo "Test 2: missing scopes → refresh runs"
+
+T2=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T2"
+
+set +e
+run_script "$T2" \
+    STUB_TOKEN_SCOPES="repo, workflow" \
+    STUB_API_ADMIN="true" \
+    > "$T2/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Missing scopes: project read:project" "$T2/run.log" "names missing scopes"
+assert_contains "auth refresh -h github.com" "$T2/gh.log" "calls gh auth refresh"
+
+# ── Test 3: refresh flips active account → script restores it ────────
+
+echo ""
+echo "Test 3: refresh flips active account → restored"
+
+T3=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T3"
+
+set +e
+run_script "$T3" \
+    STUB_TOKEN_SCOPES="repo" \
+    STUB_REFRESH_FLIPS_TO="va-worker" \
+    STUB_API_ADMIN="true" \
+    > "$T3/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "flipped active account from 'alice' to 'va-worker'" "$T3/run.log" "detects flip"
+assert_contains "Restored active account to 'alice'" "$T3/run.log" "restores via gh auth switch"
+assert_contains "auth switch --user alice" "$T3/gh.log" "calls gh auth switch with original user"
+
+# ── Test 4: token env var present → warning surfaces ─────────────────
+
+echo ""
+echo "Test 4: GITHUB_PERSONAL_ACCESS_TOKEN env var → warning"
+
+T4=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T4"
+
+set +e
+run_script "$T4" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    GITHUB_PERSONAL_ACCESS_TOKEN="ghp_fake1234567890" \
+    > "$T4/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 (continues with warning)"
+assert_contains "Found token env vars" "$T4/run.log" "surfaces token env var"
+assert_contains "GITHUB_PERSONAL_ACCESS_TOKEN" "$T4/run.log" "names the offending var"
+assert_contains "Recommended manual cleanup" "$T4/run.log" "tells user how to remove"
+
+# ── Test 5: idempotent re-run ────────────────────────────────────────
+
+echo ""
+echo "Test 5: idempotent re-run"
+
+T5=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T5"
+
+# First run
+set +e
+run_script "$T5" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    > "$T5/run1.log" 2>&1
+set -e
+
+count1=$(grep -c "^export AGILE_FLOW_SOLO_MODE=" "$T5/sandbox-home/.zshrc" || true)
+
+# Second run — must pass AGILE_FLOW_SOLO_MODE=true so the early-skip branch fires
+set +e
+run_script "$T5" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    AGILE_FLOW_SOLO_MODE="true" \
+    > "$T5/run2.log" 2>&1
+set -e
+
+count2=$(grep -c "^export AGILE_FLOW_SOLO_MODE=" "$T5/sandbox-home/.zshrc" || true)
+
+assert_eq "$count1" "$count2" "AGILE_FLOW_SOLO_MODE export not duplicated on re-run"
+assert_contains "AGILE_FLOW_SOLO_MODE=true already set" "$T5/run2.log" "re-run reports already-configured state"
+assert_contains "core.hooksPath already set" "$T5/run2.log" "hook activation noted as already set on re-run"
+
+# ── Test 6: not in repo root → fails fast ─────────────────────────────
+
+echo ""
+echo "Test 6: not in repo root → fail fast"
+
+T6=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T6"
+
+# Override the cwd to NOT be the repo root.
+set +e
+env -i \
+    HOME="$T6/sandbox-home" \
+    SHELL=/bin/zsh \
+    PATH="$T6/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T6" \
+    TERM="${TERM:-dumb}" \
+    bash -c "cd '$T6' && '$SCRIPT'" > "$T6/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 when not in repo root"
+assert_contains "Not in a git repo" "$T6/run.log" "names the issue"
+
+# ── Test 7: no admin access → fails fast ─────────────────────────────
+
+echo ""
+echo "Test 7: no admin access on origin remote → fail fast"
+
+T7=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T7"
+
+set +e
+run_script "$T7" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="false" \
+    > "$T7/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 on no admin"
+assert_contains "does NOT have admin access" "$T7/run.log" "explains why"
+
+# ── Test 8: no active gh account → fail fast ─────────────────────────
+
+echo ""
+echo "Test 8: no active gh account → fail fast"
+
+T8=$(STUB_INITIAL_ACCOUNT="" new_sandbox)
+make_gh_stub "$T8"
+
+set +e
+run_script "$T8" \
+    > "$T8/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 when no active gh account"
+assert_contains "No active gh account" "$T8/run.log" "names the issue"
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #83. Single-script bootstrap for solo mode. Collapses the seven workarounds documented in `tck517/tck517-app:docs/UPSTREAM-HANDOFF.md` Issue #4 into one invocation.

## What the script does

| Step | What | Why |
|---|---|---|
| 1 | Detect shell profile (`~/.zshrc` / `~/.bashrc` / `~/.config/fish/config.fish`) | Different shells need different export syntax |
| 2 | Persist `AGILE_FLOW_SOLO_MODE=true` to shell rc | Survive shell restart; idempotent (updates in place, doesn't duplicate) |
| 3 | Audit `GITHUB_PERSONAL_ACCESS_TOKEN*` + `GH_TOKEN` env vars AND shell-rc lines | These silently override `gh auth switch` and break agent flows. Surface with exact removal recipe; do NOT auto-modify rc (credential cleanup is an explicit user decision) |
| 4 | Verify `repo`, `project`, `workflow`, `read:project` scopes; refresh if missing | Solo-mode users need all four for agent operations. Recovers from the gh quirk where `auth refresh` flips active account (downstream Workaround B) |
| 5 | Activate `core.hooksPath = scripts/hooks` | Pre-push gate. Idempotent (overlaps with #77, harmless on already-set forks) |
| 6 | Verify admin access on origin remote via `gh api repos/<owner>/<repo>` | Solo mode needs admin for secrets, branch protection, project board |
| 7 | Warn if `AGILE_FLOW_WORKER_ACCOUNT` / `AGILE_FLOW_REVIEWER_ACCOUNT` are also set | Harmless but may confuse `doctor.sh` output |
| 8 | Print restart-Claude-Code instruction | Env vars don't propagate into existing agent subprocesses |

## What the script does NOT do

- Cache tokens to disk (downstream Workaround C was a credential anti-pattern; this script keeps tokens in gh's keyring)
- Auto-modify shell rc to remove tokens (credential cleanup is explicit user decision; surfaces exact removal command instead)
- Touch multi-bot env vars without explicit confirmation
- Run inside a multi-bot setup (Step 6 will fail with admin=false; the message points at multi-bot mode)

## Tests

`scripts/setup-solo-mode.test.sh` — 8 tests, 25 assertions:

| Test | Coverage |
|---|---|
| 1 | Happy path — exit 0, env persisted, hook activated, no spurious refresh |
| 2 | Missing scopes → refresh runs |
| 3 | Refresh flips active account → script detects + restores |
| 4 | Token env var present → warning surfaces, script continues |
| 5 | Idempotent re-run — no duplicate shell-rc lines, "already set" message |
| 6 | Not in repo root → exit 1 |
| 7 | No admin access → exit 1 with clear message |
| 8 | No active gh account → exit 1 |

The harness uses `env -i` to isolate from parent-env token vars (which leaked during initial development), and persists "active account" state to a file so the gh stub can mutate across calls.

| Suite | Before | After |
|---|---|---|
| `provision-gcp-project.test.sh` | 100 | 100 |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` | 8 | 8 |
| `diagnose-cloudrun.test.sh` | 35 | 35 |
| `setup-solo-mode.test.sh` (new) | 0 | **25** |
| **Total** | 214 | **239** |

shellcheck + markdownlint + pytest 22/22 — all clean.

## Documentation

`docs/GETTING-STARTED.md` Step 1 now recommends `bash scripts/setup-solo-mode.sh` as part of the clone+install flow. Manual fallback (`git config --local core.hooksPath scripts/hooks`) is preserved for users who don't want full bootstrap.

## Reuse + scope discipline

Reused `setup-accounts.sh`'s style verbatim (color codes, `print_*` helpers, `--- Step N/M ---` cyan banners, `detect_shell_profile`, `persist_env_var`). Did NOT extract a shared `scripts/lib/` in this PR — two scripts with copies of three small helpers is cheaper than introducing a lib directory for one consumer. If a third bootstrap script ever joins the family, that's the right time to dedupe.

## Follow-ups (separate tickets, intentionally not in this PR)

- **#84** doctor.sh `GITHUB_PERSONAL_ACCESS_TOKEN*` detection — complementary; this script's audit catches the case at bootstrap, doctor catches it for users who skipped bootstrap
- **#85** hook self-healing — defends against gh-state drift after this script runs
- **#87** CLAUDE.md framing change — promotes solo to default, multi-bot to opt-in

## Verification post-merge

- [ ] CI green
- [ ] On a fresh fork: `bash scripts/setup-solo-mode.sh` exits 0; `~/.zshrc` (or fish equivalent) gets the export line; `git config --get core.hooksPath` returns `scripts/hooks`; `/work-ticket` runs without manual auth chasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)