### PR TITLE
feat(provisioner): pre-create canonical labels on workshop repos (#112)

### DIFF
--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+#
+# Agile Flow — Canonical Label Setup
+#
+# Creates or updates the framework's canonical GitHub label set on a
+# repo. Idempotent: existing labels with matching name + color +
+# description are left alone; mismatched ones are updated; missing
+# ones are created.
+#
+# The canonical label set is the labels referenced by:
+#   - /bootstrap-workflow (Phase 4: priority labels P0/P1/P2/P3)
+#   - /groom-backlog (priorities, epic)
+#   - agile-backlog-prioritizer agent (priorities, epic)
+#   - github-ticket-worker, pr-reviewer agents (workflow labels)
+#
+# Without this script (or an equivalent one-time UI setup), a fresh
+# fork ships with only GitHub's default labels (bug, documentation,
+# enhancement, etc.) — none of the priority or workflow labels the
+# framework references exist. The agents either fail when applying
+# a label or improvise a label set, leading to cohort-to-cohort
+# drift. See #112.
+#
+# Usage:
+#   bash scripts/setup-labels.sh                    # uses current repo
+#   bash scripts/setup-labels.sh --repo owner/name  # explicit repo
+#   bash scripts/setup-labels.sh --dry-run          # preview, no writes
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated with a token that has admin
+#     write on the target repo (labels require write on Issues + Repo
+#     Metadata; classic `repo` scope or fine-grained `Issues: write`
+#     + `Metadata: read`).
+#   - Run from the repo root if --repo is omitted (auto-detection
+#     reads `gh repo view`).
+#
+# Exit codes:
+#   0 — labels are in their canonical state
+#   1 — gh missing, repo not detectable, or non-recoverable error
+#   2 — admin write missing on target repo (per-call WARNs surface
+#       individual label failures; the script keeps going and exits 2
+#       at the end so callers know "labels are not in canonical state")
+#
+# See also: docs/AGENTIC-CONTROLS.md (where label conventions belong).
+
+set -uo pipefail
+
+# Ensure bash even if invoked as `zsh scripts/setup-labels.sh`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Colors + print helpers (matches setup-solo-mode.sh shape)
+# ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+print_error()   { echo -e "${RED}✗ $1${NC}"; }
+print_info()    { echo -e "${BLUE}→ $1${NC}"; }
+
+# ───────────────────────────────────────────────────────────────────
+#  Canonical label set
+#
+#  Format: "name|color-without-hash|description"
+#  Order matters only for deterministic output.
+#
+#  Source of truth: this list. Anywhere else in the framework that
+#  references a label name must match. If you add a label here, also
+#  document it in docs/AGENTIC-CONTROLS.md or wherever the
+#  conventions live.
+# ───────────────────────────────────────────────────────────────────
+CANONICAL_LABELS=(
+    "P0|d73a4a|Critical priority - blocks other work"
+    "P1|e99695|High priority - important work"
+    "P2|fbca04|Medium priority - normal work"
+    "P3|cccccc|Low priority - nice to have"
+    "epic|0052cc|Epic — groups related issues into a deliverable phase"
+)
+
+# ───────────────────────────────────────────────────────────────────
+#  Argument parsing
+# ───────────────────────────────────────────────────────────────────
+DRY_RUN=false
+REPO=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --repo=*)
+            REPO="${1#--repo=}"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            print_error "Unknown argument: $1"
+            print_info "Usage: setup-labels.sh [--repo owner/name] [--dry-run]"
+            exit 1
+            ;;
+    esac
+done
+
+# ───────────────────────────────────────────────────────────────────
+#  Pre-flight
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}=== Agile Flow — Canonical Label Setup ===${NC}"
+echo ""
+
+if ! command -v gh >/dev/null 2>&1; then
+    print_error "gh CLI not found on PATH"
+    print_info "Install: https://cli.github.com/"
+    exit 1
+fi
+
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+    if [ -z "$REPO" ]; then
+        print_error "Could not auto-detect repo (no 'origin' remote, or gh not authenticated)"
+        print_info "Pass --repo owner/name explicitly, or run from a repo with an origin remote"
+        exit 1
+    fi
+fi
+
+print_info "Target repo: ${REPO}"
+if [ "$DRY_RUN" = "true" ]; then
+    print_info "Dry-run mode: no writes will be made"
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Reconcile each canonical label
+# ───────────────────────────────────────────────────────────────────
+NEEDS_WRITE=0
+HAD_ERROR=0
+
+for entry in "${CANONICAL_LABELS[@]}"; do
+    IFS='|' read -r name color description <<< "$entry"
+
+    # Look up the existing label (if any) via gh api.
+    existing=$(gh api "repos/${REPO}/labels/${name}" 2>/dev/null || true)
+
+    if [ -z "$existing" ]; then
+        # Label does not exist: create.
+        if [ "$DRY_RUN" = "true" ]; then
+            print_info "WOULD CREATE: ${name} (color #${color})"
+            NEEDS_WRITE=$((NEEDS_WRITE + 1))
+            continue
+        fi
+        if gh api "repos/${REPO}/labels" \
+            -f "name=${name}" \
+            -f "color=${color}" \
+            -f "description=${description}" \
+            >/dev/null 2>&1; then
+            print_success "Created: ${name}"
+        else
+            # Likely missing admin / Issues: write. Don't bail; record
+            # and continue so the user sees the full list of failures.
+            print_warning "Failed to create '${name}' (likely missing admin/write permission)"
+            HAD_ERROR=$((HAD_ERROR + 1))
+        fi
+    else
+        # Label exists: compare and update if name/color/description drift.
+        existing_color=$(echo "$existing" | jq -r .color)
+        existing_desc=$(echo "$existing" | jq -r '.description // ""')
+
+        if [ "$existing_color" = "$color" ] && [ "$existing_desc" = "$description" ]; then
+            print_success "Already canonical: ${name}"
+        else
+            if [ "$DRY_RUN" = "true" ]; then
+                print_info "WOULD UPDATE: ${name}"
+                print_info "    color:       ${existing_color} -> ${color}"
+                print_info "    description: '${existing_desc}' -> '${description}'"
+                NEEDS_WRITE=$((NEEDS_WRITE + 1))
+                continue
+            fi
+            if gh api -X PATCH "repos/${REPO}/labels/${name}" \
+                -f "new_name=${name}" \
+                -f "color=${color}" \
+                -f "description=${description}" \
+                >/dev/null 2>&1; then
+                print_success "Updated: ${name} (color/desc reconciled)"
+            else
+                print_warning "Failed to update '${name}' (likely missing admin/write permission)"
+                HAD_ERROR=$((HAD_ERROR + 1))
+            fi
+        fi
+    fi
+done
+
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Summary
+# ───────────────────────────────────────────────────────────────────
+if [ "$DRY_RUN" = "true" ]; then
+    if [ "$NEEDS_WRITE" -eq 0 ]; then
+        print_success "Dry-run: all canonical labels are already in their canonical state."
+        exit 0
+    fi
+    print_info "Dry-run: ${NEEDS_WRITE} label(s) would be created/updated."
+    print_info "Re-run without --dry-run to apply."
+    exit 0
+fi
+
+if [ "$HAD_ERROR" -gt 0 ]; then
+    print_warning "${HAD_ERROR} label(s) could not be reconciled (see WARNs above)."
+    print_info "If you lack admin/write on this repo, ask the repo owner to run this script."
+    exit 2
+fi
+
+print_success "All canonical labels are present and current on ${REPO}."
+exit 0

