### PR TITLE
fix(commands): bootstrap-workflow pre-flight aligns with solo mode + gh CLI + scope probe (#111)

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -116,16 +116,33 @@ Before running this phase, ensure you have:
 Before any board or ticket operations, verify the following. STOP and report
 to the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
-2. **GitHub account is correct** — Run `gh auth status` and confirm the active
-   account matches the expected worker/bot account. If only a personal account
-   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
-3. **Claude hooks are registered** — Check that hook files referenced in
+1. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account is appropriate for the work being done.
+   - **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the framework default per
+     CLAUDE.md and the Codespaces devcontainer): the participant's personal
+     account plays all roles — worker, reviewer, human merger. The
+     personal-account-only state is EXPECTED, not a failure.
+   - **Multi-bot mode**: verify the active account matches the configured
+     worker bot (`$AGILE_FLOW_WORKER_ACCOUNT`, default `va-worker`). If only
+     a personal account is active in multi-bot mode, STOP and instruct the
+     user to run `.claude/hooks/ensure-github-account.sh`.
+2. **GitHub access is reachable via `gh` CLI** — Confirm authentication works
+   with a quick read-only call (e.g., `gh repo view`, `gh issue list --limit 1`).
+   If gh fails, STOP. The framework uses `gh` as the primary GitHub mechanism
+   (per CLAUDE.md "Agents use the `gh` CLI for all GitHub operations"); an
+   MCP GitHub server is optional and not part of the default `.mcp.json`.
+3. **Token scopes sufficient for board operations** — Run the probe:
+   `gh api graphql -f query='{ viewer { projectsV2(first:1) { totalCount } } }'`
+   If this fails with `Resource not accessible by integration`, the active
+   token lacks the `project` scope. STOP with a clear remediation message:
+   in a Codespace, configure a `GH_TOKEN` Codespaces user secret with a
+   fine-grained PAT carrying `project`, `repo`, `workflow`, `read:org` scopes
+   (see the pre-workshop email or `agile-flow-meta:docs/workshops/`); on a
+   local clone, run `gh auth refresh -h github.com -s project,read:project`.
+4. **Claude hooks are registered** — Check that hook files referenced in
    `.claude/settings.local.json` exist and are executable. WARN if any hook is
    missing or not executable.
-4. **Project board is accessible** — Attempt to read the project board. If
+5. **Project board is accessible** — Attempt to read the project board. If
    access is denied or the board does not exist, STOP and report.
 
 ## Configuration Required

--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -9,12 +9,18 @@ Create a new ticket on the project board with guided workflow.
 Before creating any ticket, verify the following. STOP and report to the user
 if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
-2. **GitHub account is correct** — Run `gh auth status` and confirm the active
-   account matches the expected worker/bot account. If only a personal account
-   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
+1. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account is appropriate for the work being done.
+   - **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the framework default): the
+     participant's personal account plays all roles. The personal-account-only
+     state is EXPECTED, not a failure.
+   - **Multi-bot mode**: verify the active account matches the configured
+     worker bot. If only a personal account is active in multi-bot mode, STOP
+     and instruct the user to run `.claude/hooks/ensure-github-account.sh`.
+2. **GitHub access is reachable via `gh` CLI** — Confirm authentication works
+   with a quick read-only call (e.g., `gh repo view`). If gh fails, STOP.
+   (The framework uses `gh` as the primary GitHub mechanism per CLAUDE.md;
+   an MCP GitHub server is optional and not part of the default `.mcp.json`.)
 3. **Project board is accessible** — Attempt to read the project board. If
    access is denied or the board does not exist, STOP and report.
 

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -10,10 +10,17 @@ lightweight workflow that skips ticket creation and board management.
 Before any work, verify the following. STOP and report if any check fails.
 
 1. **GitHub account is correct** — Run `gh auth status` and confirm the active
-   account matches the expected worker/bot account. If only a personal account
-   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
-2. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call. If the
-   MCP server is not connected, STOP.
+   account is appropriate for the work being done.
+   - **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the framework default): the
+     participant's personal account plays all roles. The personal-account-only
+     state is EXPECTED, not a failure.
+   - **Multi-bot mode**: verify the active account matches the configured
+     worker bot. If only a personal account is active in multi-bot mode, STOP
+     and instruct the user to run `.claude/hooks/ensure-github-account.sh`.
+2. **GitHub access is reachable via `gh` CLI** — Confirm authentication works
+   with a quick read-only call (e.g., `gh repo view`). If gh fails, STOP.
+   (The framework uses `gh` as the primary GitHub mechanism per CLAUDE.md;
+   an MCP GitHub server is optional and not part of the default `.mcp.json`.)
 
 ## When to Use This Command
 

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -11,16 +11,21 @@ Launch the github-ticket-worker agent to implement the next prioritized ticket.
 Before starting work on any ticket, verify the following. STOP and report to
 the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
