### PR TITLE
fix(devcontainer): preinstall Claude Code extension in Codespace (#103)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,6 +55,22 @@
     "AGILE_FLOW_SOLO_MODE": "true"
   },
 
+  // Preinstall Claude Code in the Codespace's web VS Code (#103). The
+  // extension ships the `claude` binary AND the in-editor sidebar UI;
+  // attendees open the integrated terminal and run `claude` directly,
+  // no manual install. Without this, attendees opening a fresh
+  // Codespace would have no path to start an agent session — every
+  // bootstrap-phase docs step assumes a working `claude` invocation.
+  // First-run prompts attendees to authenticate via browser flow
+  // against their Anthropic account (separate from gh/gcloud auths).
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code"
+      ]
+    }
+  },
+
   // Run the solo-mode bootstrap automatically. Codespaces auto-injects
   // GITHUB_TOKEN, so gh is already authenticated; setup-solo-mode.sh
   // does the rest (hooks path, scope check, admin verification). uv sync

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -66,7 +66,12 @@ for you, identically across all attendees.
 2. Wait ~60 seconds for the container to provision.
 3. Run `gcloud auth login` in the integrated terminal to authenticate
    with GCP (browser OAuth flow).
-4. Skip to **Step 2: Set Up GitHub Access** below — except gh is
+4. The Claude Code extension is preinstalled. To start your first
+   agent session, open the integrated terminal (`Ctrl+` `) and run
+   `claude`. On first run you'll be prompted to authenticate via a
+   browser flow — this is your **Anthropic account**, separate from
+   the GitHub and Google Cloud auths above.
+5. Skip to **Step 2: Set Up GitHub Access** below — except gh is
    already authenticated, so you can skip Step 2 entirely.
 
 The container runs `scripts/setup-solo-mode.sh` automatically as


### PR DESCRIPTION
## Summary

Adds `anthropic.claude-code` to `.devcontainer/devcontainer.json`'s `customizations.vscode.extensions` block. The extension ships the `claude` binary AND the in-editor sidebar UI; attendees open the integrated terminal in their Codespace and run `claude` directly. No manual install. First run prompts for Anthropic-account browser auth.

Companion docs update: `GETTING-STARTED.md` Path A grows a step 4 that tells attendees to run `claude` from the integrated terminal, with an explicit note that the Anthropic-account login is separate from the GitHub and Google Cloud auths done earlier.

Closes #103.

## Why this matters

Surfaced 2026-05-01 in the second dry-run on `tck517/tck517-app-g`. After #102's gh-refresh failure was worked around manually, the attendee was stranded with no path to start a Claude Code session — the framework's bootstrap chain (`/bootstrap-product`, `/work-ticket`, etc.) all assume a working `claude` invocation, but the devcontainer didn't ship Claude Code. Every workshop attendee would hit this until fixed.

## Test plan

- [x] `.devcontainer/devcontainer.json` parses cleanly (after stripping JSONC comments)
- [x] `markdownlint-cli2` clean on `docs/GETTING-STARTED.md`
- [x] All validators pass (json/version/commands/agents/policies/lint-agent-policies/agent-restrictions)
- [x] actionlint clean
- [x] pytest 22/22
- [ ] CI green on PR
- [ ] Real-world: next Codespace boot on a workshop fork shows Claude Code preinstalled in the extensions sidebar; running `claude` from integrated terminal launches the auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)