--- a/scripts/setup-labels.test.sh
+++ b/scripts/setup-labels.test.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+#
+# Tests for setup-labels.sh — canonical label reconciliation. Stubs
+# `gh` to simulate the four states each canonical label can be in:
+#   1. Missing (create path)
+#   2. Already canonical (no-op path)
+#   3. Drifted (update path: color or description differs)
+#   4. Write denied (admin missing)
+#
+# Run: ./scripts/setup-labels.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/setup-labels.sh"
+
+new_sandbox() { mktemp -d -t aflowlabels-XXXX; }
+
+# Stub `gh` whose behavior is controlled by env vars set per-test.
+# Modes:
+#   STUB_LABEL_STATE=missing      — every GET returns 404 (label missing).
+#   STUB_LABEL_STATE=canonical    — every GET returns the canonical row.
+#   STUB_LABEL_STATE=drifted      — every GET returns drifted color.
+#   STUB_LABEL_STATE=denied       — every POST/PATCH returns 403.
+#   STUB_LABEL_STATE=mixed        — P0 missing, P1 canonical, P2 drifted.
+# All other gh invocations succeed quietly.
+make_gh_stub() {
+    local sandbox="$1"
+    mkdir -p "$sandbox/bin"
+
+    cat > "$sandbox/bin/gh" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+echo "gh $*" >> "$STUB_STATE/gh.log"
+
+# Recognize calls:
+#   gh repo view --json nameWithOwner -q .nameWithOwner
+#   gh api repos/<owner>/<repo>/labels/<name>            (GET, lookup)
+#   gh api repos/<owner>/<repo>/labels                    (POST -f name= ...)
+#   gh api -X PATCH repos/<owner>/<repo>/labels/<name>    (UPDATE)
+
+# repo auto-detect
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+    echo "test-org/test-repo"
+    exit 0
+fi
+
+# api calls
+if [[ "$1" == "api" ]]; then
+    # Detect the kind of call
+    method="GET"
+    path=""
+    is_label_lookup=false
+    is_label_create=false
+    is_label_update=false
+
+    # walk args
+    shift
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -X) method="$2"; shift 2 ;;
+            -f) shift 2 ;;
+            --jq) shift 2 ;;
+            *)
+                if [[ -z "$path" ]]; then
+                    path="$1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    label_name=""
+    if [[ "$path" =~ /labels/([A-Za-z0-9_-]+)$ ]]; then
+        label_name="${BASH_REMATCH[1]}"
+        if [[ "$method" == "PATCH" ]]; then
+            is_label_update=true
+        else
+            is_label_lookup=true
+        fi
+    elif [[ "$path" =~ /labels$ ]] && [[ "$method" == "POST" || "$method" == "GET" ]]; then
+        # Treat /labels with no trailing name as create when -f was used.
+        # We can't easily detect that here since we already consumed -f flags;
+        # err on the side of "this is a create call from setup-labels.sh".
+        is_label_create=true
+    fi
+
+    state="${STUB_LABEL_STATE:-missing}"
+
+    if $is_label_lookup; then
+        # In mixed mode, P0 missing, P1 canonical, P2 drifted, others canonical
+        effective_state="$state"
+        if [[ "$state" == "mixed" ]]; then
+            case "$label_name" in
+                P0) effective_state="missing" ;;
+                P1) effective_state="canonical" ;;
+                P2) effective_state="drifted" ;;
+                *)  effective_state="canonical" ;;
+            esac
+        fi
+
+        case "$effective_state" in
+            missing)
+                # 404 — non-zero exit, no output (mirrors `gh api` behavior)
+                exit 1
+                ;;
+            canonical)
+                # Return the exact canonical row for this label.
+                # The script uses jq on .color and .description, so emit JSON.
+                case "$label_name" in
+                    P0) cat <<'JSON'
+{"name":"P0","color":"d73a4a","description":"Critical priority - blocks other work"}
+JSON
+                        ;;
+                    P1) cat <<'JSON'
+{"name":"P1","color":"e99695","description":"High priority - important work"}
+JSON
+                        ;;
+                    P2) cat <<'JSON'
+{"name":"P2","color":"fbca04","description":"Medium priority - normal work"}
+JSON
+                        ;;
+                    P3) cat <<'JSON'
+{"name":"P3","color":"cccccc","description":"Low priority - nice to have"}
+JSON
+                        ;;
+                    epic) cat <<'JSON'
+{"name":"epic","color":"0052cc","description":"Epic — groups related issues into a deliverable phase"}
+JSON
+                        ;;
+                esac
+                exit 0
+                ;;
+            drifted)
+                # Wrong color and description so the script triggers an update.
+                cat <<JSON
+{"name":"$label_name","color":"000000","description":"old description"}
+JSON
+                exit 0
+                ;;
+        esac
+    fi
+
+    if $is_label_create; then
+        if [[ "$state" == "denied" ]]; then
+            exit 1
+        fi
+        echo "{\"name\":\"$label_name\"}"
+        exit 0
+    fi
+
+    if $is_label_update; then
+        if [[ "$state" == "denied" ]]; then
+            exit 1
+        fi
+        echo "{\"name\":\"$label_name\"}"
+        exit 0
+    fi
+
+    exit 0
+fi
+
+exit 0
+STUB_EOF
+    chmod +x "$sandbox/bin/gh"
+}
+
+# Run script in a clean env. Forward STUB_* vars.
+run_script() {
+    local sandbox="$1"
+    shift
+    env -i \
+        HOME="$sandbox" \
+        PATH="$sandbox/bin:/usr/bin:/bin:/usr/local/bin" \
+        STUB_STATE="$sandbox" \
+        TERM="${TERM:-dumb}" \
+        "$@" \
+        bash "$SCRIPT" --repo test-org/test-repo
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $expected; got: $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local needle="$1" file="$2" label="$3"
+    if grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected to contain: $needle)"
+        echo "  --- file content ---"
+        sed -e 's/^/  /' "$file"
+        echo "  --------------------"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" file="$2" label="$3"
+    if ! grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (should NOT contain: $needle)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: All labels missing → 5 creates, exit 0 ────────────────────
+
+echo ""
+echo "Test 1: empty repo (all labels missing) → creates all 5"
+
+T1=$(new_sandbox)
+make_gh_stub "$T1"
+
+set +e
+run_script "$T1" \
+    STUB_LABEL_STATE="missing" \
+    > "$T1/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Created: P0" "$T1/run.log" "P0 created"
+assert_contains "Created: P1" "$T1/run.log" "P1 created"
+assert_contains "Created: P2" "$T1/run.log" "P2 created"
+assert_contains "Created: P3" "$T1/run.log" "P3 created"
+assert_contains "Created: epic" "$T1/run.log" "epic created"
+assert_contains "All canonical labels are present" "$T1/run.log" "summary success"
+
+# ── Test 2: All labels already canonical → no-op, exit 0 ──────────────
+
+echo ""
+echo "Test 2: all labels already canonical → no-op (idempotent re-run)"
+
+T2=$(new_sandbox)
+make_gh_stub "$T2"
+
+set +e
+run_script "$T2" \
+    STUB_LABEL_STATE="canonical" \
+    > "$T2/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Already canonical: P0" "$T2/run.log" "P0 noted as canonical"
+assert_contains "Already canonical: epic" "$T2/run.log" "epic noted as canonical"
+assert_not_contains "Created:" "$T2/run.log" "no creates on canonical re-run"
+assert_not_contains "Updated:" "$T2/run.log" "no updates on canonical re-run"
+
+# ── Test 3: All labels drifted → 5 updates, exit 0 ────────────────────
+
+echo ""
+echo "Test 3: all labels drifted (wrong color/description) → updates all 5"
+
+T3=$(new_sandbox)
+make_gh_stub "$T3"
+
+set +e
+run_script "$T3" \
+    STUB_LABEL_STATE="drifted" \
+    > "$T3/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Updated: P0" "$T3/run.log" "P0 updated"
+assert_contains "Updated: P3" "$T3/run.log" "P3 updated"
+assert_contains "Updated: epic" "$T3/run.log" "epic updated"
+assert_not_contains "Created:" "$T3/run.log" "no creates when label exists"
+
+# ── Test 4: Mixed state (missing + canonical + drifted) → exit 0 ─────
+
+echo ""
+echo "Test 4: mixed state (P0 missing, P1 canonical, P2 drifted)"
+
+T4=$(new_sandbox)
+make_gh_stub "$T4"
+
+set +e
+run_script "$T4" \
+    STUB_LABEL_STATE="mixed" \
+    > "$T4/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Created: P0" "$T4/run.log" "P0 created (was missing)"
+assert_contains "Already canonical: P1" "$T4/run.log" "P1 noted canonical"
+assert_contains "Updated: P2" "$T4/run.log" "P2 updated (was drifted)"
+
+# ── Test 5: Write denied → fail-soft, exit 2 ─────────────────────────
+
+echo ""
+echo "Test 5: write permission denied → exit 2, WARN per failed label"
+
+T5=$(new_sandbox)
+make_gh_stub "$T5"
+
+set +e
+run_script "$T5" \
+    STUB_LABEL_STATE="denied" \
+    > "$T5/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "2" "$ec" "exit 2 (admin missing)"
+assert_contains "Failed to create 'P0'" "$T5/run.log" "P0 failure surfaced"
+assert_contains "Failed to create 'epic'" "$T5/run.log" "epic failure surfaced"
+assert_contains "could not be reconciled" "$T5/run.log" "summary mentions failures"
+# Critical: the script must NOT exit 1 mid-loop. It should walk all labels
+# and surface every failure. Verify all 5 are listed.
+fail_count=$(grep -c "Failed to" "$T5/run.log" || true)
+assert_eq "5" "$fail_count" "all 5 failures surfaced (no early-exit on first fail)"
+
+# ── Test 6: Dry-run (missing labels) → reports without writing ────────
+
+echo ""
+echo "Test 6: --dry-run mode → reports planned writes without making them"
+
+T6=$(new_sandbox)
+make_gh_stub "$T6"
+
+set +e
+env -i \
+    HOME="$T6" \
+    PATH="$T6/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T6" \
+    TERM="${TERM:-dumb}" \
+    STUB_LABEL_STATE="missing" \
+    bash "$SCRIPT" --repo test-org/test-repo --dry-run \
+    > "$T6/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Dry-run mode: no writes" "$T6/run.log" "dry-run banner"
+assert_contains "WOULD CREATE: P0" "$T6/run.log" "P0 marked WOULD CREATE"
+assert_contains "Re-run without --dry-run" "$T6/run.log" "guidance to apply"
+# Critical: dry-run must NOT have called the create endpoint.
+if grep -q "labels -f name=" "$T6/gh.log" 2>/dev/null || grep -q "POST" "$T6/gh.log" 2>/dev/null; then
+    echo -e "  ${RED}FAIL${NC} dry-run made a write call"
+    FAIL=$((FAIL + 1))
+else
+    echo -e "  ${GREEN}OK${NC} dry-run made no write calls"
+    PASS=$((PASS + 1))
+fi
+
+# ── Test 7: --repo flag overrides auto-detection ─────────────────────
+
+echo ""
+echo "Test 7: --repo flag is respected"
+
+T7=$(new_sandbox)
+make_gh_stub "$T7"
+
+set +e
+env -i \
+    HOME="$T7" \
+    PATH="$T7/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T7" \
+    TERM="${TERM:-dumb}" \
+    STUB_LABEL_STATE="canonical" \
+    bash "$SCRIPT" --repo explicit-org/explicit-repo \
+    > "$T7/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "explicit-org/explicit-repo" "$T7/run.log" "uses explicit --repo value"
+# Should NOT have called gh repo view (auto-detect path)
+if ! grep -q "repo view" "$T7/gh.log" 2>/dev/null; then
+    echo -e "  ${GREEN}OK${NC} auto-detect skipped when --repo given"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} called gh repo view despite explicit --repo"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 8: Unknown flag → exit 1 with usage hint ─────────────────────
+
+echo ""
+echo "Test 8: unknown argument → fail fast"
+
+T8=$(new_sandbox)
+make_gh_stub "$T8"
+
+set +e
+env -i \
+    HOME="$T8" \
+    PATH="$T8/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T8" \
+    TERM="${TERM:-dumb}" \
+    bash "$SCRIPT" --bogus-flag \
+    > "$T8/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 on unknown flag"
+assert_contains "Unknown argument" "$T8/run.log" "names the issue"
+assert_contains "Usage:" "$T8/run.log" "shows usage hint"
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0

