### PR TITLE
feat(neon): document branch model + detect parent-branch collision (closes #90)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -75,7 +75,14 @@ jobs:
           branch_name: pr-${{ env.PR_NUMBER }}
           # Workshop forks set NEON_PARENT_BRANCH to the attendee's branch name
           # (e.g. "alice") so per-PR previews inherit that attendee's schema.
-          # Non-workshop forks leave it unset and fall back to "main".
+          # Non-workshop forks leave it unset and fall back to the literal
+          # string "main" — which assumes the Neon project's default branch
+          # is named "main". Projects that were created with a different
+          # default name (e.g. "production") MUST set NEON_PARENT_BRANCH
+          # explicitly per fork; the literal-string fallback below does not
+          # query the project's actual default and will silently fail or
+          # create a sibling. See docs/PLATFORM-GUIDE.md "Neon Branch Model"
+          # for the canonical naming requirements (#90).
           # `||` is fine inside `with:` — only `if:` rejects `secrets.*`.
           parent: ${{ secrets.NEON_PARENT_BRANCH || 'main' }}
           username: ${{ vars.NEON_DB_USER || 'neondb_owner' }}

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -629,6 +629,109 @@ gitignored. They contain participant emails — never commit either.
 
 ---
 
+## Neon Branch Model
+
+Neon branches are how the framework gives each attendee an isolated
+database without provisioning a separate Neon project per person. This
+section documents the framework's branch types, the workshop
+multi-tenancy model, and the collision behavior — read it once before
+running a cohort, especially if you're reusing a Neon project across
+cohorts.
+
+### Branch namespace
+
+Neon branches are unique within a project. Across projects, names can
+repeat freely. The framework uses one Neon project per cohort by
+default.
+
+### Branch types
+
+The framework creates and consumes three categories of Neon branch:
+
+| Type | Owner | Lifetime | Created by |
+|---|---|---|---|
+| `main` | Project default | Permanent | Neon (at project creation) |
+| `<roster-handle>` | One per roster row | Long-lived | `provision-gcp-project.sh` Step 5.7 |
+| `pr-{N}` | One per open PR | Short-lived | `preview-deploy.yml` |
+
+- **`main`** — the project's default branch. The production app's
+  pooled connection points here. **Must be named `main` literally.**
+  `preview-deploy.yml:80` falls back to the literal string `'main'`
+  when `NEON_PARENT_BRANCH` is unset; if your Neon project's default
+  branch is named differently (`production`, etc.), set
+  `NEON_PARENT_BRANCH` explicitly per fork or expect the parent
+  fallback to silently fail.
+- **`<roster-handle>`** — long-lived seed branches, one per roster row.
+  Branch name defaults to the CSV's `handle` column. Created once
+  during onboarding by Step 5.7 of `provision-gcp-project.sh`. Never
+  auto-deleted — these survive across cohorts unless a facilitator
+  manually removes them.
+- **`pr-{N}`** — short-lived. Auto-created by `preview-deploy.yml`
+  on PR open, auto-deleted by `preview-cleanup.yml` on PR close. PR
+  numbers are unique-per-repo, so cross-fork preview branches do
+  not collide.
+
+### What `NEON_PARENT_BRANCH` does
+
+Determines what schema and seed data each PR's preview branch
+inherits. The default `main` means "inherit from production schema,
+no seed data." Setting it to an attendee's roster handle means
+"inherit from my seeded dev data." `provision-gcp-project.sh` Step 7
+auto-pushes this as a GitHub Actions secret on the attendee's fork.
+
+### Workshop multi-tenancy model
+
+Facilitators typically provision **one** shared Neon project per
+cohort (cost-efficient). Three implications:
+
+1. **All attendees see each other's branches in the Neon console.**
+   This is normal; not a privacy issue (branch names are roster
+   handles, not anything sensitive).
+2. **Branch deletion is project-wide.** If `preview-cleanup.yml`
+   deletes `pr-3`, it's gone for the entire project, not just the
+   triggering fork. PR-number uniqueness across forks prevents this
+   from causing real harm in normal use, but be aware.
+3. **What you should expect to see in the console.** Given a roster
+   of N attendees, expect: 1× `main` (the default), N× `<handle>`
+   (one per row), 0+× `pr-{N}` (one per open PR across all forks).
+   Anything else is checkable against `roster.csv` — if a console
+   branch isn't in the roster, it's a leftover.
+
+### Collision behavior (since #90)
+
+Two roster rows with the same handle, OR a single row whose handle
+matches a branch left over from a prior cohort, results in the
+provisioner **failing fast** with an actionable message:
+
+```text
+ERROR: Neon branch 'alice' already exists in project 'dark-grass-...'.
+  This may mean: another roster row already used this handle,
+  OR a prior cohort left a branch with this name.
+  Choose a different handle, OR set NEON_FORCE_SHARED_PARENT=true
+  if you intentionally want to share the parent branch (paired
+  collaboration, or re-running the same cohort).
+```
+
+To intentionally share a parent (paired collaboration, or
+re-running an existing cohort against the still-populated Neon
+project), set `NEON_FORCE_SHARED_PARENT=true` in the environment
+when running the provisioner. The wrapper accepts
+`--force-shared-parent` and propagates it.
+
+```bash
+# Default: fail fast on existing branch
+bash scripts/provision-workshop-roster.sh roster.csv
+
+# Intentional shared parent
+bash scripts/provision-workshop-roster.sh roster.csv --force-shared-parent
+```
+
+The previous behavior (silent reuse on 409) is preserved when the
+flag is set, so existing automation with intentional collisions
+keeps working — just turn the flag on explicitly.
+
+---
+
 ## Daily Operations
 
 ### Viewing Logs

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -654,7 +654,29 @@ sys.exit('no default branch found in project response')
     branch_id="$(python3 -c "import json,sys; print(json.load(open('$create_response_file'))['branch']['id'])")"
     echo "[neon] branch created (id=$branch_id)"
   elif [[ "$http_code" == "409" ]]; then
-    echo "[neon] branch '$NEON_BRANCH_NAME' already exists; reusing"
+    # 409: a branch with this name already exists in the project.
+    #
+    # Default behavior (since #90): fail loud. Two roster rows with
+    # the same handle, OR a roster row whose handle matches a branch
+    # left over from a prior cohort, would otherwise silently mount
+    # this attendee's database-url Secret Manager secret to the
+    # OTHER attendee's Neon branch — invisible cross-contamination.
+    #
+    # NEON_FORCE_SHARED_PARENT=true preserves the original silent-reuse
+    # behavior for legitimate cases: paired attendees collaborating on
+    # the same dataset, or re-running the same cohort against an
+    # already-populated Neon project. Set explicitly; never default on.
+    if [[ "${NEON_FORCE_SHARED_PARENT:-false}" != "true" ]]; then
+      echo "ERROR: Neon branch '$NEON_BRANCH_NAME' already exists in project '$NEON_PROJECT_ID'." >&2
+      echo "  This may mean: another roster row already used this handle," >&2
+      echo "  OR a prior cohort left a branch with this name." >&2
+      echo "  Choose a different handle, OR set NEON_FORCE_SHARED_PARENT=true" >&2
+      echo "  if you intentionally want to share the parent branch (paired" >&2
+      echo "  collaboration, or re-running the same cohort)." >&2
+      rm -f "$create_response_file"
+      exit 1
+    fi
+    echo "[neon] branch '$NEON_BRANCH_NAME' already exists; reusing per NEON_FORCE_SHARED_PARENT=true"
     # Look up the existing branch's ID by name.
     branch_id="$(echo "$branches_json" | python3 -c "
 import json, sys

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -1184,6 +1184,8 @@ EOF
   # Use ${var-default} (no colon) so an explicit empty string passed by
   # the caller — like test 15's "" for NEON_API_KEY — stays empty.
   # ${var:-default} would substitute on empty, which we don't want here.
+  # 5th arg is NEON_FORCE_SHARED_PARENT (default false; pass "true" for
+  # collision-reuse tests in the post-#90 world).
   set +e
   PATH="$tmp/bin:$PATH" \
     GCP_PROJECT_ID="af-step57-test" \
@@ -1191,6 +1193,7 @@ EOF
     NEON_API_KEY="${2-fake-api-key}" \
     NEON_PROJECT_ID="${3-fake-project-id}" \
     NEON_BRANCH_NAME="${4-alice}" \
+    NEON_FORCE_SHARED_PARENT="${5-false}" \
     "$SCRIPT" --create-project > "$tmp/stdout.log" 2>&1
   set -e
 
@@ -1262,17 +1265,20 @@ else
 fi
 
 # Test 17: branch exists, secret exists with SAME value → no-op skip
+# Requires NEON_FORCE_SHARED_PARENT=true (since #90) — the realistic
+# trigger for this code path is re-running the same cohort against an
+# already-populated Neon project, which is the explicit-share case.
 
 echo ""
-echo "Test 17: Step 5.7 idempotent when branch + secret already current"
+echo "Test 17: Step 5.7 idempotent when branch + secret already current (with --force-shared-parent)"
 
-T17=$(run_step5_7_test "exists-same-value")
+T17=$(run_step5_7_test "exists-same-value" "fake-api-key" "fake-project-id" "alice" "true")
 
-if grep -q "branch.*alice.*already exists" "$T17/stdout.log"; then
-  echo -e "  ${GREEN}✓${NC} branch-already-exists log line"
+if grep -q "branch.*alice.*already exists.*reusing per NEON_FORCE_SHARED_PARENT" "$T17/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} branch-already-exists log line names the force flag"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}✗${NC} expected 'branch already exists' in stdout"
+  echo -e "  ${RED}✗${NC} expected 'branch already exists; reusing per NEON_FORCE_SHARED_PARENT' in stdout"
   cat "$T17/stdout.log"
   FAIL=$((FAIL + 1))
 fi
