### PR TITLE
fix(setup): solo-mode bootstrap survives Codespaces GITHUB_TOKEN (#102)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,7 +59,12 @@
   // GITHUB_TOKEN, so gh is already authenticated; setup-solo-mode.sh
   // does the rest (hooks path, scope check, admin verification). uv sync
   // installs Python deps so `uv run pytest` works on first command.
-  "postCreateCommand": "bash scripts/setup-solo-mode.sh && uv sync --extra dev",
+  //
+  // Use `;` (not `&&`) so a setup-solo-mode warning or non-fatal exit
+  // doesn't block uv sync. setup-solo-mode is advisory (audits state,
+  // persists an env var); uv sync is essential (without Python deps
+  // nothing runs). Don't gate the latter on the former. (#102 Fix C.)
+  "postCreateCommand": "bash scripts/setup-solo-mode.sh; uv sync --extra dev",
 
   // FastAPI dev server.
   "forwardPorts": [8080],

--- a/scripts/setup-solo-mode.sh
+++ b/scripts/setup-solo-mode.sh
@@ -217,22 +217,42 @@ echo ""
 # In solo mode, ANY of these env vars override `gh auth switch` silently.
 # Detection is from the current shell environment (what gh sees right now)
 # AND from the shell rc file (so the user knows what to remove permanently).
+#
+# Tracked vars (#102 generalization): the broader category is "env-var
+# token that shadows the keyring." `gh` recognizes GITHUB_TOKEN, GH_TOKEN,
+# GH_ENTERPRISE_TOKEN, and the GITHUB_PERSONAL_ACCESS_TOKEN* family.
+# All four belong to the same class.
 token_env_vars=()
 while IFS= read -r line; do
     [ -n "$line" ] && token_env_vars+=("$line")
-done < <(env | grep -E "^(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN)" | cut -d= -f1 || true)
+done < <(env | grep -E "^(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN)" | cut -d= -f1 || true)
 
 token_rc_lines=()
 if [ -f "$profile" ]; then
     while IFS= read -r line; do
         [ -n "$line" ] && token_rc_lines+=("$line")
-    done < <(grep -nE "^(export\s+)?GITHUB_PERSONAL_ACCESS_TOKEN|^(export\s+)?GH_TOKEN|^set -Ux\s+GITHUB_PERSONAL_ACCESS_TOKEN|^set -Ux\s+GH_TOKEN" "$profile" 2>/dev/null || true)
+    done < <(grep -nE "^(export\s+)?(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN)|^set -Ux\s+(GITHUB_PERSONAL_ACCESS_TOKEN|GH_TOKEN|GITHUB_TOKEN|GH_ENTERPRISE_TOKEN)" "$profile" 2>/dev/null || true)
 fi
 
 env_count=${#token_env_vars[@]}
 rc_count=${#token_rc_lines[@]}
+
+# Codespaces auto-injects GITHUB_TOKEN. If that's the ONLY token var
+# present, treat it as expected/informational rather than a warning —
+# noise is the enemy of attendees finding the real signal. Step 4
+# handles the scope-refresh workaround for the Codespaces case.
+expected_codespace_only=false
+if [ -n "${CODESPACES:-}" ] \
+   && [ "$env_count" -eq 1 ] \
+   && [ "${token_env_vars[0]}" = "GITHUB_TOKEN" ] \
+   && [ "$rc_count" -eq 0 ]; then
+    expected_codespace_only=true
+fi
+
 if [ "$env_count" -eq 0 ] && [ "$rc_count" -eq 0 ]; then
     print_success "No token env vars detected (gh keyring is the source of truth)"
+elif [ "$expected_codespace_only" = "true" ]; then
+    print_info "Codespaces GITHUB_TOKEN detected (expected). Step 4 will check its scopes."
 else
     print_warning "Found token env vars that override gh auth switch:"
     echo ""
@@ -278,11 +298,41 @@ done
 
 if [ ${#missing_scopes[@]} -eq 0 ]; then
     print_success "All required scopes present (${required_scopes[*]})"
+elif [ -n "${CODESPACES:-}" ]; then
+    # Codespaces (#102): the auto-injected GITHUB_TOKEN is a user-to-server
+    # token (`ghu_` prefix) that gh does NOT own. `gh auth refresh` against
+    # it fails with "The value of the GITHUB_TOKEN environment variable is
+    # being used for authentication. To refresh credentials stored in
+    # GitHub CLI, first clear the value from the environment." This is true
+    # regardless of TTY presence (#97's IS_INTERACTIVE guard doesn't help
+    # here because postCreateCommand may have a TTY but the refresh still
+    # fails on the same error).
+    #
+    # The supported workshop path is to configure a GH_TOKEN Codespaces
+    # user secret with a fine-grained PAT carrying the required scopes.
+    # gh prefers GH_TOKEN over GITHUB_TOKEN, so once that secret is set
+    # and the Codespace is rebuilt, scopes are satisfied without any
+    # refresh call.
+    print_warning "Missing scopes: ${missing_scopes[*]}"
+    print_warning "Codespaces detected — GITHUB_TOKEN cannot be refreshed (gh does not own it)."
+    echo ""
+    print_info "To fix: configure a GH_TOKEN Codespaces user secret with the required scopes."
+    print_info "  1. Generate a fine-grained PAT at https://github.com/settings/tokens?type=beta"
+    print_info "     Required scopes: ${required_scopes[*]}"
+    print_info "  2. Save as a Codespaces user secret named GH_TOKEN at"
+    print_info "     https://github.com/settings/codespaces"
+    print_info "  3. Grant the secret access to this fork"
+    print_info "  4. Rebuild the Codespace (Command Palette → Codespaces: Rebuild Container)"
+    echo ""
+    print_info "GH_TOKEN takes precedence over GITHUB_TOKEN, so gh will use the"
+    print_info "broader-scoped token after rebuild without further changes."
+    echo ""
+    print_warning "Continuing — uv sync and the rest of postCreate should still run."
 elif [ "$IS_INTERACTIVE" != "true" ]; then
-    # Non-interactive (Codespace postCreateCommand, CI, piped invocation):
-    # `gh auth refresh` would hang waiting for browser OAuth. WARN and
-    # surface the manual command for the user to run from their first
-    # interactive terminal. See #97.
+    # Non-interactive non-Codespace (CI, piped invocation): `gh auth
+    # refresh` would hang waiting for browser OAuth. WARN and surface the
+    # manual command for the user to run from their first interactive
+    # terminal. See #97.
     print_warning "Missing scopes: ${missing_scopes[*]}"
     print_warning "Skipping refresh (non-interactive context — would block on browser OAuth)"
     print_info "Run manually after this script finishes:"

--- a/scripts/setup-solo-mode.test.sh
+++ b/scripts/setup-solo-mode.test.sh
@@ -390,6 +390,97 @@ set -e
 assert_eq "1" "$ec" "exit 1 when no active gh account"
 assert_contains "No active gh account" "$T8/run.log" "names the issue"
 
+# ── Test 9: Codespaces + missing scopes → WARN+continue, no refresh ──
+# #102 fix: when CODESPACES=true is set, the auto-injected GITHUB_TOKEN
+# cannot be refreshed by gh (gh does not own it). The script must
+# detect Codespaces specifically (not infer from TTY) and exit Step 4
+# cleanly without calling gh auth refresh, regardless of whether stdin
+# has a TTY. Also: the script must continue (not exit 1) so downstream
+# postCreateCommand steps (uv sync) still run.
+
+echo ""
+echo "Test 9: Codespaces + missing scopes → WARN+continue (no refresh attempted)"
+
+T9=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T9"
+
+set +e
+run_script "$T9" \
+    CODESPACES=true \
+    GITHUB_TOKEN="ghu_fake1234567890" \
+    STUB_TOKEN_SCOPES="repo, workflow" \
+    STUB_API_ADMIN="true" \
+    > "$T9/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 (continues so uv sync can run)"
+assert_contains "Codespaces detected" "$T9/run.log" "names Codespaces context"
+assert_contains "GITHUB_TOKEN cannot be refreshed" "$T9/run.log" "explains why refresh is skipped"
+assert_contains "GH_TOKEN Codespaces user secret" "$T9/run.log" "names the supported workaround"
+assert_contains "fine-grained PAT" "$T9/run.log" "tells user what kind of PAT to generate"
+assert_contains "Rebuild the Codespace" "$T9/run.log" "names the apply step (rebuild)"
+# Critical: gh auth refresh must NOT have been called
+if ! grep -q "auth refresh" "$T9/gh.log"; then
+    echo -e "  ${GREEN}OK${NC} did NOT call gh auth refresh in Codespaces context"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} script called gh auth refresh in Codespaces (would error against GITHUB_TOKEN)"
+    cat "$T9/gh.log"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 10: Codespaces + GITHUB_TOKEN present → audit treats as expected
+# Step 3 should NOT scare-warn the user about the auto-injected
+# GITHUB_TOKEN in Codespaces. That's expected/normal. The "Found token
+# env vars that override gh auth switch" warning belongs to setups
+# where the user accidentally exported a token in their shell rc.
+
+echo ""
+echo "Test 10: Codespaces + only GITHUB_TOKEN set → Step 3 informational, not warning"
+
+T10=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T10"
+
+set +e
+run_script "$T10" \
+    CODESPACES=true \
+    GITHUB_TOKEN="ghu_fake1234567890" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    > "$T10/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 on Codespaces happy path"
+assert_contains "Codespaces GITHUB_TOKEN detected (expected)" "$T10/run.log" "informational, not warning"
+assert_not_contains "Found token env vars that override" "$T10/run.log" "no scare-warning for expected Codespaces token"
+
+# ── Test 11: non-Codespace + GITHUB_TOKEN in env → still warns (not silent)
+# Outside Codespaces, GITHUB_TOKEN in the shell env IS a real problem —
+# the user has a stray token export. Step 3 must surface that. This
+# guards against the Codespaces special-case being too permissive.
+
+echo ""
+echo "Test 11: non-Codespace + GITHUB_TOKEN env var → audit warns"
+
+T11=$(STUB_INITIAL_ACCOUNT=alice new_sandbox)
+make_gh_stub "$T11"
+
+set +e
+run_script "$T11" \
+    GITHUB_TOKEN="ghp_fake1234567890" \
+    STUB_TOKEN_SCOPES="repo, project, workflow, read:project" \
+    STUB_API_ADMIN="true" \
+    > "$T11/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 (continues with warning)"
+assert_contains "Found token env vars" "$T11/run.log" "GITHUB_TOKEN audit fires outside Codespaces"
+assert_contains "GITHUB_TOKEN" "$T11/run.log" "names the offending var"
+assert_not_contains "GITHUB_TOKEN detected (expected)" "$T11/run.log" "does not falsely treat as expected outside Codespaces"
+
 # ── Summary ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Three complementary changes for the failure mode that bricked Codespace provisioning on the 2026-05-01 dry-run on `tck517/tck517-app-g`. Closes #102.

**Fix A** — `scripts/setup-solo-mode.sh` Step 4 now detects `CODESPACES` env var directly. Codespaces' auto-injected `GITHUB_TOKEN` is a user-to-server token (`ghu_` prefix) that `gh` does NOT own; `gh auth refresh` fails against it regardless of TTY state. The earlier #97 `IS_INTERACTIVE` guard inferred from TTY presence — empirically Codespaces postCreateCommand DOES have a TTY, so the guard didn't fire. New CODESPACES branch prints attendee-actionable guidance (configure `GH_TOKEN` Codespaces user secret, fine-grained PAT, rebuild) and continues cleanly.

**Fix B** — `scripts/setup-solo-mode.sh` Step 3's audit generalized to cover `GITHUB_TOKEN` and `GH_ENTERPRISE_TOKEN` (in addition to existing `GITHUB_PERSONAL_ACCESS_TOKEN*` and `GH_TOKEN`). All four belong to the "env-var token that shadows the keyring" class. Special case: in Codespaces, a single `GITHUB_TOKEN` is expected — downgrade to informational rather than scare-warning. Outside Codespaces, all four still warn.

**Fix C** — `.devcontainer/devcontainer.json` `postCreateCommand` changed from `&&` to `;` between `setup-solo-mode.sh` and `uv sync --extra dev`. The two are independent: setup-solo-mode is advisory; uv sync is essential.

## Why each fix

- Without Fix A: every workshop attendee opening a Codespace hits `✗ gh auth refresh failed` and the postCreateCommand exits 1.
- Without Fix B: Codespaces' `GITHUB_TOKEN` was already shadowing the keyring on every workshop fork; the audit just wasn't checking for it.
- Without Fix C: even with Fix A in place, any non-fatal warning from setup-solo-mode would block uv sync, leaving the Python environment unprovisioned.

## Tests

42/42 pass locally (28 prior + 14 new):

- **Test 9** — Codespaces + missing scopes → WARN+continue, no `gh auth refresh` attempted, attendee gets specific GH_TOKEN guidance
- **Test 10** — Codespaces + only GITHUB_TOKEN set → Step 3 informational, not scary warning
- **Test 11** — Non-Codespace + GITHUB_TOKEN in env → Step 3 still warns (special case is properly narrow)

## Test plan

- [x] `./scripts/setup-solo-mode.test.sh` — 42/42
- [x] shellcheck on script + tests
- [x] devcontainer.json parses (after stripping JSONC comments)
- [x] All other validators (json/version/commands/agents/policies/lint-agent-policies/agent-restrictions)
- [x] actionlint clean
- [x] pytest 22/22
- [ ] CI green on PR
- [ ] Real-world: next Codespace boot on a workshop fork should provision cleanly through `setup-solo-mode.sh` → `uv sync` even without a `GH_TOKEN` secret configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)