--- a/scripts/setup-solo-mode.sh
+++ b/scripts/setup-solo-mode.sh
@@ -16,6 +16,7 @@
 #     (repo, project, workflow, read:project) and refreshes if not.
 #   ✓ Activates the in-repo pre-push hook (`core.hooksPath`).
 #   ✓ Verifies you have admin access on the current fork.
+#   ✓ Creates the canonical label set (P0/P1/P2/P3/epic) on the fork.
 #
 #   ✗ Does NOT cache tokens to disk. Tokens stay in gh's keyring.
 #   ✗ Does NOT auto-modify your shell rc to remove tokens — surfaces
@@ -183,9 +184,9 @@ if [ ! -t 0 ]; then
 fi
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 1/8: Detect shell + show current state
+#  Step 1/9: Detect shell + show current state
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 1/8: Detect shell ---${NC}"
+echo -e "${CYAN}--- Step 1/9: Detect shell ---${NC}"
 echo ""
 
 profile=$(detect_shell_profile)
@@ -196,9 +197,9 @@ print_info "Active gh account: ${active_account:-(none detected)}"
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 2/8: Persist AGILE_FLOW_SOLO_MODE
+#  Step 2/9: Persist AGILE_FLOW_SOLO_MODE
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 2/8: Persist AGILE_FLOW_SOLO_MODE=true ---${NC}"
+echo -e "${CYAN}--- Step 2/9: Persist AGILE_FLOW_SOLO_MODE=true ---${NC}"
 echo ""
 
 if [ "${AGILE_FLOW_SOLO_MODE:-}" = "true" ] && grep -qE "(^export AGILE_FLOW_SOLO_MODE=|^set -Ux AGILE_FLOW_SOLO_MODE )" "$profile" 2>/dev/null; then