@@ -2248,6 +2254,91 @@ if grep -q "\[hook\] Activated pre-push hook" "$T28c/run.log"; then
 else
   echo -e "  ${RED}✗${NC} expected '[hook] Activated' before the GCP_PROJECT_ID error"
   cat "$T28c/run.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 29: Neon 409 with NEON_FORCE_SHARED_PARENT unset → fail fast ──
+#
+# Per #90: silent reuse on 409 is the cross-contamination footgun. Two
+# attendees with the same handle (or a re-run cohort against a populated
+# Neon project) should fail fast with an actionable message rather than
+# transparently mounting the second attendee's database-url secret to
+# the first attendee's branch.
+
+echo ""
+echo "Test 29: Step 5.7 fails fast on Neon 409 when NEON_FORCE_SHARED_PARENT unset"
+
+T29=$(run_step5_7_test "exists" "fake-api-key" "fake-project-id" "alice" "false")
+
+# Note: run_step5_7_test wraps the inner call in `set +e`, so the helper
+# always returns 0. Verify behavior via stdout content + gcloud.log.
+
+if grep -q "ERROR: Neon branch 'alice' already exists" "$T29/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} fail-fast error message names the branch and project"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected fail-fast error in stdout"
+  cat "$T29/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "set NEON_FORCE_SHARED_PARENT=true" "$T29/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} error message points at the escape hatch"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected error to mention NEON_FORCE_SHARED_PARENT escape hatch"
+  FAIL=$((FAIL + 1))
+fi
+
+# Should NOT have proceeded to write the database-url secret (cross-contam guard)
+if ! grep -q "secrets create database-url\|secrets versions add database-url" "$T29/gcloud.log"; then
+  echo -e "  ${GREEN}✓${NC} did NOT write database-url secret after fail-fast"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} script wrote database-url secret despite collision (cross-contam!)"
+  cat "$T29/gcloud.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 30: Neon 409 with NEON_FORCE_SHARED_PARENT=true → silent reuse ──
+#
+# The opt-in path: legitimate re-run of an existing cohort, or paired
+# attendees intentionally sharing a parent branch. Same behavior as the
+# pre-#90 default: reuse the branch, write the secret, no error.
+
+echo ""
+echo "Test 30: Step 5.7 reuses existing branch when NEON_FORCE_SHARED_PARENT=true"
+
+T30=$(run_step5_7_test "exists" "fake-api-key" "fake-project-id" "alice" "true")
+
+if grep -q "reusing per NEON_FORCE_SHARED_PARENT=true" "$T30/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} reuse log line names the force flag"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected 'reusing per NEON_FORCE_SHARED_PARENT' in stdout"
+  cat "$T30/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+if ! grep -q "ERROR: Neon branch" "$T30/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} no fail-fast error when force flag is set"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} script emitted error despite force flag"
+  cat "$T30/stdout.log"
+  FAIL=$((FAIL + 1))
+fi
+
+# Should have proceeded through to secret write (preserves the pre-#90 behavior).
+# The script emits its own `[create] database-url secret` /
+# `[skip] database-url secret already current` log prefix on stdout;
+# the underlying gcloud call lives in gcloud.log.
+if grep -qE "\[(create|update|skip)\] database-url secret" "$T30/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} proceeded to database-url secret handling"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} did not reach database-url secret step under force flag"
+  cat "$T30/stdout.log"
   FAIL=$((FAIL + 1))
 fi
 

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -7,9 +7,20 @@
 #
 # Usage:
 #   BILLING_ACCOUNT_ID=XXX-XXXX-XXXX ./scripts/provision-workshop-roster.sh roster.csv
