### PR TITLE
fix(hook): make ensure-github-account.sh self-healing (#85)

### DIFF
--- a/.claude/hooks/ensure-github-account.sh
+++ b/.claude/hooks/ensure-github-account.sh
@@ -12,6 +12,16 @@
 #
 # Configure via environment variables or edit the defaults below.
 #
+# Two short-circuits before the hook attempts any account switch:
+#   1. Env-var fast path — AGILE_FLOW_SOLO_MODE=true exits 0 unconditionally.
+#   2. Keyring safety net (#85) — if the active gh account is not one of the
+#      configured bots, exit 0. Catches solo-mode setups where the env var
+#      didn't propagate to Claude's Bash subprocesses, and post
+#      `gh auth refresh` recoveries that flipped the active account to
+#      personal. Both are present because env vars and keyring state can
+#      diverge in real-world scenarios; the keyring is the reliable signal
+#      when they conflict. See UPSTREAM-HANDOFF.md Issue #4 Fix B.
+#
 
 set -euo pipefail
 
@@ -55,8 +65,41 @@ case "$tool_name" in
     ;;
 esac
 
-# Get current active account
-current_account=$(gh auth status 2>&1 | grep -B2 "Active account: true" | grep "Logged in to" | sed 's/.*account \([^ ]*\).*/\1/')
+# Get current active account. Fail-open: with `set -o pipefail`, an
+# empty/unparsable `gh auth status` would otherwise kill the hook
+# with exit 1 and block the tool call. The self-heal block below and
+# the existing switch logic both handle empty `current_account`
+# gracefully, so we'd rather get an empty value than die here.
+current_account=$(gh auth status 2>&1 | grep -B2 "Active account: true" | grep "Logged in to" | sed 's/.*account \([^ ]*\).*/\1/' || true)
+
+# Self-healing safety net (#85). If the active account is not one of
+# the configured bots, the user is on a personal account on purpose
+# (solo mode without env-var propagation, or post `gh auth refresh`
+# recovery). Respect that and exit 0 — don't undo their state.
+#
+# Two real-world scenarios where this fires:
+#   1. User ran scripts/setup-solo-mode.sh AFTER starting Claude Code.
+#      AGILE_FLOW_SOLO_MODE is set in their shell rc, but Claude Code's
+#      Bash subprocesses see a snapshot from session start. The
+#      env-var fast path at the top of this hook misses; the keyring
+#      is the more reliable signal.
+#   2. `gh auth refresh` flipped the active account to a personal
+#      account during scope recovery. Switching back to a bot here
+#      would silently undo the user's manual recovery.
+#
+# Multi-bot mode is unaffected: a user with $WORKER_ACCOUNT active
+# falls through to the existing switch-to-reviewer logic below.
+# Fail-open if `gh auth status` returned no parsable account — let
+# the existing logic surface the gh-state error rather than blocking
+# the tool call here.
+# See: docs/UPSTREAM-HANDOFF.md Issue #4 Fix B (originating fork's
+# 2026-04-30 dry-run).
+if [[ -n "$current_account" ]] \
+  && [[ "$current_account" != "$WORKER_ACCOUNT" ]] \
+  && [[ "$current_account" != "$REVIEWER_ACCOUNT" ]]; then
+  echo "[ensure-github-account] Active account '$current_account' is not a configured bot ($WORKER_ACCOUNT/$REVIEWER_ACCOUNT); not switching for $tool_name" >&2
+  exit 0
+fi
 
 # Switch if needed
 if [[ "$current_account" != "$required_account" ]]; then

--- a/.claude/hooks/ensure-github-account.test.sh
+++ b/.claude/hooks/ensure-github-account.test.sh
@@ -174,6 +174,157 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── Test 5: Self-heal — personal account active, env var unset ─────────
+# The downstream's #85 failure mode: user runs setup-solo-mode.sh
+# mid-session, env var doesn't propagate to subprocesses, but the
+# keyring shows them on a personal account. Hook must respect that
+# and not flip them to a bot.
+
+echo ""
+echo "Test 5: personal account active + AGILE_FLOW_SOLO_MODE unset → no switch"
+
+T5=$(new_tmp)
+make_gh_stub "$T5" "tck517"
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T5/bin:$PATH" \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T5/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 (self-heal exits cleanly)"
+
+if [[ -f "$T5/gh.log" ]] && grep -q "auth switch" "$T5/gh.log"; then
+  echo -e "  ${RED}✗${NC} gh auth switch was called — self-heal failed to short-circuit"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} no gh auth switch attempted (self-heal respected personal account)"
+  PASS=$((PASS + 1))
+fi
+
+# Stderr should explain why the switch was skipped, so the user knows
+# what state they're in.
+if grep -q "not a configured bot" "$T5/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} stderr explains why switch was skipped"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected stderr message about non-bot account"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 6: Self-heal — personal account active, env var explicitly false
+# Defends against shells that set AGILE_FLOW_SOLO_MODE to something
+# other than "true" (e.g. "false", "0"). The keyring check should still
+# fire and the user should still not be flipped to a bot.
+
+echo ""
+echo "Test 6: personal account active + AGILE_FLOW_SOLO_MODE=false → no switch"
+
+T6=$(new_tmp)
+make_gh_stub "$T6" "tck517"
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T6/bin:$PATH" \
+  AGILE_FLOW_SOLO_MODE=false \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T6/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+
+if [[ -f "$T6/gh.log" ]] && grep -q "auth switch" "$T6/gh.log"; then
+  echo -e "  ${RED}✗${NC} gh auth switch was called — self-heal failed under SOLO_MODE=false"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} no gh auth switch attempted under SOLO_MODE=false (keyring still respected)"
+  PASS=$((PASS + 1))
+fi
+
+# ── Test 7: Self-heal does NOT fire when active account IS a bot ────────
+# Multi-bot mode regression guard. va-worker active + gh pr review → must
+# still switch to va-reviewer.
+
+echo ""
+echo "Test 7: va-worker active + gh pr review → switch to va-reviewer"
+
+T7=$(new_tmp)
+make_gh_stub "$T7" "va-worker"
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr review 123 --approve"}}'
+
+set +e
+PATH="$T7/bin:$PATH" \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T7/stdout.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+
+if [[ -f "$T7/gh.log" ]] && grep -q "auth switch --user va-reviewer" "$T7/gh.log"; then
+  echo -e "  ${GREEN}✓${NC} gh auth switch --user va-reviewer was called (multi-bot still works)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected switch to va-reviewer for gh pr review"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 8: Fail-open when gh auth status returns no active account ─────
+# If the parse yields an empty current_account, the self-heal check
+# skips (since -n "" is false) and existing logic continues. The
+# existing gh auth switch attempt will then surface the actual auth
+# error — better than blocking the tool call from this hook.
+
+echo ""
+echo "Test 8: empty active account → self-heal does NOT short-circuit"
+
+T8=$(new_tmp)
+mkdir -p "$T8/bin"
+# gh stub that returns empty `auth status` output (no Active account line).
+cat > "$T8/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$T8/gh.log"
+case "\$1 \$2" in
+  "auth status") echo ""; exit 0 ;;
+  "auth switch") echo "switched"; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T8/bin/gh"
+
+input='{"tool_name":"Bash","tool_input":{"command":"gh pr create --title foo"}}'
+
+set +e
+PATH="$T8/bin:$PATH" \
+  AGILE_FLOW_WORKER_ACCOUNT="va-worker" \
+  AGILE_FLOW_REVIEWER_ACCOUNT="va-reviewer" \
+  bash "$HOOK" <<< "$input" > "$T8/stdout.log" 2>&1
+ec=$?
+set -e
+
+# Empty current_account → self-heal block's [[ -n "$current_account" ]]
+# is false → falls through. Then the switch block compares "" to
+# "va-worker", attempts the switch, the stub returns success → exit 0.
+assert_eq "0" "$ec" "exit 0 (existing logic ran, stub auth-switch succeeded)"
+
+# Confirm the self-heal stderr message did NOT fire.
+if grep -q "not a configured bot" "$T8/stdout.log"; then
+  echo -e "  ${RED}✗${NC} self-heal fired with empty current_account (should fail-open)"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} self-heal did NOT fire on empty current_account (fail-open)"
+  PASS=$((PASS + 1))
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Adds a keyring-state safety net to `.claude/hooks/ensure-github-account.sh`. The existing `AGILE_FLOW_SOLO_MODE` env-var check is the fast path; this is the defense-in-depth for when that env var didn't propagate into Claude Code's Bash tool subprocesses (the real-world failure mode that bit the 2026-04-30 dry-run on `tck517/tck517-app` — UPSTREAM-HANDOFF.md Issue #4 Fix B).

Two scenarios covered:
1. User ran `scripts/setup-solo-mode.sh` AFTER starting Claude Code. Env var is in their shell rc but Claude's Bash subprocesses see a session-start snapshot.
2. `gh auth refresh` flipped the active account to a personal account during scope recovery; switching back to a bot would silently undo the user's manual recovery.

## Implementation

- After fetching `current_account` (which the hook already does), check whether it matches one of the configured bots. If not, log to stderr and `exit 0`. Multi-bot mode is unchanged — `va-worker` active still switches to `va-reviewer` for `gh pr review`.
- Also added `|| true` to the existing `gh auth status | grep ... | sed ...` pipeline. Without it, `set -o pipefail` would kill the hook with exit 1 on unparsable `gh` state, blocking the tool call.
- Top-of-script docstring updated to describe both short-circuits (env-var fast path + keyring safety net).

## Deviation from ticket spec — small but worth noting

Ticket #85's Happy Path proposed `gh auth status --active --json login | jq -r '.login // empty'`. Empirically `gh auth status` does not support `--json login` — only `--jq` for filtering host-list JSON. I used the existing parsing pattern instead, which:

- Matches the test stub's output shape (no test fixture changes needed)
- Is consistent with the rest of the hook (line 59 already uses this pattern for the bot-switching path)
- Stays accurate to the ticket's intent — same self-heal semantics, different mechanic

## Tests

- **Test 5:** personal account active + `AGILE_FLOW_SOLO_MODE` unset → no `gh auth switch` (the originating dry-run failure mode)
- **Test 6:** personal account active + `AGILE_FLOW_SOLO_MODE=false` → still no switch (defends against shells that set the var to non-`true` values)
- **Test 7:** `va-worker` active + `gh pr review` → switches to `va-reviewer` (multi-bot regression guard)
- **Test 8:** empty active account → self-heal does NOT short-circuit; falls through to existing logic (fail-open)

8 tests / 17 assertions — all pass.

## Test plan

- [x] `./.claude/hooks/ensure-github-account.test.sh` — 17/17
- [x] `shellcheck` clean (with project's standard exclusions)
- [x] All validation scripts pass
- [x] `pytest` 22/22
- [ ] CI green on PR
- [ ] Real-world: next mid-session `setup-solo-mode.sh` run on a fresh fork (the upcoming dry-run will exercise this path)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)