### PR TITLE
fix(doctor): flag GITHUB_PERSONAL_ACCESS_TOKEN as FAIL in solo mode (closes #84)

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -335,46 +335,10 @@ fi
 
 fi  # end gh guard
 
-# ═══════════════════════════════════════════════════════════════════
-#  4. MCP Config
-# ═══════════════════════════════════════════════════════════════════
-section "MCP Config"
-
-# .mcp.json exists (FAIL)
-if [ -f ".mcp.json" ]; then
-    pass "MCP Config" ".mcp.json exists"
-
-    if ! JQ_CMD=$(resolve_cmd jq); then
-        skip "MCP Config" "Content checks (memory server, npx path)" "jq not installed"
-    else
-        # memory server (WARN)
-        if "$JQ_CMD" -e '.mcpServers.memory' .mcp.json &>/dev/null; then
-            pass "MCP Config" "memory server configured"
-        else
-            warn "MCP Config" "memory server missing from .mcp.json" "Optional but recommended for agent context"
-        fi
-
-        # npx path resolves (WARN)
-        mcp_npx_path=$("$JQ_CMD" -r '.mcpServers.memory.command // empty' .mcp.json 2>/dev/null)
-        if [ -n "$mcp_npx_path" ]; then
-            if resolve_cmd "$mcp_npx_path" &>/dev/null; then
-                pass "MCP Config" "npx command in .mcp.json resolves: $mcp_npx_path"
-                # Also check that node is available (npx shim needs it)
-                if resolve_cmd node &>/dev/null; then
-                    pass "MCP Config" "node available (required by npx)"
-                else
-                    warn "MCP Config" "npx found but node not resolvable" "npx requires node — install from https://nodejs.org"
-                fi
-            else
-                warn "MCP Config" "npx path in .mcp.json does not resolve: $mcp_npx_path" "Update .mcp.json command path or install npx"
-            fi
-        fi
-    fi  # end jq guard
-else
-    fail "MCP Config" ".mcp.json not found" "Run bootstrap.sh Phase 0 to create it"
-fi
-
 # Token env-var precedence audit (FAIL solo / WARN multi-bot)
+#
+# Outside the gh guard intentionally: token env vars matter even when
+# gh isn't installed yet (they would poison any future gh install).
 #
 # `gh` uses GITHUB_PERSONAL_ACCESS_TOKEN (any suffix) and GH_TOKEN above
 # its keyring whenever set. That makes `gh auth switch` silently
@@ -430,6 +394,45 @@ if [ ${#classic_pat_names[@]} -gt 0 ]; then
     classic_summary="$(IFS=', '; echo "${classic_pat_names[*]}")"
     warn "GitHub Auth" "Classic PAT(s) detected: ${classic_summary}" \
         "Prefer fine-grained PATs (github_pat_*); they scope to specific repos and expire."
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+#  4. MCP Config
+# ═══════════════════════════════════════════════════════════════════
+section "MCP Config"
+
+# .mcp.json exists (FAIL)
+if [ -f ".mcp.json" ]; then
+    pass "MCP Config" ".mcp.json exists"
+
+    if ! JQ_CMD=$(resolve_cmd jq); then
+        skip "MCP Config" "Content checks (memory server, npx path)" "jq not installed"
+    else
+        # memory server (WARN)
+        if "$JQ_CMD" -e '.mcpServers.memory' .mcp.json &>/dev/null; then
+            pass "MCP Config" "memory server configured"
+        else
+            warn "MCP Config" "memory server missing from .mcp.json" "Optional but recommended for agent context"
+        fi
+
+        # npx path resolves (WARN)
+        mcp_npx_path=$("$JQ_CMD" -r '.mcpServers.memory.command // empty' .mcp.json 2>/dev/null)
+        if [ -n "$mcp_npx_path" ]; then
+            if resolve_cmd "$mcp_npx_path" &>/dev/null; then
+                pass "MCP Config" "npx command in .mcp.json resolves: $mcp_npx_path"
+                # Also check that node is available (npx shim needs it)
+                if resolve_cmd node &>/dev/null; then
+                    pass "MCP Config" "node available (required by npx)"
+                else
+                    warn "MCP Config" "npx found but node not resolvable" "npx requires node — install from https://nodejs.org"
+                fi
+            else
+                warn "MCP Config" "npx path in .mcp.json does not resolve: $mcp_npx_path" "Update .mcp.json command path or install npx"
+            fi
+        fi
+    fi  # end jq guard
+else
+    fail "MCP Config" ".mcp.json not found" "Run bootstrap.sh Phase 0 to create it"
 fi
 
 # ═══════════════════════════════════════════════════════════════════

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -374,17 +374,62 @@ else
     fail "MCP Config" ".mcp.json not found" "Run bootstrap.sh Phase 0 to create it"
 fi
 
-# GITHUB_PERSONAL_ACCESS_TOKEN (WARN — optional, only needed for direct GraphQL API calls)
-if [ -n "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]; then
-    # Mask the token in output — guard against short tokens
-    if [ ${#GITHUB_PERSONAL_ACCESS_TOKEN} -ge 12 ]; then
-        token_preview="${GITHUB_PERSONAL_ACCESS_TOKEN:0:4}...${GITHUB_PERSONAL_ACCESS_TOKEN: -4}"
+# Token env-var precedence audit (FAIL solo / WARN multi-bot)
+#
+# `gh` uses GITHUB_PERSONAL_ACCESS_TOKEN (any suffix) and GH_TOKEN above
+# its keyring whenever set. That makes `gh auth switch` silently
+# ineffective: the keyring's "active account" pointer updates, but
+# every gh call authenticates with the env-var token instead. In
+# solo mode this breaks agent workflows opaquely; in multi-bot it's
+# tolerable but still surprising.
+#
+# Also flags classic PATs (ghp_*) as a credential-hygiene WARN —
+# prefer fine-grained PATs (github_pat_*) which can scope to specific
+# repos and expire. See #84.
+#
+# Token preview (first 4...last 4) — never logs the full value.
+mask_token() {
+    local t="$1"
+    if [ ${#t} -ge 12 ]; then
+        echo "${t:0:4}...${t: -4}"
     else
-        token_preview="(set, ${#GITHUB_PERSONAL_ACCESS_TOKEN} chars)"
+        echo "(set, ${#t} chars)"
     fi
-    pass "MCP Config" "GITHUB_PERSONAL_ACCESS_TOKEN set ($token_preview)"
+}
+
+# Build a list of "NAME=preview" entries for every detected token var.
+token_entries=()
+classic_pat_names=()
+while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    name="${entry%%=*}"
+    value="${entry#*=}"
+    token_entries+=("${name}=$(mask_token "$value")")
+    # Classic PAT prefix: ghp_
+    if [[ "$value" == ghp_* ]]; then
+        classic_pat_names+=("$name")
+    fi
+done < <(env | grep -E "^(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN)" || true)
+
+if [ ${#token_entries[@]} -eq 0 ]; then
+    pass "GitHub Auth" "No GITHUB_PERSONAL_ACCESS_TOKEN env vars (gh keyring is the source of truth)"
 else
-    skip "MCP Config" "GITHUB_PERSONAL_ACCESS_TOKEN not set" "Optional — gh auth handles GitHub access"
+    # Build a one-line summary listing every detected var.
+    summary="$(IFS=', '; echo "${token_entries[*]}")"
+    if [ "${AGILE_FLOW_SOLO_MODE:-false}" = "true" ]; then
+        fail "GitHub Auth" "Token env vars override gh auth switch in solo mode: ${summary}" \
+            "Remove from your shell rc (and rotate the tokens). Helper: scripts/setup-solo-mode.sh audits these."
+    else
+        warn "GitHub Auth" "Token env vars override gh auth switch: ${summary}" \
+            "Multi-bot mode tolerates this if you understand the precedence."
+    fi
+fi
+
+# Classic-PAT hygiene check (WARN regardless of mode).
+if [ ${#classic_pat_names[@]} -gt 0 ]; then
+    classic_summary="$(IFS=', '; echo "${classic_pat_names[*]}")"
+    warn "GitHub Auth" "Classic PAT(s) detected: ${classic_summary}" \
+        "Prefer fine-grained PATs (github_pat_*); they scope to specific repos and expire."
 fi
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #84. Inverts the doctor check on `GITHUB_PERSONAL_ACCESS_TOKEN`: previously a PASS signal, now mode-aware (FAIL in solo mode, WARN in multi-bot). Also detects suffixed variants and `GH_TOKEN`, and adds a classic-PAT (`ghp_*`) hygiene WARN that fires regardless of mode.

## Why

`gh` uses `GITHUB_PERSONAL_ACCESS_TOKEN` (any suffix) and `GH_TOKEN` above its keyring whenever set. That makes `gh auth switch` silently ineffective: the keyring's "active account" pointer updates, but every gh call still authenticates with the env-var token. The downstream 2026-04-30 dry-run on `tck517/tck517-app` discovered this with three such variables set; the symptom was a session full of opaque `403 Resource not accessible by personal access token` errors.

`doctor.sh` is the framework's diagnostic tool — it should be the first place this surfaces, not a missing signal.

## What changed

| Behavior | Before | After |
|---|---|---|
| `GITHUB_PERSONAL_ACCESS_TOKEN` set, solo mode | PASS | **FAIL** with actionable cleanup recipe + `setup-solo-mode.sh` reference |
| `GITHUB_PERSONAL_ACCESS_TOKEN` set, multi-bot | PASS | **WARN** with precedence note |
| `GITHUB_PERSONAL_ACCESS_TOKEN_TCK517` set | not detected | detected (any suffix matches) |
| `GH_TOKEN` set | not detected | detected |
| `ghp_*` classic PAT detected | not flagged | **WARN** regardless of mode (hygiene) |
| No token env vars set | SKIP | **PASS** ("gh keyring is the source of truth") |
| Multiple tokens detected | N/A | one consolidated FAIL/WARN with comma-joined list |
| Token preview leak risk | low (first-4...last-4) | unchanged |

Verified manually against my current shell (3 token vars: 2 classic PATs + 1 oauth). All four classification paths exercised and produce correct output.

## Tests

doctor.sh has no test harness in this repo. Verification was manual:

```
$ bash scripts/doctor.sh 2>&1 | grep "Token env vars\|Classic PAT"
[WARN] GitHub Auth: Token env vars override gh auth switch: GITHUB_PERSONAL_ACCESS_TOKEN_VA_WORKER=ghp_...RHRj,
       GITHUB_PERSONAL_ACCESS_TOKEN_TCK517=ghp_...eWuf,
       GITHUB_PERSONAL_ACCESS_TOKEN=gho_...VGxr — Multi-bot mode tolerates...
[WARN] GitHub Auth: Classic PAT(s) detected: GITHUB_PERSONAL_ACCESS_TOKEN_VA_WORKER,
       GITHUB_PERSONAL_ACCESS_TOKEN_TCK517 — Prefer fine-grained PATs...

$ AGILE_FLOW_SOLO_MODE=true bash scripts/doctor.sh 2>&1 | grep "Token env vars"
[FAIL] GitHub Auth: Token env vars override gh auth switch in solo mode: ... — Remove from your shell rc...
```

shellcheck clean (one pre-existing SC2034 at line 199 is unrelated to this PR; `scripts/validation/validate-scripts.sh` excludes SC2034).

All 6 fast test suites green (139 assertions): setup-solo-mode (25), diagnose-cloudrun (35), workshop-roster (32), workshop-setup (21), workshop-teardown (18), ensure-github-account (8). pytest 22/22. lint-agent-policies clean.

## Verification post-merge

- [ ] CI green
- [ ] After merge: a fresh fork in solo mode with stale token env vars sees a FAIL on first `/doctor` run with the actionable cleanup hint
- [ ] After `setup-solo-mode.sh` (#83) audits + the user removes the env vars + restarts shell: `/doctor` reports PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)