+#   BILLING_ACCOUNT_ID=XXX ./scripts/provision-workshop-roster.sh roster.csv --force-shared-parent
 #
 # Required environment variables:
 #   BILLING_ACCOUNT_ID   The GCP billing account to attach each project to
+#
+# Optional flags:
+#   --force-shared-parent    Pass NEON_FORCE_SHARED_PARENT=true to the inner
+#                            script. By default, an existing Neon branch with
+#                            a roster handle's name causes the inner script
+#                            to fail with an actionable error (#90 — prevents
+#                            silent cross-contamination). Set this flag to
+#                            opt back into the previous silent-reuse behavior
+#                            for paired collaboration or re-running an existing
+#                            cohort against a still-populated Neon project.
 #
 # Optional environment variables:
 #   GCP_REGION           (default: us-central1) — passed through to inner script
@@ -17,6 +28,8 @@
 #   PROVISION_SCRIPT     (default: scripts/provision-gcp-project.sh) — for tests
 #   NEON_API_KEY         optional; forwarded to inner script for branch creation
 #   NEON_PROJECT_ID      optional; forwarded to inner script for branch creation
+#   NEON_FORCE_SHARED_PARENT  same effect as --force-shared-parent above; the
+#                            flag sets this env var on the inner script
 #   BUDGET_CAP_USD       optional; forwarded to inner script for Step 5.6
 #                        (per-project billing budget). Default for workshop
 #                        usage is 25.
