### PR TITLE
fix(workflows): convert silent-skip guards to fail-loud (#52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,11 @@ jobs:
           uv run --extra dev pytest --tb=short -q --cov --cov-report=term-missing --cov-fail-under=${COVERAGE_THRESHOLD:-80}
 
       - name: Run BDD tests
+        # Legitimate opt-out (per #52 silent-skip audit): hashFiles('') == '' when
+        # the fork has no `features/*.feature` files. Many forks of this template
+        # don't ship BDD tests — the empty result means "no BDD features in this
+        # repo," not "feature collection failed." Keep as a skip-when-absent
+        # gate, NOT a silent-failure cascade.
         if: steps.check_python.outputs.skip != 'true' && hashFiles('features/*.feature') != ''
         run: uv run --extra dev pytest --tb=short -q features/
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -90,14 +90,34 @@ jobs:
 
       # ── Apply Alembic migrations to the Neon branch ──────────────────
 
+      - name: Verify Neon branch produced a usable connection URL
+        # Silent-skip-cascade guard (#52). When neon_configured is true,
+        # `Create Neon branch` MUST produce `db_url_with_pooler`. An
+        # empty output here means the Neon action ran but failed to
+        # emit its output (e.g. an output-name typo regression, an API
+        # change, or a transient Neon API failure). Without this step,
+        # downstream gates would silently skip migrations and the
+        # preview deploy would ship with an empty DATABASE_URL — green
+        # CI, broken preview. Fail loud here turns the latent failure
+        # into a workflow-level error users actually see. See #52, #78.
+        if: steps.check_secrets.outputs.skip != 'true' && steps.check_secrets.outputs.neon_configured == 'true'
+        run: |
+          if [ -z "${{ steps.neon.outputs.db_url_with_pooler }}" ]; then
+            echo "::error::Neon branch step succeeded but did not emit db_url_with_pooler."
+            echo "::error::This is a silent-failure regression — the action ran but produced no usable output."
+            echo "::error::Likely causes: output-name typo, Neon action API change, or upstream transient failure."
+            exit 1
+          fi
+          echo "Neon db_url_with_pooler is populated; proceeding to migrations."
+
       - name: Install uv
-        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_with_pooler != ''
+        if: steps.check_secrets.outputs.skip != 'true' && steps.check_secrets.outputs.neon_configured == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.5.x"
 
       - name: Run Alembic migrations against branch database
-        if: steps.check_secrets.outputs.skip != 'true' && steps.neon.outputs.db_url_with_pooler != ''
+        if: steps.check_secrets.outputs.skip != 'true' && steps.check_secrets.outputs.neon_configured == 'true'
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url_with_pooler }}
         run: |