@@ -209,9 +210,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 3/8: Audit GITHUB_PERSONAL_ACCESS_TOKEN* env vars
+#  Step 3/9: Audit GITHUB_PERSONAL_ACCESS_TOKEN* env vars
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 3/8: Audit GITHUB_PERSONAL_ACCESS_TOKEN env vars ---${NC}"
+echo -e "${CYAN}--- Step 3/9: Audit GITHUB_PERSONAL_ACCESS_TOKEN env vars ---${NC}"
 echo ""
 
 # In solo mode, ANY of these env vars override `gh auth switch` silently.
@@ -280,9 +281,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 4/8: Verify scopes
+#  Step 4/9: Verify scopes
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 4/8: Verify gh token scopes ---${NC}"
+echo -e "${CYAN}--- Step 4/9: Verify gh token scopes ---${NC}"
 echo ""
 
 required_scopes=(repo project workflow read:project)
@@ -363,9 +364,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 5/8: Activate pre-push hook
+#  Step 5/9: Activate pre-push hook
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 5/8: Activate pre-push hook ---${NC}"
+echo -e "${CYAN}--- Step 5/9: Activate pre-push hook ---${NC}"
 echo ""
 
 if [ -f "scripts/hooks/pre-push" ]; then
@@ -382,9 +383,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 6/8: Verify admin access on this fork
+#  Step 6/9: Verify admin access on this fork
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 6/8: Verify admin access on this fork ---${NC}"
+echo -e "${CYAN}--- Step 6/9: Verify admin access on this fork ---${NC}"
 echo ""
 
 remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