@@ -65,16 +78,42 @@ OUTPUT_CSV="${OUTPUT_CSV:-roster-output.csv}"
 
 # ── Argument parsing ─────────────────────────────────────────────────────
 
-if [[ $# -ne 1 ]]; then
+ROSTER_CSV=""
+FORCE_SHARED_PARENT="${NEON_FORCE_SHARED_PARENT:-false}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-shared-parent)
+      FORCE_SHARED_PARENT=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,60p' "$0"
+      exit 0
+      ;;
+    --*)
+      echo "ERROR: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$ROSTER_CSV" ]]; then
+        echo "ERROR: multiple positional arguments; expected exactly one (the roster CSV)" >&2
+        exit 2
+      fi
+      ROSTER_CSV="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$ROSTER_CSV" ]]; then
   cat >&2 <<EOF
-Usage: BILLING_ACCOUNT_ID=XXX ./scripts/provision-workshop-roster.sh <roster.csv>
+Usage: BILLING_ACCOUNT_ID=XXX ./scripts/provision-workshop-roster.sh <roster.csv> [--force-shared-parent]
 
 See header of $0 for full documentation.
 EOF
   exit 2
 fi
-
-ROSTER_CSV="$1"
 
 if [[ ! -f "$ROSTER_CSV" ]]; then
   echo "ERROR: roster file not found: $ROSTER_CSV" >&2
@@ -229,6 +268,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   NEON_BRANCH_NAME="$neon_branch" \
   NEON_API_KEY="${NEON_API_KEY:-}" \
   NEON_PROJECT_ID="${NEON_PROJECT_ID:-}" \
+  NEON_FORCE_SHARED_PARENT="$FORCE_SHARED_PARENT" \
   BUDGET_CAP_USD="${BUDGET_CAP_USD:-}" \
     "$PROVISION_SCRIPT" --create-project
 


### PR DESCRIPTION
## Summary

Closes #90. Closes a silent-cross-contamination footgun in the Neon-branch flow + adds the canonical Neon Branch Model docs section.

## Why

Two real workshop scenarios collided with the framework's pre-#90 silent-reuse-on-409 behavior in `provision-gcp-project.sh:656-657`:

1. **Two attendees with the same handle** in the roster CSV: the second provisioner run silently mounted the second attendee's `database-url` Secret Manager secret to the first attendee's existing Neon branch. No error.
2. **Re-running a cohort against an already-populated Neon project** (common when a facilitator runs the workshop a second time with a fresh roster): every attendee whose handle matched a leftover branch from the prior cohort hit the same silent-reuse path.