--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -47,6 +47,7 @@
 21. [GitHub Actions: Graceful Secret Gating](#21-github-actions-graceful-secret-gating)
 22. [GitHub Actions: CI Checks Not Attaching to PR](#22-github-actions-ci-checks-not-attaching-to-pr)
 23. [GitHub Actions: Reusable Workflow Missing workflow_call](#23-github-actions-reusable-workflow-missing-workflow_call)
+33. [GitHub Actions: Silent-Skip Cascade in `if:` Guards](#33-github-actions-silent-skip-cascade-in-if-guards)
 
 ### GitHub Platform
 
@@ -1215,3 +1216,113 @@ deploys alternated against the same service. First fixed defensively
 in #66 with `--remove-env-vars=DATABASE_URL`; later re-fixed
 structurally in #68 by switching both workflows to the same type
 (plain env var).
+
+---
+
+## 33. GitHub Actions: Silent-Skip Cascade in `if:` Guards
+
+**Gotcha:** A workflow step with `if: steps.foo.outputs.bar != ''`
+treats "value missing" as a benign skip signal. But there are two
+distinct reasons an output can be empty:
+
+1. **Legitimate opt-out** — the upstream step was conditionally
+   skipped (user didn't configure the relevant secret, fork doesn't
+   ship that capability, etc.). The downstream skip is correct.
+2. **Silent failure** — the upstream step ran but failed to emit the
+   output (output-name typo, action API change, transient API
+   failure). The downstream skip MASKS the regression.
+
+GitHub Actions can't tell these apart from the workflow file alone.
+Without a guard, the wrong case looks identical to the right case
+on the run summary: green CI, every step "succeeded" or "skipped,"
+and a broken artifact ships.
+
+This template's preview-deploy.yml burned this pattern at scale.
+A typo in the Neon action's output name (`db_url_with_pooler` vs an
+older `db_url`) caused `steps.neon.outputs.db_url_with_pooler` to be
+empty for the entire history of the template. Every downstream
+`!= ''` guard skipped silently. Smoke test passed against
+`/api/health` (which doesn't touch the DB). PR comments said "Ready
+for testing." Only when a human opened the URL did the failure
+surface as a 500 on `/`.
+
+**Pattern:** When a step's `if:` checks an upstream output for
+non-emptiness, ask: *what does empty mean?*
+
+- If empty means "user opted out" — keep the guard, add an inline
+  comment explaining what disables it. The reader can tell intentional
+  skip from accidental skip.
+- If empty means "the upstream step failed silently" — add a
+  **validate step** between the producing and consuming steps. The
+  validate step fires under the same conditions as the consumers, runs
+  an explicit `[ -z "$VAL" ] && exit 1` check with a clear error
+  message, and turns the latent failure into a workflow-level failure
+  the user actually sees.
+
+```yaml
+# BEFORE — silent-skip cascade
+- name: Create Neon branch
+  id: neon
+  if: steps.check_secrets.outputs.neon_configured == 'true'
+  uses: neondatabase/create-branch-action@v5
+  ...
+
+- name: Run migrations
+  # If neon_configured=true but db_url_with_pooler='' (typo, API change),
+  # this skip silently masks the regression.
+  if: steps.neon.outputs.db_url_with_pooler != ''
+  run: uv run alembic upgrade head
+```
+
+```yaml
+# AFTER — fail-loud validation gate
+- name: Create Neon branch
+  id: neon
+  if: steps.check_secrets.outputs.neon_configured == 'true'
+  uses: neondatabase/create-branch-action@v5
+  ...
+
+- name: Verify Neon branch produced a usable connection URL
+  if: steps.check_secrets.outputs.neon_configured == 'true'
+  run: |
+    if [ -z "${{ steps.neon.outputs.db_url_with_pooler }}" ]; then
+      echo "::error::Neon branch step succeeded but did not emit db_url_with_pooler."
+      echo "::error::Likely causes: output-name typo, Neon action API change, transient failure."
+      exit 1
+    fi
+
+- name: Run migrations
+  # Now safe: validate step above ensures the output is populated.
+  if: steps.check_secrets.outputs.neon_configured == 'true'
+  env:
+    DATABASE_URL: ${{ steps.neon.outputs.db_url_with_pooler }}
+  run: uv run alembic upgrade head
+```
+
+**Distinguishing legitimate opt-outs from silent-skip cascades:** the
+clean signal is whether the producing step's *own* `if:` is a
+superset of (or equal to) the consumer's. If the producer ran (its
+`if` was true), then a missing output means failure, not skip.
+Validate step's `if:` should match the producer's, not the
+consumer's "is the output set?" pattern.
+
+**Example of a legitimate opt-out** (kept as-is):
+
+```yaml
+- name: Run BDD tests
+  # Many forks of this template don't ship BDD tests — empty hash
+  # means "no .feature files in this repo," NOT "feature collection
+  # failed." Skip-when-absent is correct here.
+  if: hashFiles('features/*.feature') != ''
+  run: pytest features/
+```
+
+Surfaced in the 2026-04-29 audit (#52). The cumulative cost of
+silent-skip cascades in this template's preview-deploy.yml was
+estimated at three latent bugs hidden for the entire history of the
+fork — a typo, a psycopg3 driver mismatch, and mutually-exclusive
+gcloud env-var flags — none of which would have manifested if any
+single CI run had failed loud at the missing output. Conversion to
+fail-loud is therefore a *retroactive* defense: it doesn't fix the
+specific bugs the cascade hid, but it ensures the next bug surfaces
+within one run instead of months.


### PR DESCRIPTION
## Summary

Audits every `if: ... != ''` guard in the workflow surface and converts silent-skip cascades to fail-loud, while documenting the legitimate opt-out so future audits don't re-flag it.

- **ci.yml** — `hashFiles('features/*.feature') != ''` is a legitimate opt-out (many forks don't ship BDD tests). Documented inline.
- **preview-deploy.yml** — Two guards on `db_url_with_pooler != ''` (Install uv, Run Alembic) were silent-skip cascades. Replaced with `neon_configured == 'true'` and added a fail-loud verify step between the Neon action and its consumers. If Neon ran but emitted no usable URL (output-name regression, API change, transient failure), the workflow now errors visibly instead of shipping a preview with an empty `DATABASE_URL`.
- **docs/PATTERN-LIBRARY.md** — Pattern #33 codifies the anti-pattern with this template's history as the worked example.

## Why this matters

Three latent bugs in this repo's history (#27, #29, #76) were each masked by some flavor of cascade-hides-failure. #78 specifically burned a workshop dry-run cycle because the migration step silently skipped on an empty Neon URL — green CI, broken preview. This change closes that class.

## Test plan

- [x] `actionlint -config-file .github/actionlint.yaml` clean
- [x] `pytest` 22/22
- [x] `markdownlint-cli2 docs/PATTERN-LIBRARY.md` clean
- [x] All agent / command / policy validators pass
- [ ] CI green on PR
- [ ] Real-world verification: next preview deploy on a Neon-configured fork. The fail-loud path is exercised any time the Neon action emits empty output.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)