@@ -418,9 +419,39 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 7/8: Multi-bot env-var sanity check
+#  Step 7/9: Set up canonical labels (#112)
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 7/8: Multi-bot env-var sanity check ---${NC}"
+echo -e "${CYAN}--- Step 7/9: Set up canonical labels ---${NC}"
+echo ""
+
+# Labels require the same admin/write permission as Step 6 verifies,
+# so we co-locate them. fail-soft: setup-labels.sh exits 2 on missing
+# admin (per-label WARNs surface failures); the bootstrap continues
+# regardless. The framework's other outputs (env var, hook activation)
+# are still valuable when labels can't be reconciled.
+labels_script="$(dirname "$0")/setup-labels.sh"
+if [ -f "$labels_script" ]; then
+    if bash "$labels_script" 2>&1 | sed 's/^/    /'; then
+        # exit 0 from setup-labels.sh
+        :
+    else
+        labels_ec=$?
+        if [ "$labels_ec" = "2" ]; then
+            print_warning "Some labels could not be reconciled (likely missing admin/write)."
+            print_info "Re-run 'bash scripts/setup-labels.sh' from a session with admin to finish."
+        else
+            print_warning "setup-labels.sh exited with code ${labels_ec}; continuing."
+        fi
+    fi
+else
+    print_warning "scripts/setup-labels.sh not found; skipping canonical label setup."
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 8/9: Multi-bot env-var sanity check
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 8/9: Multi-bot env-var sanity check ---${NC}"
 echo ""
 
 if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
