### PR TITLE
feat(setup): scripted CLAUDE.md placeholder population (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,9 +165,12 @@ TEMPLATE: Fill in project-specific details below when using this template.
 ### Project Information
 
 - **License**: BSL 1.1 (converts to Apache 2.0 after 3 years per release)
+<!-- bootstrap:project-config:start -->
 - **Project Name**: [Your project name]
+- **Organization**: [GitHub org name]
 - **Repository**: [GitHub repo URL]
 - **Project Board**: [GitHub project board URL]
+<!-- bootstrap:project-config:end -->
 - **Tech Stack**: FastAPI + Jinja2 + HTMX on Python 3.12
 - **Database layer**: SQLModel + Alembic
 - **Platform**: Google Cloud Platform (Cloud Run)
@@ -175,7 +178,6 @@ TEMPLATE: Fill in project-specific details below when using this template.
 - **Container Registry**: Artifact Registry
 - **Secrets**: Google Secret Manager
 - **Package manager**: uv
-- **Organization**: [GitHub org name]
 
 ### Build & Test Commands
 

--- a/scripts/populate-claude-md.sh
+++ b/scripts/populate-claude-md.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+#
+# Agile Flow — CLAUDE.md placeholder population
+#
+# Replaces the bracketed placeholders inside CLAUDE.md's
+# `<!-- bootstrap:project-config:start --> ... :end --` marker block
+# with values derived from `git remote origin` and (when missing)
+# user-supplied flags. Idempotent: re-running on a populated block
+# does not duplicate or change values that already match.
+#
+# The marker block in CLAUDE.md MUST exist with both the start and
+# end sentinels and exactly four lines between them, in this order:
+#
+#     - **Project Name**: ...
+#     - **Organization**: ...
+#     - **Repository**: ...
+#     - **Project Board**: ...
+#
+# Without this script, fresh forks ship with `[Your project name]`
+# and `[GitHub repo URL]` text in CLAUDE.md, which is loaded into
+# every subsequent agent session's system prompt. See #113.
+#
+# Usage:
+#   bash scripts/populate-claude-md.sh \
+#     --project-name "My App" \
+#     --project-board "https://github.com/orgs/myorg/projects/1"
+#
+#   bash scripts/populate-claude-md.sh   # interactive prompts
+#
+# Flags:
+#   --project-name <name>      Project's human-readable name
+#   --project-board <url>      Full URL to the GitHub project board
+#   --owner <owner>            Override owner derived from git remote
+#   --repo <repo>              Override repo name derived from git remote
+#   --file <path>              CLAUDE.md path (default: CLAUDE.md in cwd)
+#   --dry-run                  Print planned changes; don't write
+#   -h | --help                Show this header
+#
+# Auto-derived from `git remote get-url origin`:
+#   - Organization → owner segment of the remote URL
+#   - Repository   → full https URL (https://github.com/<owner>/<repo>)
+#
+# Exit codes:
+#   0 — placeholders populated (or already populated)
+#   1 — file missing, marker block missing/malformed, or other
+#       non-recoverable error
+#   2 — required value couldn't be obtained (no git remote AND no
+#       --owner override; or interactive run on a non-TTY stdin)
+#
+# See also: scripts/setup-solo-mode.sh (which invokes this script).
+
+set -uo pipefail
+
+# Ensure bash even if invoked as `zsh scripts/populate-claude-md.sh`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Colors + print helpers (matches setup-solo-mode.sh shape)
+# ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+print_error()   { echo -e "${RED}✗ $1${NC}"; }
+print_info()    { echo -e "${BLUE}→ $1${NC}"; }
+
+# ───────────────────────────────────────────────────────────────────
+#  Argument parsing
+# ───────────────────────────────────────────────────────────────────
+PROJECT_NAME=""
+PROJECT_BOARD=""
+OWNER=""
+REPO=""
+FILE="CLAUDE.md"
+DRY_RUN=false
+
+show_help() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-name)   PROJECT_NAME="$2"; shift 2 ;;
+        --project-name=*) PROJECT_NAME="${1#--project-name=}"; shift ;;
+        --project-board)  PROJECT_BOARD="$2"; shift 2 ;;
+        --project-board=*) PROJECT_BOARD="${1#--project-board=}"; shift ;;
+        --owner)          OWNER="$2"; shift 2 ;;
+        --owner=*)        OWNER="${1#--owner=}"; shift ;;
+        --repo)           REPO="$2"; shift 2 ;;
+        --repo=*)         REPO="${1#--repo=}"; shift ;;
+        --file)           FILE="$2"; shift 2 ;;
+        --file=*)         FILE="${1#--file=}"; shift ;;
+        --dry-run)        DRY_RUN=true; shift ;;
+        -h|--help)        show_help; exit 0 ;;
+        *)
+            print_error "Unknown argument: $1"
+            print_info "Run with --help for usage."
+            exit 1
+            ;;
+    esac
+done
+
+# ───────────────────────────────────────────────────────────────────
+#  Pre-flight
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}=== Agile Flow — CLAUDE.md placeholder population ===${NC}"
+echo ""
+
+if [ ! -f "$FILE" ]; then
+    print_error "File not found: $FILE"
+    exit 1
+fi
+
+if ! grep -q '<!-- bootstrap:project-config:start -->' "$FILE"; then
+    print_error "Marker block not found in $FILE"
+    print_info "Expected: <!-- bootstrap:project-config:start --> ... <!-- bootstrap:project-config:end -->"
+    exit 1
+fi
+if ! grep -q '<!-- bootstrap:project-config:end -->' "$FILE"; then
+    print_error "Marker block end sentinel missing in $FILE"
+    print_info "Expected: <!-- bootstrap:project-config:end -->"
+    exit 1
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Derive owner/repo from git remote when not supplied
+# ───────────────────────────────────────────────────────────────────
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+    remote_url=""
+    if command -v git >/dev/null 2>&1; then
+        remote_url=$(git remote get-url origin 2>/dev/null || true)
+    fi
+
+    if [ -z "$remote_url" ]; then
+        if [ -z "$OWNER" ] && [ -z "$REPO" ]; then
+            print_error "No git remote found and --owner/--repo not provided."
+            print_info "Either run this from a repo with an 'origin' remote,"
+            print_info "or pass --owner <name> --repo <name>."
+            exit 2
+        fi
+    else
+        # Normalize remote_url. Handles:
+        #   git@github.com:owner/repo.git
+        #   git@github.com:owner/repo
+        #   https://github.com/owner/repo.git
+        #   https://github.com/owner/repo
+        normalized=$(echo "$remote_url" | sed -E '
+            s|^git@github\.com:|/|
+            s|^https://github\.com/||
+            s|\.git$||
+            s|^/||
+        ')
+        derived_owner=$(echo "$normalized" | cut -d/ -f1)
+        derived_repo=$(echo "$normalized" | cut -d/ -f2)
+
+        [ -z "$OWNER" ] && OWNER="$derived_owner"
+        [ -z "$REPO" ] && REPO="$derived_repo"
+    fi
+fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+    print_error "Could not determine owner/repo. Pass --owner and --repo explicitly."
+    exit 2
+fi
+
+REPO_URL="https://github.com/${OWNER}/${REPO}"
+
+# ───────────────────────────────────────────────────────────────────
+#  Interactive prompts for missing values
+# ───────────────────────────────────────────────────────────────────
+prompt_for() {
+    local label="$1" var_name="$2" suggested="$3"
+
+    if [ ! -t 0 ]; then
+        # Non-interactive context (Codespace postCreateCommand, CI, piped invocation)
+        if [ -n "$suggested" ]; then
+            print_warning "$label not provided; using suggested value: $suggested"
+            eval "$var_name=\"\$suggested\""
+            return 0
+        fi
+        print_error "$label not provided and stdin is not a TTY (cannot prompt)."
+        print_info "Pass --${var_name//_/-} <value> to fill it in."
+        exit 2
+    fi
+
+    if [ -n "$suggested" ]; then
+        echo -ne "${BLUE}? ${label}${NC} [${suggested}]: "
+    else
+        echo -ne "${BLUE}? ${label}${NC}: "
+    fi
+    read -r reply
+    if [ -z "$reply" ] && [ -n "$suggested" ]; then
+        reply="$suggested"
+    fi
+    eval "$var_name=\"\$reply\""
+}
+
+if [ -z "$PROJECT_NAME" ]; then
+    prompt_for "Project name" PROJECT_NAME "$REPO"
+fi
+
+if [ -z "$PROJECT_BOARD" ]; then
+    # Reasonable default: org-scoped projects URL listing.
+    suggested_board="https://github.com/orgs/${OWNER}/projects"
+    prompt_for "Project board URL" PROJECT_BOARD "$suggested_board"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Apply replacement inside the marker block
+# ───────────────────────────────────────────────────────────────────
+new_block=$(cat <<EOF
+<!-- bootstrap:project-config:start -->
+- **Project Name**: ${PROJECT_NAME}
+- **Organization**: ${OWNER}
+- **Repository**: ${REPO_URL}
+- **Project Board**: ${PROJECT_BOARD}
+<!-- bootstrap:project-config:end -->
+EOF
+)
+
+print_info "Target file:    $FILE"
+print_info "Project Name:   $PROJECT_NAME"
+print_info "Organization:   $OWNER"
+print_info "Repository:     $REPO_URL"
+print_info "Project Board:  $PROJECT_BOARD"
+echo ""
+
+# Idempotency: if the existing block already matches what we'd write,
+# do nothing.
+existing_block=$(awk '
+    /<!-- bootstrap:project-config:start -->/ { capture=1 }
+    capture { print }
+    /<!-- bootstrap:project-config:end -->/ { capture=0 }
+' "$FILE")
+
+if [ "$existing_block" = "$new_block" ]; then
+    print_success "CLAUDE.md project-config block is already up to date."
+    exit 0
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+    print_info "Dry-run: would replace the marker block with:"
+    echo ""
+    echo "$new_block" | sed 's/^/    /'
+    echo ""
+    exit 0
+fi
+
+# Replace the block. Stash the new block in a temp file (BSD awk
+# doesn't accept multi-line strings via -v, so we read the
+# replacement from a sibling file via getline). Works on macOS BSD
+# awk and GNU awk.
+block_file=$(mktemp -t aflow-claudemd-block-XXXX)
+out_file=$(mktemp -t aflow-claudemd-out-XXXX)
+trap 'rm -f "$block_file" "$out_file"' EXIT
+
+printf '%s\n' "$new_block" > "$block_file"
+
+awk -v block_file="$block_file" '
+    /<!-- bootstrap:project-config:start -->/ {
+        # Inject the new block (already contains start + end markers)
+        while ((getline line < block_file) > 0) {
+            print line
+        }
+        close(block_file)
+        skip = 1
+        next
+    }
+    /<!-- bootstrap:project-config:end -->/ {
+        skip = 0
+        next
+    }
+    !skip { print }
+' "$FILE" > "$out_file"
+
+mv "$out_file" "$FILE"
+
+print_success "Populated CLAUDE.md project-config block."
+exit 0

--- a/scripts/populate-claude-md.test.sh
+++ b/scripts/populate-claude-md.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+#
+# Tests for populate-claude-md.sh — CLAUDE.md placeholder population.
+# Exercises the marker-block replacement, git-remote auto-detection,
+# idempotency, dry-run, and error handling.
+#
+# Run: ./scripts/populate-claude-md.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/populate-claude-md.sh"
+
+new_sandbox() { mktemp -d -t aflowclaudemd-XXXX; }
+
+# Write a CLAUDE.md test fixture into the sandbox with the marker
+# block in its initial (placeholder) state.
+write_fixture() {
+    local sandbox="$1"
+    cat > "$sandbox/CLAUDE.md" <<'EOF'
+# Some project
+
+## Project-Specific Configuration
+
+### Project Information
+
+- **License**: BSL 1.1
+<!-- bootstrap:project-config:start -->
+- **Project Name**: [Your project name]
+- **Organization**: [GitHub org name]
+- **Repository**: [GitHub repo URL]
+- **Project Board**: [GitHub project board URL]
+<!-- bootstrap:project-config:end -->
+- **Tech Stack**: FastAPI
+
+## Reference
+EOF
+}
+
+# Initialize a git repo with origin set so the script can auto-detect.
+init_git_remote() {
+    local sandbox="$1" remote_url="$2"
+    git -C "$sandbox" init -q -b main 2>/dev/null
+    git -C "$sandbox" remote add origin "$remote_url" 2>/dev/null
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $expected; got: $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local needle="$1" file="$2" label="$3"
+    if grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $needle)"
+        echo "  --- file ---"
+        sed -e 's/^/  /' "$file"
+        echo "  ------------"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" file="$2" label="$3"
+    if ! grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (should NOT contain: $needle)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: Happy path with all flags ─────────────────────────────────
+
+echo ""
+echo "Test 1: happy path with --project-name + --project-board"
+
+T1=$(new_sandbox)
+write_fixture "$T1"
+
+set +e
+(cd "$T1" && bash "$SCRIPT" \
+    --project-name "MyApp" \
+    --project-board "https://github.com/orgs/myorg/projects/3" \
+    --owner "myorg" \
+    --repo "myapp" \
+    > "$T1/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Project Name**: MyApp" "$T1/CLAUDE.md" "Project Name replaced"
+assert_contains "Organization**: myorg" "$T1/CLAUDE.md" "Organization replaced"
+assert_contains "Repository**: https://github.com/myorg/myapp" "$T1/CLAUDE.md" "Repository URL derived"
+assert_contains "Project Board**: https://github.com/orgs/myorg/projects/3" "$T1/CLAUDE.md" "Project Board replaced"
+assert_not_contains "[Your project name]" "$T1/CLAUDE.md" "no leftover placeholder"
+assert_contains "Tech Stack**: FastAPI" "$T1/CLAUDE.md" "Tech Stack line preserved (outside marker)"
+
+# ── Test 2: Idempotent re-run ─────────────────────────────────────────
+
+echo ""
+echo "Test 2: re-run on already-populated file → no-op"
+
+T2=$(new_sandbox)
+write_fixture "$T2"
+
+# First run
+(cd "$T2" && bash "$SCRIPT" \
+    --project-name "MyApp" \
+    --project-board "https://github.com/orgs/myorg/projects/3" \
+    --owner "myorg" --repo "myapp" \
+    > "$T2/run1.log" 2>&1)
+hash1=$(md5 -q "$T2/CLAUDE.md" 2>/dev/null || md5sum "$T2/CLAUDE.md" | cut -d' ' -f1)
+
+# Second run with same args
+set +e
+(cd "$T2" && bash "$SCRIPT" \
+    --project-name "MyApp" \
+    --project-board "https://github.com/orgs/myorg/projects/3" \
+    --owner "myorg" --repo "myapp" \
+    > "$T2/run2.log" 2>&1)
+ec=$?
+set -e
+hash2=$(md5 -q "$T2/CLAUDE.md" 2>/dev/null || md5sum "$T2/CLAUDE.md" | cut -d' ' -f1)
+
+assert_eq "0" "$ec" "exit 0"
+assert_eq "$hash1" "$hash2" "file content unchanged on re-run"
+assert_contains "already up to date" "$T2/run2.log" "no-op message on re-run"
+
+# ── Test 3: Auto-detect owner/repo from git remote (HTTPS) ────────────
+
+echo ""
+echo "Test 3: auto-detect from HTTPS git remote"
+
+T3=$(new_sandbox)
+write_fixture "$T3"
+init_git_remote "$T3" "https://github.com/auto-org/auto-repo.git"
+
+set +e
+(cd "$T3" && bash "$SCRIPT" \
+    --project-name "AutoApp" \
+    --project-board "https://github.com/orgs/auto-org/projects/1" \
+    > "$T3/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Organization**: auto-org" "$T3/CLAUDE.md" "owner derived from HTTPS remote"
+assert_contains "Repository**: https://github.com/auto-org/auto-repo" "$T3/CLAUDE.md" "repo derived from HTTPS remote"
+
+# ── Test 4: Auto-detect from SSH git remote ───────────────────────────
+
+echo ""
+echo "Test 4: auto-detect from SSH git remote"
+
+T4=$(new_sandbox)
+write_fixture "$T4"
+init_git_remote "$T4" "git@github.com:ssh-org/ssh-repo.git"
+
+set +e
+(cd "$T4" && bash "$SCRIPT" \
+    --project-name "SshApp" \
+    --project-board "https://github.com/orgs/ssh-org/projects/1" \
+    > "$T4/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Organization**: ssh-org" "$T4/CLAUDE.md" "owner derived from SSH remote"
+assert_contains "Repository**: https://github.com/ssh-org/ssh-repo" "$T4/CLAUDE.md" "repo URL normalized to https"
+
+# ── Test 5: Marker block missing → exit 1 ─────────────────────────────
+
+echo ""
+echo "Test 5: missing marker block → fail fast"
+
+T5=$(new_sandbox)
+cat > "$T5/CLAUDE.md" <<'EOF'
+# Project without markers
+
+- **Project Name**: foo
+EOF
+
+set +e
+(cd "$T5" && bash "$SCRIPT" \
+    --project-name "X" --project-board "Y" \
+    --owner "o" --repo "r" \
+    > "$T5/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 when markers missing"
+assert_contains "Marker block not found" "$T5/run.log" "names the issue"
+
+# ── Test 6: File missing → exit 1 ─────────────────────────────────────
+
+echo ""
+echo "Test 6: target file missing → fail fast"
+
+T6=$(new_sandbox)
+
+set +e
+(cd "$T6" && bash "$SCRIPT" \
+    --project-name "X" --project-board "Y" \
+    --owner "o" --repo "r" \
+    --file "nope.md" \
+    > "$T6/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 when file missing"
+assert_contains "File not found" "$T6/run.log" "names the issue"
+
+# ── Test 7: Dry-run does not modify the file ──────────────────────────
+
+echo ""
+echo "Test 7: --dry-run preview without writes"
+
+T7=$(new_sandbox)
+write_fixture "$T7"
+hash_before=$(md5 -q "$T7/CLAUDE.md" 2>/dev/null || md5sum "$T7/CLAUDE.md" | cut -d' ' -f1)
+
+set +e
+(cd "$T7" && bash "$SCRIPT" \
+    --project-name "DryApp" \
+    --project-board "https://github.com/orgs/dry/projects/1" \
+    --owner "dry" --repo "dryrepo" \
+    --dry-run \
+    > "$T7/run.log" 2>&1)
+ec=$?
+set -e
+
+hash_after=$(md5 -q "$T7/CLAUDE.md" 2>/dev/null || md5sum "$T7/CLAUDE.md" | cut -d' ' -f1)
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "Dry-run" "$T7/run.log" "dry-run banner"
+assert_contains "Project Name**: DryApp" "$T7/run.log" "planned content shown in output"
+assert_eq "$hash_before" "$hash_after" "file unchanged in dry-run"
+assert_contains "[Your project name]" "$T7/CLAUDE.md" "placeholders still present in dry-run"
+
+# ── Test 8: Non-interactive without --project-name → uses suggested ──
+
+echo ""
+echo "Test 8: non-interactive context with no --project-name → uses suggested"
+
+T8=$(new_sandbox)
+write_fixture "$T8"
+
+# Run with stdin redirected from /dev/null so [ -t 0 ] is false.
+# Provide --owner --repo so derivation succeeds. Skip --project-name
+# and --project-board. Both should fall through to suggested values
+# (repo name and orgs URL respectively) with WARN messages.
+set +e
+(cd "$T8" && bash "$SCRIPT" \
+    --owner "octo" --repo "octopus" \
+    < /dev/null \
+    > "$T8/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 (used suggested defaults non-interactively)"
+assert_contains "using suggested value" "$T8/run.log" "WARN about suggested fallback"
+assert_contains "Project Name**: octopus" "$T8/CLAUDE.md" "fell through to repo-name suggestion"
+
+# ── Test 9: Unknown flag → exit 1 ─────────────────────────────────────
+
+echo ""
+echo "Test 9: unknown argument → fail fast"
+
+T9=$(new_sandbox)
+
+set +e
+(cd "$T9" && bash "$SCRIPT" --bogus-flag > "$T9/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 on unknown flag"
+assert_contains "Unknown argument" "$T9/run.log" "names the issue"
+
+# ── Test 10: No git remote AND no --owner/--repo → exit 2 ─────────────
+
+echo ""
+echo "Test 10: no git remote and no --owner/--repo → exit 2"
+
+T10=$(new_sandbox)
+write_fixture "$T10"
+# Initialize a git repo BUT do NOT add a remote
+git -C "$T10" init -q -b main 2>/dev/null
+
+set +e
+(cd "$T10" && bash "$SCRIPT" \
+    --project-name "NoRemote" --project-board "x" \
+    < /dev/null \
+    > "$T10/run.log" 2>&1)
+ec=$?
+set -e
+
+assert_eq "2" "$ec" "exit 2 when neither remote nor flag is available"
+assert_contains "No git remote found" "$T10/run.log" "names the issue"
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0

--- a/scripts/setup-solo-mode.sh
+++ b/scripts/setup-solo-mode.sh
@@ -17,6 +17,7 @@
 #   ✓ Activates the in-repo pre-push hook (`core.hooksPath`).
 #   ✓ Verifies you have admin access on the current fork.
 #   ✓ Creates the canonical label set (P0/P1/P2/P3/epic) on the fork.
+#   ✓ Populates CLAUDE.md project-config placeholders from git remote.
 #
 #   ✗ Does NOT cache tokens to disk. Tokens stay in gh's keyring.
 #   ✗ Does NOT auto-modify your shell rc to remove tokens — surfaces
@@ -184,9 +185,9 @@ if [ ! -t 0 ]; then
 fi
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 1/9: Detect shell + show current state
+#  Step 1/10: Detect shell + show current state
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 1/9: Detect shell ---${NC}"
+echo -e "${CYAN}--- Step 1/10: Detect shell ---${NC}"
 echo ""
 
 profile=$(detect_shell_profile)
@@ -197,9 +198,9 @@ print_info "Active gh account: ${active_account:-(none detected)}"
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 2/9: Persist AGILE_FLOW_SOLO_MODE
+#  Step 2/10: Persist AGILE_FLOW_SOLO_MODE
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 2/9: Persist AGILE_FLOW_SOLO_MODE=true ---${NC}"
+echo -e "${CYAN}--- Step 2/10: Persist AGILE_FLOW_SOLO_MODE=true ---${NC}"
 echo ""
 
 if [ "${AGILE_FLOW_SOLO_MODE:-}" = "true" ] && grep -qE "(^export AGILE_FLOW_SOLO_MODE=|^set -Ux AGILE_FLOW_SOLO_MODE )" "$profile" 2>/dev/null; then
@@ -210,9 +211,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 3/9: Audit GITHUB_PERSONAL_ACCESS_TOKEN* env vars
+#  Step 3/10: Audit GITHUB_PERSONAL_ACCESS_TOKEN* env vars
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 3/9: Audit GITHUB_PERSONAL_ACCESS_TOKEN env vars ---${NC}"
+echo -e "${CYAN}--- Step 3/10: Audit GITHUB_PERSONAL_ACCESS_TOKEN env vars ---${NC}"
 echo ""
 
 # In solo mode, ANY of these env vars override `gh auth switch` silently.
@@ -281,9 +282,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 4/9: Verify scopes
+#  Step 4/10: Verify scopes
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 4/9: Verify gh token scopes ---${NC}"
+echo -e "${CYAN}--- Step 4/10: Verify gh token scopes ---${NC}"
 echo ""
 
 required_scopes=(repo project workflow read:project)
@@ -364,9 +365,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 5/9: Activate pre-push hook
+#  Step 5/10: Activate pre-push hook
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 5/9: Activate pre-push hook ---${NC}"
+echo -e "${CYAN}--- Step 5/10: Activate pre-push hook ---${NC}"
 echo ""
 
 if [ -f "scripts/hooks/pre-push" ]; then
@@ -383,9 +384,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 6/9: Verify admin access on this fork
+#  Step 6/10: Verify admin access on this fork
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 6/9: Verify admin access on this fork ---${NC}"
+echo -e "${CYAN}--- Step 6/10: Verify admin access on this fork ---${NC}"
 echo ""
 
 remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
@@ -419,9 +420,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 7/9: Set up canonical labels (#112)
+#  Step 7/10: Set up canonical labels (#112)
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 7/9: Set up canonical labels ---${NC}"
+echo -e "${CYAN}--- Step 7/10: Set up canonical labels ---${NC}"
 echo ""
 
 # Labels require the same admin/write permission as Step 6 verifies,
@@ -449,9 +450,9 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 8/9: Multi-bot env-var sanity check
+#  Step 8/10: Multi-bot env-var sanity check
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 8/9: Multi-bot env-var sanity check ---${NC}"
+echo -e "${CYAN}--- Step 8/10: Multi-bot env-var sanity check ---${NC}"
 echo ""
 
 if [ -n "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]; then
@@ -467,9 +468,45 @@ fi
 echo ""
 
 # ───────────────────────────────────────────────────────────────────
-#  Step 9/9: Done — restart prompt
+#  Step 9/10: Populate CLAUDE.md project-config block (#113)
 # ───────────────────────────────────────────────────────────────────
-echo -e "${CYAN}--- Step 9/9: Done ---${NC}"
+echo -e "${CYAN}--- Step 9/10: Populate CLAUDE.md project-config ---${NC}"
+echo ""
+
+# Replace the placeholder lines inside CLAUDE.md's marker block with
+# values derived from `git remote origin`. Skipped silently if the
+# marker block isn't present (older forks / instances that haven't
+# upgraded yet); the script just notes that and moves on.
+populate_script="$(dirname "$0")/populate-claude-md.sh"
+if [ ! -f "$populate_script" ]; then
+    print_warning "scripts/populate-claude-md.sh not found; skipping CLAUDE.md fill."
+elif [ ! -f "CLAUDE.md" ]; then
+    print_warning "CLAUDE.md not in cwd; skipping CLAUDE.md fill."
+elif ! grep -q '<!-- bootstrap:project-config:start -->' CLAUDE.md 2>/dev/null; then
+    print_info "CLAUDE.md has no project-config marker block; skipping fill."
+    print_info "(Older forks pre-#113. Upgrade the framework or wrap placeholders manually.)"
+else
+    # Run non-interactively from setup-solo-mode (we'd hit the
+    # populate-claude-md.sh's TTY check otherwise). Pass --owner/--repo
+    # explicitly when we can derive them so the suggested-default path
+    # gets sensible values for project-name (= repo) and project-board
+    # (= orgs/<owner>/projects).
+    if bash "$populate_script" < /dev/null 2>&1 | sed 's/^/    /'; then
+        :
+    else
+        populate_ec=$?
+        if [ "$populate_ec" -ne 0 ]; then
+            print_warning "populate-claude-md.sh exited with code ${populate_ec}; continuing."
+            print_info "Run 'bash scripts/populate-claude-md.sh' manually with --project-name and --project-board to finish."
+        fi
+    fi
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Step 10/10: Done — restart prompt
+# ───────────────────────────────────────────────────────────────────
+echo -e "${CYAN}--- Step 10/10: Done ---${NC}"
 echo ""
 
 print_success "Solo mode is configured."


### PR DESCRIPTION
## Summary

Closes #113. Surfaced 2026-05-01 in the dry-run on `vibeacademy/kira-kim-11` (handoff item 7): every fork ships with `[Your project name]` and `[GitHub repo URL]` in CLAUDE.md and that text loads into every subsequent agent session's system prompt because no bootstrap phase fills the placeholders.

Three changes that together fix it.

## 1. CLAUDE.md restructured with marker block

Wrapped the four placeholder lines in an explicit, scriptable block:

```markdown
<!-- bootstrap:project-config:start -->
- **Project Name**: [Your project name]
- **Organization**: [GitHub org name]
- **Repository**: [GitHub repo URL]
- **Project Board**: [GitHub project board URL]
<!-- bootstrap:project-config:end -->
```

Reordered Project Information so all four placeholders are contiguous (Organization moved up next to Project Name; Tech Stack / Database / etc. unchanged and outside the marker block).

## 2. New script: `scripts/populate-claude-md.sh`

Idempotent. Re-runs are no-ops when the block already matches.

```
bash scripts/populate-claude-md.sh \
  --project-name "MyApp" \
  --project-board "https://github.com/orgs/myorg/projects/1"
```

- Derives **Organization** and **Repository** from `git remote get-url origin` (handles both HTTPS and SSH URL forms; normalizes to https://github.com/owner/repo)
- Accepts `--project-name`, `--project-board`, `--owner`, `--repo`, `--file`, `--dry-run`
- Interactive prompts when flags missing on a TTY; falls through to suggested defaults (`--project-name` defaults to repo name, `--project-board` defaults to `https://github.com/orgs/<owner>/projects`) when stdin is not a TTY (e.g., Codespaces postCreateCommand)

**Implementation note worth flagging in review:** BSD awk on macOS rejects multi-line strings passed via `-v`. The replacement uses a temp file + `getline line < block_file` to read the block, which works on both BSD and GNU awk. Caught during local testing.

## 3. Hook into `setup-solo-mode.sh`

New **Step 9/10**, renumbered "Done" from 9 → 10. Skipped gracefully when the CLAUDE.md marker block isn't present (older forks pre-#113 just see an info message). Runs non-interactively (`< /dev/null`) so it doesn't block the bootstrap with a prompt — falls through to suggested defaults.

## Tests — 10 cases / 32 assertions

- Happy path with all flags
- Idempotent re-run
- HTTPS git remote auto-detection
- SSH git remote auto-detection (URL normalized to https)
- Missing marker block → exit 1
- Missing file → exit 1
- Dry-run preview (no writes)
- Non-interactive context falls through to suggested defaults
- Unknown flag → exit 1
- No git remote AND no --owner/--repo → exit 2

Plus existing `setup-solo-mode.test.sh` still 42/42 after the step renumber.

## Test plan

- [x] `./scripts/populate-claude-md.test.sh` — 32/32
- [x] `./scripts/setup-solo-mode.test.sh` — 42/42 (renumber didn't break)
- [x] `./scripts/setup-labels.test.sh` — 37/37 (just to be sure)
- [x] shellcheck clean on both new files
- [x] markdownlint clean on CLAUDE.md
- [x] All other validators pass
- [x] actionlint clean
- [x] pytest 22/22
- [x] Manual dry-run against this repo's CLAUDE.md correctly auto-detects `vibeacademy` / `agile-flow-gcp`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)