Surfaced in `tck517/tck517-app:docs/UPSTREAM-HANDOFF.md` Issue #5.

## What changed

### Fix B — Collision detection in provisioner

Replace silent-reuse path at `scripts/provision-gcp-project.sh:656` with fail-or-force gate:

```diff
   elif [[ "$http_code" == "409" ]]; then
-    echo "[neon] branch '$NEON_BRANCH_NAME' already exists; reusing"
+    if [[ "${NEON_FORCE_SHARED_PARENT:-false}" != "true" ]]; then
+      echo "ERROR: Neon branch '$NEON_BRANCH_NAME' already exists in project '$NEON_PROJECT_ID'." >&2
+      echo "  This may mean: another roster row already used this handle," >&2
+      echo "  OR a prior cohort left a branch with this name." >&2
+      echo "  Choose a different handle, OR set NEON_FORCE_SHARED_PARENT=true" >&2
+      echo "  if you intentionally want to share the parent branch (paired" >&2
+      echo "  collaboration, or re-running the same cohort)." >&2
+      rm -f "$create_response_file"
+      exit 1
+    fi
+    echo "[neon] branch '$NEON_BRANCH_NAME' already exists; reusing per NEON_FORCE_SHARED_PARENT=true"
```

The escape-hatch path preserves the pre-#90 silent-reuse behavior verbatim — paired collaboration and re-running existing cohorts continue to work, just opt-in.

### Fix A — `docs/PLATFORM-GUIDE.md` Neon Branch Model section

New top-level section between Workshop Lifecycle and Daily Operations, covering:
- Branch namespace (unique within project)
- Three framework branch types (`main`, `<roster-handle>`, `pr-{N}`) with owners + lifetimes
- What `NEON_PARENT_BRANCH` does
- Workshop multi-tenancy model
- **What you should expect to see in the console** — given a roster of N, expect 1× `main` + N× `<handle>` + 0+× `pr-{N}`. Anything else is checkable against `roster.csv`. Generalizes the `va-worker`-confusion case from the downstream report (the user saw a Neon branch named after a bot, didn't know if it was legitimate; turned out to be a roster row with that handle).
- Collision behavior with the new fail-fast guard

### Fix C — `preview-deploy.yml` comment update

Inline comment at `parent: ${{ secrets.NEON_PARENT_BRANCH || 'main' }}` now explicitly calls out that `'main'` is a literal-string fallback, not "the project's actual default branch." Projects with a different default name must set `NEON_PARENT_BRANCH` explicitly.

### Wrapper change — `--force-shared-parent` flag

`scripts/provision-workshop-roster.sh` accepts `--force-shared-parent` and propagates as `NEON_FORCE_SHARED_PARENT=true`. Wrapper arg parsing rewritten to support flags alongside the positional roster CSV; preserves the strict "exactly one positional arg" check.

```bash
# Default: fail fast on existing branch
bash scripts/provision-workshop-roster.sh roster.csv

# Intentional shared parent
bash scripts/provision-workshop-roster.sh roster.csv --force-shared-parent
```

## Tests

| Test | Coverage |
|---|---|
| 17 (updated) | Existing idempotent-rerun test now passes `--force-shared-parent`; asserts the new log line names the flag |
| 29 (new) | Neon 409 + force unset → exit 1 with actionable message, names escape hatch, **does NOT write database-url secret** (cross-contam guard) |
| 30 (new) | Neon 409 + force=true → silent reuse, no error, proceeds to database-url secret handling |

| Suite | Before | After |
|---|---|---|
| `provision-gcp-project.test.sh` | 100 | **106** |
| `provision-workshop-roster.test.sh` | 32 | 32 |
| `setup-solo-mode.test.sh` | 25 | 25 |
| `diagnose-cloudrun.test.sh` | 35 | 35 |
| `workshop-setup.test.sh` | 21 | 21 |
| `workshop-teardown.test.sh` | 18 | 18 |
| `ensure-github-account.test.sh` | 8 | 8 |
| **Total** | 239 | **245** |

shellcheck + markdownlint + actionlint + pytest all clean.

## Verification post-merge

- [ ] CI green
- [ ] On a re-run cohort: confirm provisioner exits 1 with the actionable message when a roster handle collides with a leftover branch
- [ ] On a paired-collaboration row: confirm `--force-shared-parent` enables the silent-reuse path with the new explicit log line
- [ ] PLATFORM-GUIDE.md "Neon Branch Model" section renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)