@@ -436,9 +467,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 8/8: Done — restart prompt
+#  Step 9/9: Done — restart prompt
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 8/8: Done ---${NC}"
+echo -e "${CYAN}--- Step 9/9: Done ---${NC}"
 echo ""
 
 print_success "Solo mode is configured."


### PR DESCRIPTION
## Summary

Closes #112. Surfaced 2026-05-01 in the dry-run on `vibeacademy/kira-kim-11` (handoff item 6): a fresh fork ships with only GitHub's default labels — none of `P0`/`P1`/`P2`/`P3`/`epic` exist, even though `/bootstrap-workflow`, `/groom-backlog`, and the `agile-backlog-prioritizer` agent all assume those labels.

Adds `scripts/setup-labels.sh` — idempotent canonical label reconciliation — and hooks it into `setup-solo-mode.sh` as a new Step 7/9.

## What's in the canonical set

| Label | Color | Description |
|-------|-------|-------------|
| P0 | `#d73a4a` | Critical priority - blocks other work |
| P1 | `#e99695` | High priority - important work |
| P2 | `#fbca04` | Medium priority - normal work |
| P3 | `#cccccc` | Low priority - nice to have |
| epic | `#0052cc` | Epic — groups related issues into a deliverable phase |

Other labels referenced in the framework (`workshop-prep`, `solo-mode`, `epic-gcp-workshop`) are cohort/initiative-specific — they belong in the framework instance's setup, not in the upstream template's canonical set. Forks add their own.