-2. **GitHub account is correct** — Run `gh auth status` and confirm the active
-   account matches the expected worker/bot account. If only a personal account
-   is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
-   **Solo mode exception:** if `AGILE_FLOW_SOLO_MODE=true` is set, this check
-   is skipped — the participant uses one personal account for both worker and
-   reviewer roles. This is the workshop/tutorial path. The bot-account
-   separation is the production architecture.
+1. **GitHub account is correct** — Run `gh auth status` and confirm the active
+   account is appropriate for the work being done.
+   - **Solo mode** (`AGILE_FLOW_SOLO_MODE=true`, the framework default per
+     CLAUDE.md and the Codespaces devcontainer): the participant's personal
+     account plays all roles — worker, reviewer, human merger. The
+     personal-account-only state is EXPECTED, not a failure.
+   - **Multi-bot mode**: verify the active account matches the configured
+     worker bot (`$AGILE_FLOW_WORKER_ACCOUNT`, default `va-worker`). If only
+     a personal account is active in multi-bot mode, STOP and instruct the
+     user to run `.claude/hooks/ensure-github-account.sh`.
+2. **GitHub access is reachable via `gh` CLI** — Confirm authentication works
+   with a quick read-only call (e.g., `gh repo view`, `gh issue list --limit 1`).
+   If gh fails, STOP. The framework uses `gh` as the primary GitHub mechanism
+   (per CLAUDE.md "Agents use the `gh` CLI for all GitHub operations"); an
+   MCP GitHub server is optional and not part of the default `.mcp.json`.
 3. **Claude hooks are registered** — Check that hook files referenced in
    `.claude/settings.local.json` exist and are executable. WARN if any hook is
    missing or not executable.


### PR DESCRIPTION
## Summary

Fixes three classes of pre-flight bug that STOPped `/bootstrap-workflow` (and three other commands) on every fresh workshop fork. Surfaced 2026-05-01 in the dry-run on `vibeacademy/kira-kim-11`.

The same pre-flight section was duplicated across 4 slash commands (`bootstrap-workflow`, `work-ticket`, `create-ticket`, `quick-fix`). All 4 are now updated consistently.

## Three fixes

### 1. MCP GitHub server check contradicted CLAUDE.md

Pre-flight said "STOP if MCP GitHub server unreachable; do not fall back to CLI-only mode silently." But:
- The framework's `.mcp.json` only registers `memory` and `sequential-thinking`
- CLAUDE.md says "Agents use the `gh` CLI for all GitHub operations"

Result: every fresh fork STOPped at pre-flight #1. Rewrote to "GitHub access is reachable via `gh` CLI" with explicit note that the MCP GitHub server is optional.

### 2. Solo-mode mismatch with the framework default

Pre-flight #2 said STOP "if only a personal account is active." But solo mode is the framework default — `AGILE_FLOW_SOLO_MODE=true` in the Codespaces devcontainer + CLAUDE.md rule 5. `work-ticket.md` already had a solo-mode exception (added in #87); the other three didn't. All four now branch on `AGILE_FLOW_SOLO_MODE` consistently.

### 3. Broken script path

Pre-flight referenced `scripts/ensure-github-account.sh`. Actual path: `.claude/hooks/ensure-github-account.sh`. Fixed in all four commands.

## Bonus: token-scope probe for bootstrap-workflow

Added a fail-loud probe to `bootstrap-workflow.md` (only — the other commands don't need this since they don't create boards):

```bash
gh api graphql -f query='{ viewer { projectsV2(first:1) { totalCount } } }'
```

If this fails with "Resource not accessible by integration", STOP with attendee-actionable remediation: configure a `GH_TOKEN` Codespaces user secret with a fine-grained PAT carrying the required scopes, OR run `gh auth refresh -h github.com -s project,read:project`. This is the May 2026 workshop architecture's fail-loud guard — without `project` scope, the rest of Phase 4 fails later with cryptic GraphQL errors.

## Test plan

- [x] All 4 commands pass `validate-commands.sh`
- [x] All 4 markdownlint clean
- [x] Agent policy linter clean
- [x] No remaining references to `scripts/ensure-github-account` (grepped `.claude/` and `docs/`)
- [x] pytest 22/22
- [ ] CI green on PR
- [ ] Real-world: next dry-run from a fresh Codespace passes pre-flight cleanly under solo mode

## Source

`/Users/teddykim/Desktop/donwntream.md` items 1, 11, 12, plus scope-probe portion of items 2/4 from the same handoff.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)