### PR TITLE
docs: document auto-move-to-Done UI toggle (closes #86)

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -33,6 +33,40 @@ Verify or create project board with columns:
 - **In Review** - PR created, awaiting review
 - **Done** - Merged and complete
 
+### 1.5. Enable Auto-Move-to-Done Workflow (manual)
+
+After the project board exists, enable the built-in
+**"Item closed → Status: Done"** workflow so issues auto-move to
+Done when their PR merges (PR body has `Closes #N` → GitHub
+auto-closes the issue → built-in workflow bumps the Status column).
+
+Without this step, every merged PR leaves its issue stuck in **In
+Review** until a human manually drags it to Done — the framework's
+"only humans move to Done" rule is honored, but the human has to
+remember to do it on every merge. Enabling this workflow once
+per-project removes that per-merge step.
+
+**Manual UI toggle (recommended):**
+
+1. Open the project: `https://github.com/orgs/<org>/projects/<N>`
+   (or the user-scoped equivalent)
+2. Click **⋯** (top-right) → **Workflows**
+3. Find **"Item closed"**
+4. Set **When** = `Issue is closed`
+5. Set **Set Status** = `Done`
+6. Toggle **Enabled**
+7. Click **Save and turn on workflow**
+
+**Why not via API:** GitHub's GraphQL exposes
+`projectV2.workflows` for read and `deleteProjectV2Workflow` for
+removal, but no `createProjectV2Workflow` or
+`updateProjectV2Workflow` mutation exists. Built-in workflows can
+only be configured via the web UI. See #86 for the API research.
+
+If the user can't access the UI right now, document that the toggle
+is pending and set a follow-up reminder; the framework still works
+without it (just with manual board-moves on merge).
+
 ### 2. Branch Protection Configuration
 
 Verify or configure branch protection on `main`:

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -770,6 +770,37 @@ keeps working — just turn the flag on explicitly.
 
 ## Daily Operations
 
+### Project board hygiene: enable auto-move-to-Done
+
+If your project board's tickets stay stuck in **In Review** after
+their PRs merge, the project's built-in **"Item closed → Status:
+Done"** workflow isn't enabled.
+
+The framework's `/bootstrap-workflow` instructs facilitators to
+enable this once at project creation (Step 1.5). For existing
+projects (cohorts already past bootstrap), enable it manually
+via the GitHub Projects UI:
+
+1. Open the project: `https://github.com/orgs/<org>/projects/<N>`
+2. Click **⋯** (top-right) → **Workflows**
+3. Find **"Item closed"**
+4. Set **When** = `Issue is closed`, **Set Status** = `Done`
+5. Toggle **Enabled** → **Save and turn on workflow**
+
+Once enabled, the flow becomes: human merges PR → GitHub
+auto-closes the linked issue (because the PR body has
+`Closes #N`) → built-in workflow bumps the project board's
+Status column to Done. **No agent ever moves tickets to Done** —
+the framework's "only humans move to Done" rule is preserved
+because the human's act of merging triggers the chain.
+
+There is no GraphQL mutation to flip this workflow's `enabled`
+state — `projectV2.workflows` is queryable and
+`deleteProjectV2Workflow` exists, but no
+`createProjectV2Workflow` or `updateProjectV2Workflow` exists in
+the public API. The web UI is the only configuration path. See
+issue #86 for the API research.
+
 ### Viewing Logs
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #86 via Option B (accepted by reviewer escalation). Adds doc paths for enabling the project board's built-in **"Item closed → Status: Done"** workflow.

## Why doc-only

Original ticket spec assumed an `updateProjectV2Workflow` GraphQL mutation that doesn't exist in GitHub's public API. Verified empirically:

```
gh api graphql -f query='{ __schema { mutationType { fields { name } } } }'
```

returns `deleteProjectV2Workflow` but no `createProjectV2Workflow` or `updateProjectV2Workflow`. Built-in Project workflows can only be configured via the web UI. The ESCALATION on #86 walked through three options; **Option B (document the manual toggle)** was selected as the only path that doesn't introduce per-fork PAT/App provisioning friction.

## What changed

| File | Change |
|---|---|
| `.claude/commands/bootstrap-workflow.md` | New **Step 1.5** between project-board setup and branch-protection: documents the one-click UI toggle for **"Item closed → Status: Done"**. Bootstrap is the right place because it's a one-time per-project action |
| `docs/PLATFORM-GUIDE.md` | New **"Project board hygiene: enable auto-move-to-Done"** subsection at the top of Daily Operations: manual fallback for existing projects (cohorts already past bootstrap) |

Both sections explicitly note the API limitation (with the specific GraphQL field/mutation names) so the next agent who reads either page doesn't waste time looking for the missing mutation.

## Why this preserves the framework's authority model

CLAUDE.md and the agent briefs prohibit agents from moving tickets to Done — only humans do. **This PR doesn't touch those prohibitions.** The fix is at the *project-board configuration* layer, not the *agent-instruction* layer.

After enabling the workflow:
1. Human merges PR (the existing "only humans merge" act)
2. GitHub auto-closes the linked issue because the PR body has `Closes #N`
3. Project's built-in workflow bumps the Status column to Done

Zero per-merge agent action. The chain triggers from the human's merge.

## What this PR does NOT do

- Update agent briefs to "remove the manual `updateProjectV2ItemFieldValue` step on merge" (the ticket DoD listed this as conditional). Verified via grep — agents never had that instruction. The `move to Done` text in the briefs is exclusively about *prohibiting* it, not about agents performing it. Nothing to remove.
- Provision a workflow YAML or PAT/App. Considered as Option A in the escalation; rejected because it adds the kind of per-fork secret provisioning friction that #82–#84 just removed.

## Tests

Doc-only; no functional code changes. Quality gates run as a sanity check:

- `markdownlint` clean on both touched files
- `actionlint` clean (no workflow YAML changes)
- `lint-agent-policies.sh` clean
- Fast test suites still green (35 + 28 + 32 = 95 spot-checked)
- `pytest` 22/22

## Verification post-merge

- [ ] CI green
- [ ] After merge: re-run `/bootstrap-workflow` on a throwaway project. Confirm Step 1.5 prompts the facilitator with the UI-toggle instructions.
- [ ] On the active workshop project (which inherits the In-Review-stuck bug from this conversation): manually enable the workflow per PLATFORM-GUIDE's new subsection. The 7 stuck-from-this-cycle tickets are already moved to Done by hand; the next merge should auto-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)