## Behavior

- **Idempotent.** Existing labels matching the canonical name+color+description are left alone (no-op). Mismatched labels are updated. Missing labels are created.
- **Fail-soft on missing admin write.** Per-label WARNs surface every failure (no early-exit on first fail), then the script exits 2 so callers know the repo isn't in canonical state. The broader bootstrap continues regardless — labels not in canonical state isn't a fatal condition.
- **`--dry-run`** flag for preview without writes.
- **`--repo owner/name`** flag for explicit targeting; auto-detects via `gh repo view` when omitted.

## Hook into setup-solo-mode.sh

Inserted as new **Step 7/9** between admin verification (Step 6) and multi-bot sanity (now Step 8). Co-located with admin verification because labels need the same admin write permission. Steps 7→8 and 8→9 renumbered. Top-of-file docstring updated.

## Tests — 8 cases, 37 assertions, all passing

- All labels missing → 5 creates, exit 0
- All labels canonical → idempotent no-op
- All labels drifted → 5 updates, no creates
- Mixed state (P0 missing, P1 canonical, P2 drifted) → correct routing per label
- Write denied → fail-soft, exit 2, all 5 failures surfaced (no early-exit)
- `--dry-run` mode → reports planned writes, makes no actual writes
- `--repo` flag → respected, auto-detect skipped
- Unknown flag → exit 1 with usage hint

## Out of scope (deferred)

`provision-workshop-roster.sh` doesn't have a per-attendee `gh repo create` step under the current model — attendee forks already exist in personal accounts. Under the May 2026 architecture's **#107** work (workshop-org-hosted repos created at provisioning time), the natural insertion point will be right after `gh repo create vibeacademy/<handle>`. Folding `setup-labels.sh` into that flow is deferred to land alongside #107.

## Test plan

- [x] `./scripts/setup-labels.test.sh` — 37/37
- [x] `./scripts/setup-solo-mode.test.sh` — 42/42 (renumber didn't break anything)
- [x] shellcheck clean on both new files
- [x] All other validators (json/version/commands/agents/policies/lint-agent-policies)
- [x] actionlint clean
- [x] pytest 22/22
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)