### PR TITLE
feat(neon): per-attendee Neon project under shared workshop org (#108)

### DIFF
--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -731,8 +731,32 @@ cohorts.
 ### Branch namespace
 
 Neon branches are unique within a project. Across projects, names can
-repeat freely. The framework uses one Neon project per cohort by
-default.
+repeat freely. The framework supports two Neon project models for
+workshop cohorts:
+
+- **Shared cohort project (default for small N or paired use):** one
+  Neon project per cohort with one branch per attendee. Roster CSV
+  uses 4/5/6-column variants; cohort-level `NEON_PROJECT_ID` env var
+  applies to every row.
+- **Per-attendee project under a workshop org (#108, recommended for
+  workshops with ≥4 attendees):** each attendee gets their own Neon
+  project under a workshop-scoped Neon org. Console clarity (each
+  attendee sees only their own project), free-tier branch quota
+  isolation, and clean teardown. Use the 7-column roster variant
+  with `neon_project_id` populated by
+  `scripts/create-workshop-neon-projects.sh`:
+
+  ```bash
+  NEON_API_KEY=neon_... NEON_ORG_ID=org-... \
+    bash scripts/create-workshop-neon-projects.sh roster.csv
+  ```
+
+  The script creates one Neon project per row under the org and
+  writes the IDs back into the CSV. `provision-workshop-roster.sh`
+  then forwards each row's `neon_project_id` to the inner
+  provisioner per-row, overriding the cohort env var.
+
+  See #109 for the full deployment-models comparison.
 
 ### Branch types
 

--- a/scripts/create-workshop-neon-projects.sh
+++ b/scripts/create-workshop-neon-projects.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# create-workshop-neon-projects.sh — create one Neon project per
+# attendee under a workshop-scoped Neon org, then write each project's
+# ID back into the roster CSV's `neon_project_id` column.
+#
+# Run ONCE before `provision-workshop-roster.sh` in the workshop-org-
+# hosted flow. Idempotent: rows that already have a non-empty
+# `neon_project_id` are skipped. Rows whose target name already exists
+# in the org are reconciled (the existing project's ID is written back).
+#
+# Why per-attendee projects (not branches in a shared cohort project)?
+# See agile-flow-meta:docs/workshops/gcp-architecture-may-2026.md and
+# #108. Briefly:
+#   - Console clarity: each attendee sees only their own project
+#   - Free-tier quota: each project has its own 10-branch quota; a
+#     shared model blows past with ~3 attendees doing per-PR previews
+#   - Clean teardown: facilitator deletes the workshop org → all
+#     attendee projects gone in one call
+#
+# Usage:
+#   NEON_API_KEY=neon_... NEON_ORG_ID=org-... \
+#     ./scripts/create-workshop-neon-projects.sh roster.csv
+#
+#   ./scripts/create-workshop-neon-projects.sh roster.csv --dry-run
+#
+# Required environment variables:
+#   NEON_API_KEY    Neon API key with write access to the org
+#   NEON_ORG_ID     The Neon org ID (org-...) under which to create
+#                   projects. Get it from the Neon Console URL or
+#                   `GET /api/v2/organizations`.
+#
+# Optional flags:
+#   --dry-run            Print planned actions; don't write to Neon
+#                        and don't update the CSV.
+#   --region <region>    Neon region for new projects.
+#                        Default: aws-us-east-2 (closest to GCP us-central1).
+#
+# Optional environment variables:
+#   NEON_PROJECT_PREFIX  Prefix prepended to each attendee handle when
+#                        naming their Neon project. Default: empty
+#                        (project name == handle). Useful when you want
+#                        to namespace cohort projects, e.g.
+#                        NEON_PROJECT_PREFIX="2026-05-" → project name
+#                        becomes "2026-05-alice".
+#
+# Roster CSV format:
+#   The roster header must already include `neon_project_id` as the
+#   7th column. The script does NOT add the column for you — it expects
+#   the facilitator to upgrade the roster file first. Older 4/5/6-column
+#   rosters are rejected with a clear error.
+#
+# Exit codes:
+#   0 — all rows reconciled (created or skipped)
+#   1 — missing prerequisites (env vars, file, jq) or unrecoverable error
+#   2 — at least one row failed to reconcile (per-row WARNs surface
+#       individual failures; script continues to attempt all rows)
+#
+# See also: docs/PLATFORM-GUIDE.md "Workshop deployment models" section.
+
+set -uo pipefail
+
+# Ensure bash even if invoked as `zsh ...`
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Colors + print helpers
+# ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+print_error()   { echo -e "${RED}✗ $1${NC}"; }
+print_info()    { echo -e "${BLUE}→ $1${NC}"; }
+
+# ───────────────────────────────────────────────────────────────────
+#  Argument parsing
+# ───────────────────────────────────────────────────────────────────
+ROSTER_CSV=""
+DRY_RUN=false
+REGION="aws-us-east-2"
+
+show_help() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)   DRY_RUN=true; shift ;;
+        --region)    REGION="$2"; shift 2 ;;
+        --region=*)  REGION="${1#--region=}"; shift ;;
+        -h|--help)   show_help; exit 0 ;;
+        --*)
+            print_error "Unknown flag: $1"
+            print_info "Run with --help for usage."
+            exit 1
+            ;;
+        *)
+            if [ -n "$ROSTER_CSV" ]; then
+                print_error "Multiple positional arguments; expected exactly one (the roster CSV)"
+                exit 1
+            fi
+            ROSTER_CSV="$1"
+            shift
+            ;;
+    esac
+done
+
+# ───────────────────────────────────────────────────────────────────
+#  Pre-flight
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}=== Agile Flow — Workshop Neon Project Creation ===${NC}"
+echo ""
+
+if [ -z "$ROSTER_CSV" ]; then
+    print_error "Roster CSV path required."
+    print_info "Usage: NEON_API_KEY=... NEON_ORG_ID=... $0 <roster.csv> [--dry-run]"
+    exit 1
+fi
+
+if [ ! -f "$ROSTER_CSV" ]; then
+    print_error "Roster file not found: $ROSTER_CSV"
+    exit 1
+fi
+
+if [ -z "${NEON_API_KEY:-}" ]; then
+    print_error "NEON_API_KEY env var is required."
+    print_info "Get one from https://console.neon.tech/app/settings/api-keys"
+    exit 1
+fi
+
+if [ -z "${NEON_ORG_ID:-}" ]; then
+    print_error "NEON_ORG_ID env var is required."
+    print_info "Find it via: curl -H 'Authorization: Bearer \$NEON_API_KEY' https://console.neon.tech/api/v2/organizations"
+    exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    print_error "curl not found on PATH"
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    print_error "jq not found on PATH"
+    print_info "Install: brew install jq  OR  apt-get install jq"
+    exit 1
+fi
+
+# ───────────────────────────────────────────────────────────────────
+#  Validate roster header (must include neon_project_id as 7th col)
+# ───────────────────────────────────────────────────────────────────
+EXPECTED_HEADER_7="handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id"
+ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
+
+if [ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_7" ]; then
+    print_error "Roster CSV must have 7-column header for per-attendee Neon projects:"
+    echo "       expected: $EXPECTED_HEADER_7" >&2
+    echo "       got:      $ACTUAL_HEADER" >&2
+    print_info "Upgrade your roster: add 'neon_project_id' as the 7th column, leave values empty for new projects."
+    exit 1
+fi
+
+print_info "Target roster:    $ROSTER_CSV"
+print_info "Target Neon org:  $NEON_ORG_ID"
+print_info "Region:           $REGION"
+print_info "Project prefix:   ${NEON_PROJECT_PREFIX:-(none)}"
+if [ "$DRY_RUN" = "true" ]; then
+    print_info "Dry-run mode: no Neon writes, no CSV updates"
+fi
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Neon API helpers
+# ───────────────────────────────────────────────────────────────────
+NEON_API_BASE="${NEON_API_BASE:-https://console.neon.tech/api/v2}"
+
+# GET. Echoes body to stdout, returns curl exit code (0 = ok).
+neon_get() {
+    local path="$1"
+    curl --silent --show-error --fail \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        -H "Accept: application/json" \
+        "${NEON_API_BASE}${path}"
+}
+
+# POST. Echoes body to a tempfile (path passed in), echoes HTTP code
+# to stdout, returns curl exit code (0 = curl-ok, regardless of HTTP).
+# Caller checks the HTTP code.
+neon_post() {
+    local path="$1"
+    local body="$2"
+    local out_file="$3"
+    curl --silent --show-error \
+        --output "$out_file" \
+        --write-out '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        "${NEON_API_BASE}${path}"
+}
+
+# ───────────────────────────────────────────────────────────────────
+#  Look up existing org projects once (for idempotent name reuse)
+# ───────────────────────────────────────────────────────────────────
+echo "[lookup] Fetching existing projects in org $NEON_ORG_ID"
+existing_projects_json="$(neon_get "/projects?org_id=${NEON_ORG_ID}" || true)"
+
+if [ -z "$existing_projects_json" ]; then
+    print_warning "Could not list existing Neon projects in org $NEON_ORG_ID."
+    print_warning "Proceeding anyway; new-project creation may collide on names."
+    existing_projects_json='{"projects":[]}'
+fi
+
+# Map from project name → id, written as one "name<TAB>id" per line
+existing_map_file="$(mktemp -t aflow-neon-XXXX)"
+trap 'rm -f "$existing_map_file"' EXIT
+echo "$existing_projects_json" | \
+    jq -r '.projects[] | "\(.name)\t\(.id)"' > "$existing_map_file"
+
+print_info "Found $(wc -l < "$existing_map_file" | tr -d ' ') existing project(s) in org"
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+#  Iterate roster rows
+# ───────────────────────────────────────────────────────────────────
+HAD_ERROR=0
+CREATED=0
+REUSED=0
+SKIPPED=0
+
+# Build the new CSV in a tempfile so we can swap atomically at the end
+new_csv="$(mktemp -t aflow-roster-XXXX)"
+trap 'rm -f "$existing_map_file" "$new_csv"' EXIT
+head -n 1 "$ROSTER_CSV" > "$new_csv"
+
+while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo neon_project_id; do
+    # Strip whitespace and CR (Windows line endings)
+    handle="$(echo "$handle" | tr -d '[:space:]\r')"
+    github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
+    email="$(echo "$email" | tr -d '[:space:]\r')"
+    cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
+    neon_branch="$(echo "${neon_branch:-}" | tr -d '[:space:]\r')"
+    github_full_repo="$(echo "${github_full_repo:-}" | tr -d '[:space:]\r')"
+    neon_project_id="$(echo "${neon_project_id:-}" | tr -d '[:space:]\r')"
+
+    if [ -z "$handle" ]; then
+        # Pass empty/blank rows through unchanged
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo},${neon_project_id}" >> "$new_csv"
+        continue
+    fi
+
+    # Skip rows that already have a project ID
+    if [ -n "$neon_project_id" ]; then
+        print_success "Row '${handle}': already has project_id ${neon_project_id} (skipping)"
+        SKIPPED=$((SKIPPED + 1))
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo},${neon_project_id}" >> "$new_csv"
+        continue
+    fi
+
+    # Compute target project name
+    project_name="${NEON_PROJECT_PREFIX:-}${handle}"
+
+    # Look up existing project by name
+    existing_id="$(awk -F'\t' -v target="$project_name" '$1 == target { print $2; exit }' "$existing_map_file")"
+
+    if [ -n "$existing_id" ]; then
+        print_success "Row '${handle}': reusing existing project '${project_name}' (id=${existing_id})"
+        REUSED=$((REUSED + 1))
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo},${existing_id}" >> "$new_csv"
+        continue
+    fi
+
+    # Need to create
+    if [ "$DRY_RUN" = "true" ]; then
+        print_info "Row '${handle}': WOULD CREATE Neon project '${project_name}' under org $NEON_ORG_ID"
+        # Still write the row through with empty neon_project_id (dry-run leaves it untouched)
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo}," >> "$new_csv"
+        continue
+    fi
+
+    response_file="$(mktemp -t aflow-neon-resp-XXXX)"
+    body="$(printf '{"project":{"name":"%s","org_id":"%s","region_id":"%s"}}' "$project_name" "$NEON_ORG_ID" "$REGION")"
+    http_code="$(neon_post "/projects" "$body" "$response_file" || echo "000")"
+
+    if [ "$http_code" = "201" ] || [ "$http_code" = "200" ]; then
+        new_id="$(jq -r '.project.id // empty' < "$response_file")"
+        if [ -z "$new_id" ]; then
+            print_warning "Row '${handle}': Neon returned ${http_code} but no project.id in body"
+            cat "$response_file" | sed 's/^/    /' >&2
+            HAD_ERROR=$((HAD_ERROR + 1))
+            echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo}," >> "$new_csv"
+            rm -f "$response_file"
+            continue
+        fi
+        print_success "Row '${handle}': created Neon project '${project_name}' (id=${new_id})"
+        CREATED=$((CREATED + 1))
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo},${new_id}" >> "$new_csv"
+    else
+        print_warning "Row '${handle}': Neon API returned HTTP ${http_code} for project '${project_name}'"
+        cat "$response_file" 2>/dev/null | sed 's/^/    /' >&2 || true
+        HAD_ERROR=$((HAD_ERROR + 1))
+        echo "${handle},${github_user},${email},${cohort},${neon_branch},${github_full_repo}," >> "$new_csv"
+    fi
+    rm -f "$response_file"
+done < <(tail -n +2 "$ROSTER_CSV")
+
+# ───────────────────────────────────────────────────────────────────
+#  Apply CSV update (or report dry-run summary)
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────"
+echo "  Summary"
+echo "─────────────────────────────────"
+echo "  Created (new):     $CREATED"
+echo "  Reused (existing): $REUSED"
+echo "  Skipped (had id):  $SKIPPED"
+echo "  Failed:            $HAD_ERROR"
+echo "─────────────────────────────────"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+    print_info "Dry-run: roster file unchanged."
+    exit 0
+fi
+
+# Swap CSV atomically
+cp "$ROSTER_CSV" "${ROSTER_CSV}.bak"
+mv "$new_csv" "$ROSTER_CSV"
+print_success "Updated $ROSTER_CSV with neon_project_id values (backup: ${ROSTER_CSV}.bak)"
+
+if [ "$HAD_ERROR" -gt 0 ]; then
+    print_warning "${HAD_ERROR} row(s) failed; see WARNs above."
+    print_info "Re-run after resolving the underlying Neon API issue (the script is idempotent)."
+    exit 2
+fi
+
+print_success "All rows reconciled."
+exit 0

--- a/scripts/create-workshop-neon-projects.test.sh
+++ b/scripts/create-workshop-neon-projects.test.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+#
+# Tests for create-workshop-neon-projects.sh — per-attendee Neon
+# project reconciliation. Stubs `curl` and `jq` is real.
+#
+# Run: ./scripts/create-workshop-neon-projects.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/create-workshop-neon-projects.sh"
+
+new_sandbox() { mktemp -d -t aflowneon-XXXX; }
+
+# Write a 7-column roster fixture
+write_fixture() {
+    local sandbox="$1" content="$2"
+    cat > "$sandbox/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+${content}
+EOF
+}
+
+# Stub `curl` — all calls behave per env-var STUB_NEON_STATE.
+# Modes:
+#   missing      — list returns empty; POST /projects returns 201 with new ID
+#   existing     — list returns matching project for each handle
+#   denied       — POST returns 403
+#   list_fails   — list returns empty + non-zero (script should fail-soft)
+make_stubs() {
+    local sandbox="$1"
+    mkdir -p "$sandbox/bin"
+
+    cat > "$sandbox/bin/curl" <<'STUB_EOF'
+#!/usr/bin/env bash
+# Log every call
+echo "curl $*" >> "$STUB_STATE/curl.log"
+
+# Find the URL (last positional arg, but easier: scan for https://)
+url=""
+output_file=""
+write_out=false
+data=""
+method="GET"
+for arg in "$@"; do
+    case "$arg" in
+        --output) capture_output=true ;;
+        -X) capture_method=true ;;
+        -d) capture_data=true ;;
+        --write-out) capture_writeout=true ;;
+        https://*) url="$arg" ;;
+        *)
+            if [[ "${capture_output:-}" == "true" ]]; then
+                output_file="$arg"; capture_output=""
+            elif [[ "${capture_method:-}" == "true" ]]; then
+                method="$arg"; capture_method=""
+            elif [[ "${capture_data:-}" == "true" ]]; then
+                data="$arg"; capture_data=""
+            elif [[ "${capture_writeout:-}" == "true" ]]; then
+                write_out=true; capture_writeout=""
+            fi
+            ;;
+    esac
+done
+
+state="${STUB_NEON_STATE:-missing}"
+
+# GET /projects?org_id=... → list
+if [[ "$method" == "GET" && "$url" == *"/projects?org_id="* ]]; then
+    if [[ "$state" == "list_fails" ]]; then
+        # `--fail` means non-zero exit on HTTP error; the script reads stdout then `|| true`s
+        echo ""
+        exit 22
+    fi
+    if [[ "$state" == "existing" ]]; then
+        # Return projects matching the test handles
+        cat <<'JSON'
+{"projects":[
+  {"name":"alice","id":"proj-alice-existing-001"},
+  {"name":"bob","id":"proj-bob-existing-002"}
+]}
+JSON
+        exit 0
+    fi
+    # Default: missing
+    echo '{"projects":[]}'
+    exit 0
+fi
+
+# POST /projects → create
+if [[ "$method" == "POST" && "$url" == *"/projects" ]]; then
+    if [[ "$state" == "denied" ]]; then
+        echo '{"message":"Forbidden"}' > "$output_file"
+        if $write_out; then echo -n "403"; fi
+        exit 0
+    fi
+    # Extract the project name from the JSON body for echo-back
+    name="$(echo "$data" | sed -E 's/.*"name":"([^"]+)".*/\1/')"
+    new_id="proj-${name}-new-$(date +%s)$RANDOM"
+    cat > "$output_file" <<EOF
+{"project":{"id":"$new_id","name":"$name"}}
+EOF
+    if $write_out; then echo -n "201"; fi
+    exit 0
+fi
+
+# Anything else: succeed quietly
+exit 0
+STUB_EOF
+    chmod +x "$sandbox/bin/curl"
+}
+
+# Run script in a clean env, forwarding STUB_* vars.
+run_script() {
+    local sandbox="$1"
+    shift
+    env -i \
+        HOME="$sandbox" \
+        PATH="$sandbox/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+        STUB_STATE="$sandbox" \
+        TERM="${TERM:-dumb}" \
+        "$@" \
+        bash "$SCRIPT" "$sandbox/roster.csv"
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $expected; got: $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local needle="$1" file="$2" label="$3"
+    if grep -qF "$needle" "$file"; then
+        echo -e "  ${GREEN}OK${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $label  (expected: $needle)"
+        echo "  --- file ---"
+        sed -e 's/^/  /' "$file"
+        echo "  ------------"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: All rows missing → creates all, updates CSV ──────────────
+
+echo ""
+echo "Test 1: 3 rows with no project_id → creates all 3"
+
+T1=$(new_sandbox)
+make_stubs "$T1"
+write_fixture "$T1" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,
+carol,carol-gh,carol@x.com,2026-05,carol,vibeacademy/carol,"
+
+set +e
+run_script "$T1" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    > "$T1/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "created Neon project 'alice'" "$T1/run.log" "alice created"
+assert_contains "created Neon project 'bob'" "$T1/run.log" "bob created"
+assert_contains "created Neon project 'carol'" "$T1/run.log" "carol created"
+# CSV should now have non-empty neon_project_id for each row
+created_count=$(grep -c "proj-.*-new-" "$T1/roster.csv" || true)
+assert_eq "3" "$created_count" "all 3 rows have new project IDs in CSV"
+# Backup created
+if [ -f "$T1/roster.csv.bak" ]; then
+    echo -e "  ${GREEN}OK${NC} backup file created"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} no backup file"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 2: Idempotent — rows with existing IDs are skipped ─────────
+
+echo ""
+echo "Test 2: rows already have project_id → skipped"
+
+T2=$(new_sandbox)
+make_stubs "$T2"
+write_fixture "$T2" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-existing-1
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,proj-existing-2"
+
+set +e
+run_script "$T2" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    > "$T2/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "alice': already has project_id proj-existing-1" "$T2/run.log" "alice skipped"
+assert_contains "bob': already has project_id proj-existing-2" "$T2/run.log" "bob skipped"
+# Critical: must NOT have called POST
+if ! grep -q "POST" "$T2/curl.log" 2>/dev/null; then
+    echo -e "  ${GREEN}OK${NC} no POST calls when all rows already have IDs"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} POST called despite existing IDs"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 3: Reuse existing org project by name ──────────────────────
+
+echo ""
+echo "Test 3: existing org project with matching name → reuse, not re-create"
+
+T3=$(new_sandbox)
+make_stubs "$T3"
+write_fixture "$T3" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,"
+
+set +e
+run_script "$T3" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    STUB_NEON_STATE="existing" \
+    > "$T3/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "reusing existing project 'alice' (id=proj-alice-existing-001)" "$T3/run.log" "alice reused"
+assert_contains "reusing existing project 'bob' (id=proj-bob-existing-002)" "$T3/run.log" "bob reused"
+# Should NOT have called POST
+if ! grep -q "POST" "$T3/curl.log" 2>/dev/null; then
+    echo -e "  ${GREEN}OK${NC} no POST when names exist"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} POST called despite existing names"
+    FAIL=$((FAIL + 1))
+fi
+# CSV updated with the existing IDs
+assert_contains "proj-alice-existing-001" "$T3/roster.csv" "alice's existing ID written to CSV"
+assert_contains "proj-bob-existing-002" "$T3/roster.csv" "bob's existing ID written to CSV"
+
+# ── Test 4: Wrong header (6-column) → fail fast ─────────────────────
+
+echo ""
+echo "Test 4: 6-column header → fail fast with clear message"
+
+T4=$(new_sandbox)
+make_stubs "$T4"
+cat > "$T4/roster.csv" <<'EOF'
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice
+EOF
+
+set +e
+run_script "$T4" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    > "$T4/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 on wrong header"
+assert_contains "must have 7-column header" "$T4/run.log" "names the issue"
+assert_contains "Upgrade your roster" "$T4/run.log" "tells user how to fix"
+
+# ── Test 5: Missing NEON_API_KEY → fail fast ────────────────────────
+
+echo ""
+echo "Test 5: missing NEON_API_KEY → exit 1"
+
+T5=$(new_sandbox)
+make_stubs "$T5"
+write_fixture "$T5" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,"
+
+set +e
+run_script "$T5" \
+    NEON_ORG_ID="org-test" \
+    > "$T5/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1"
+assert_contains "NEON_API_KEY" "$T5/run.log" "names missing var"
+
+# ── Test 6: Missing NEON_ORG_ID → fail fast ─────────────────────────
+
+echo ""
+echo "Test 6: missing NEON_ORG_ID → exit 1"
+
+T6=$(new_sandbox)
+make_stubs "$T6"
+write_fixture "$T6" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,"
+
+set +e
+run_script "$T6" \
+    NEON_API_KEY="key123" \
+    > "$T6/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1"
+assert_contains "NEON_ORG_ID" "$T6/run.log" "names missing var"
+
+# ── Test 7: Dry-run does not write to Neon or CSV ───────────────────
+
+echo ""
+echo "Test 7: --dry-run preview only"
+
+T7=$(new_sandbox)
+make_stubs "$T7"
+write_fixture "$T7" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,"
+hash_before=$(md5 -q "$T7/roster.csv" 2>/dev/null || md5sum "$T7/roster.csv" | cut -d' ' -f1)
+
+set +e
+env -i \
+    HOME="$T7" \
+    PATH="$T7/bin:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+    STUB_STATE="$T7" \
+    TERM="${TERM:-dumb}" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    bash "$SCRIPT" "$T7/roster.csv" --dry-run \
+    > "$T7/run.log" 2>&1
+ec=$?
+set -e
+
+hash_after=$(md5 -q "$T7/roster.csv" 2>/dev/null || md5sum "$T7/roster.csv" | cut -d' ' -f1)
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "WOULD CREATE" "$T7/run.log" "dry-run shows planned action"
+assert_contains "Dry-run: roster file unchanged" "$T7/run.log" "summary"
+assert_eq "$hash_before" "$hash_after" "roster CSV unchanged"
+# No POST call should have been made
+if ! grep -q "POST" "$T7/curl.log" 2>/dev/null; then
+    echo -e "  ${GREEN}OK${NC} dry-run made no POST call"
+    PASS=$((PASS + 1))
+else
+    echo -e "  ${RED}FAIL${NC} dry-run made a POST call"
+    FAIL=$((FAIL + 1))
+fi
+
+# ── Test 8: Neon write denied → exit 2 ──────────────────────────────
+
+echo ""
+echo "Test 8: POST returns 403 → exit 2 with WARN per failed row"
+
+T8=$(new_sandbox)
+make_stubs "$T8"
+write_fixture "$T8" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,"
+
+set +e
+run_script "$T8" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    STUB_NEON_STATE="denied" \
+    > "$T8/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "2" "$ec" "exit 2 on at-least-one failure"
+assert_contains "alice': Neon API returned HTTP 403" "$T8/run.log" "alice failure surfaced"
+assert_contains "bob': Neon API returned HTTP 403" "$T8/run.log" "bob failure surfaced"
+# Both failures must be reported (no early-exit on first failure)
+fail_count=$(grep -c "Neon API returned HTTP 403" "$T8/run.log" || true)
+assert_eq "2" "$fail_count" "both failures surfaced (no early-exit)"
+
+# ── Test 9: Mixed state — some rows have IDs, some don't ────────────
+
+echo ""
+echo "Test 9: mixed roster (1 with id, 1 without) → only creates the missing one"
+
+T9=$(new_sandbox)
+make_stubs "$T9"
+write_fixture "$T9" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-alice-prefilled
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,"
+
+set +e
+run_script "$T9" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    > "$T9/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "alice': already has project_id proj-alice-prefilled" "$T9/run.log" "alice skipped"
+assert_contains "created Neon project 'bob'" "$T9/run.log" "bob created"
+# CSV should preserve alice's prefilled ID and have a new one for bob
+assert_contains "proj-alice-prefilled" "$T9/roster.csv" "alice's prefilled ID preserved"
+
+# ── Test 10: NEON_PROJECT_PREFIX → applied to project name ──────────
+
+echo ""
+echo "Test 10: NEON_PROJECT_PREFIX prepends to handle for project name"
+
+T10=$(new_sandbox)
+make_stubs "$T10"
+write_fixture "$T10" "alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,"
+
+set +e
+run_script "$T10" \
+    NEON_API_KEY="key123" \
+    NEON_ORG_ID="org-test" \
+    NEON_PROJECT_PREFIX="2026-05-" \
+    > "$T10/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0"
+assert_contains "created Neon project '2026-05-alice'" "$T10/run.log" "prefix applied"
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+(( FAIL > 0 )) && exit 1
+exit 0

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -34,7 +34,7 @@
 #                        (per-project billing budget). Default for workshop
 #                        usage is 25.
 #
-# CSV format (header required, accepts 4, 5, or 6 columns):
+# CSV format (header required, accepts 4, 5, 6, or 7 columns):
 #   handle,github_user,email,cohort
 #   alice,alice-gh,alice@example.com,2026-05
 #   bob,bob-gh,bob@example.com,2026-05
@@ -47,6 +47,16 @@
 #   alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
 #   bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
 #   carol,carol-gh,carol@example.com,2026-05,carol,                (defaults)
+#
+#   handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id (7)
+#   alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice,proj-alice-123
+#   bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop,proj-bob-456
+#
+# In the 7-column variant, the per-row `neon_project_id` overrides the
+# cohort-level NEON_PROJECT_ID env var. This enables the per-attendee
+# Neon project model (#108) — populate the column via
+# `scripts/create-workshop-neon-projects.sh` before running this wrapper.
+# Empty `neon_project_id` falls back to the env var (cohort-shared model).
 #
 # When the optional `neon_branch` column is empty or absent, NEON_BRANCH_NAME
 # defaults to the row's `handle`. Use the override when the same person needs
@@ -145,15 +155,18 @@ fi
 EXPECTED_HEADER_4="handle,github_user,email,cohort"
 EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
 EXPECTED_HEADER_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
+EXPECTED_HEADER_7="handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
 
 if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" \
    && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" \
-   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_6" ]]; then
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_6" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_7" ]]; then
   echo "ERROR: roster CSV header must be one of:" >&2
   echo "       $EXPECTED_HEADER_4" >&2
   echo "       $EXPECTED_HEADER_5" >&2
   echo "       $EXPECTED_HEADER_6" >&2
+  echo "       $EXPECTED_HEADER_7" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -175,9 +188,9 @@ skipped=0
 # tail -n +2 skips header. Process substitution avoids subshell so counters
 # survive into the summary block.
 #
-# We read 6 fields. 4- and 5-column rows leave the trailing fields empty;
-# the default-fallback logic below covers them.
-while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo; do
+# We read 7 fields. 4-, 5-, and 6-column rows leave the trailing fields
+# empty; the default-fallback logic below covers them.
+while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo row_neon_project_id; do
   # Strip whitespace and CR (Windows line endings)
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
@@ -185,6 +198,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   cohort="$(echo "$cohort" | tr -d '[:space:]\r')"
   neon_branch="$(echo "${neon_branch:-}" | tr -d '[:space:]\r')"
   github_full_repo="$(echo "${github_full_repo:-}" | tr -d '[:space:]\r')"
+  row_neon_project_id="$(echo "${row_neon_project_id:-}" | tr -d '[:space:]\r')"
 
   if [[ -z "$handle" || -z "$cohort" ]]; then
     continue
@@ -254,9 +268,17 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   # for any external caller still relying on that env-var name.
   #
   # NEON_BRANCH_NAME enables the Neon-branch-per-attendee step (5.7).
-  # NEON_API_KEY and NEON_PROJECT_ID are forwarded only if set in the
-  # facilitator's environment; the inner script skips that step when
-  # either is missing.
+  # NEON_API_KEY and NEON_PROJECT_ID are forwarded only if set; the
+  # inner script skips Step 5.7 when either is missing.
+  #
+  # Per-row override (#108): when the 7-column roster has a non-empty
+  # neon_project_id, use it for THIS attendee instead of the cohort
+  # env var. Falls back to the env var when the cell is empty (5/6-col
+  # rosters and 7-col rows with no project assigned yet). This is what
+  # enables the per-attendee Neon project model — each attendee's
+  # project ID is their own.
+  effective_neon_project_id="${row_neon_project_id:-${NEON_PROJECT_ID:-}}"
+
   GCP_PROJECT_ID="$project_id" \
   BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
   GCP_REGION="${GCP_REGION:-us-central1}" \
@@ -267,7 +289,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   GITHUB_REPOSITORY="$github_full_repo" \
   NEON_BRANCH_NAME="$neon_branch" \
   NEON_API_KEY="${NEON_API_KEY:-}" \
-  NEON_PROJECT_ID="${NEON_PROJECT_ID:-}" \
+  NEON_PROJECT_ID="$effective_neon_project_id" \
   NEON_FORCE_SHARED_PARENT="$FORCE_SHARED_PARENT" \
   BUDGET_CAP_USD="${BUDGET_CAP_USD:-}" \
     "$PROVISION_SCRIPT" --create-project

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -64,7 +64,7 @@ EOF
 #!/usr/bin/env bash
 # Log every invocation along with the env vars the wrapper is supposed
 # to forward. Tests grep this log to verify per-row env passthrough.
-echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-} GITHUB_USERNAME=\${GITHUB_USERNAME:-} GITHUB_OWNER=\${GITHUB_OWNER:-} GITHUB_REPO=\${GITHUB_REPO:-} NEON_BRANCH_NAME=\${NEON_BRANCH_NAME:-}" >> "$tmp/provision.log"
+echo "provision \$* GCP_PROJECT_ID=\${GCP_PROJECT_ID:-} GITHUB_USERNAME=\${GITHUB_USERNAME:-} GITHUB_OWNER=\${GITHUB_OWNER:-} GITHUB_REPO=\${GITHUB_REPO:-} NEON_BRANCH_NAME=\${NEON_BRANCH_NAME:-} NEON_PROJECT_ID=\${NEON_PROJECT_ID:-}" >> "$tmp/provision.log"
 
 if [[ "$behavior" == "fail" ]]; then
   echo "fake provision failure" >&2
@@ -456,6 +456,100 @@ assert_contains "GITHUB_OWNER=alice-gh.*GITHUB_REPO=agile-flow-gcp" "$T12/provis
 assert_contains "GITHUB_OWNER=bob-gh.*GITHUB_REPO=agile-flow-gcp" "$T12/provision.log" "bob defaults to bob-gh/agile-flow-gcp"
 
 # ── Summary ──────────────────────────────────────────────────────────────
+
+# ── Test 13: 7-column header accepted; per-row neon_project_id forwarded ──
+#
+# #108: workshop facilitators populate the 7th column via
+# create-workshop-neon-projects.sh before running this wrapper. The
+# wrapper must accept the 7-column header and forward each row's
+# neon_project_id as NEON_PROJECT_ID to the inner script (per-row,
+# not from cohort env).
+
+echo ""
+echo "Test 13: 7-column header forwards per-row NEON_PROJECT_ID"
+
+T13=$(new_tmp)
+make_stubs "$T13" "ok"
+cat > "$T13/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-alice-aaa
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,proj-bob-bbb
+EOF
+
+set +e
+PATH="$T13/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T13/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T13/roster-output.csv" \
+  "$WRAPPER" "$T13/roster.csv" > "$T13/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 7-column header"
+assert_contains "GCP_PROJECT_ID=af-alice-2026-05.*NEON_PROJECT_ID=proj-alice-aaa" "$T13/provision.log" "alice forwards her per-row project ID"
+assert_contains "GCP_PROJECT_ID=af-bob-2026-05.*NEON_PROJECT_ID=proj-bob-bbb" "$T13/provision.log" "bob forwards his per-row project ID"
+
+# ── Test 14: empty per-row neon_project_id falls back to cohort env var ──
+#
+# Backwards-compat: rows with empty neon_project_id (or 5/6-column rosters)
+# fall back to the cohort-level NEON_PROJECT_ID env var. This preserves
+# the shared-project model for non-workshop-org-hosted setups.
+
+echo ""
+echo "Test 14: empty per-row neon_project_id falls back to NEON_PROJECT_ID env"
+
+T14=$(new_tmp)
+make_stubs "$T14" "ok"
+cat > "$T14/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-alice-aaa
+carol,carol-gh,carol@x.com,2026-05,carol,vibeacademy/carol,
+EOF
+
+set +e
+PATH="$T14/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  NEON_PROJECT_ID="cohort-shared-proj-zzz" \
+  PROVISION_SCRIPT="$T14/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T14/roster-output.csv" \
+  "$WRAPPER" "$T14/roster.csv" > "$T14/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with mixed per-row IDs"
+# alice: per-row value wins
+assert_contains "GCP_PROJECT_ID=af-alice-2026-05.*NEON_PROJECT_ID=proj-alice-aaa" "$T14/provision.log" "alice's per-row ID overrides env var"
+# carol: empty per-row → fallback to env var
+assert_contains "GCP_PROJECT_ID=af-carol-2026-05.*NEON_PROJECT_ID=cohort-shared-proj-zzz" "$T14/provision.log" "carol's empty per-row falls back to env var"
+
+# ── Test 15: 6-column roster + cohort env var still forwards env var ─────
+#
+# Backwards-compat regression guard: 4/5/6-column rosters never had a
+# neon_project_id column. The wrapper must continue to forward the
+# cohort env var for them, exactly as before.
+
+echo ""
+echo "Test 15: 6-column roster forwards cohort NEON_PROJECT_ID env var"
+
+T15=$(new_tmp)
+make_stubs "$T15" "ok"
+cat > "$T15/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice
+EOF
+
+set +e
+PATH="$T15/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  NEON_PROJECT_ID="cohort-shared-proj-zzz" \
+  PROVISION_SCRIPT="$T15/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T15/roster-output.csv" \
+  "$WRAPPER" "$T15/roster.csv" > "$T15/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 6-column header (regression guard)"
+assert_contains "NEON_PROJECT_ID=cohort-shared-proj-zzz" "$T15/provision.log" "6-column row forwards cohort env var unchanged"
 
 echo ""
 echo "─────────────────────────────────"

--- a/scripts/roster.example.csv
+++ b/scripts/roster.example.csv
@@ -1,4 +1,4 @@
-handle,github_user,email,cohort,neon_branch,github_full_repo
-alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice
-bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop
-carol,carol-gh,carol@example.com,2026-05,,
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice,
+bob,bob-gh,bob@acme.com,2026-05,bob,acme/widget-shop,
+carol,carol-gh,carol@example.com,2026-05,,,


### PR DESCRIPTION
## Summary

Closes #108. PR-1 of a 2-PR bundle for the May 2026 workshop architecture (#107 follows). Adds the per-attendee Neon project model: each attendee gets their own Neon project under a workshop-scoped Neon org instead of sharing a cohort project's branches.

Backwards-compatible: 4/5/6-column rosters still work with the cohort-shared model. The new 7-column variant opts into per-attendee projects.

## Why per-attendee projects

Three concrete wins from the architecture doc:

- **Console clarity:** each attendee sees only their own project in the Neon dashboard. No cross-attendee branch list.
- **Free-tier quota isolation:** each project has its own 10-branch quota. The shared model blows past with ~3 attendees doing per-PR previews.
- **Clean teardown:** facilitator deletes the workshop org → all attendee projects gone in one call. No per-attendee cleanup script.

## Three coordinated changes

### 1. New script: `scripts/create-workshop-neon-projects.sh`

Run once before `provision-workshop-roster.sh`. Creates one Neon project per roster row under the org, writes IDs back into the CSV.

```bash
NEON_API_KEY=neon_... NEON_ORG_ID=org-... \
  bash scripts/create-workshop-neon-projects.sh roster.csv
```

- **Idempotent:** rows with non-empty `neon_project_id` are skipped; rows whose target name already exists in the org reuse that project's ID
- **Fail-soft:** per-row WARNs surface failures, exits 2 on partial failure (same pattern as #112's setup-labels.sh and #114's setup-repo-protection.sh)
- **Flags:** `--dry-run`, `--region` (default `aws-us-east-2`), `--help`
- **Optional:** `NEON_PROJECT_PREFIX` env var for cohort namespacing

### 2. `provision-workshop-roster.sh` — 7-column variant + per-row override

New header accepted: `handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id`. Per-row `neon_project_id` is forwarded as `NEON_PROJECT_ID` to the inner provisioner, overriding the cohort env var. Empty per-row falls back to env var (preserves shared-project model).

The inner script (`provision-gcp-project.sh`) already accepts per-call `NEON_PROJECT_ID` — no change needed there.

### 3. `roster.example.csv` upgraded + `PLATFORM-GUIDE.md` brief note

Example CSV is now the 7-column form (existing rows have empty `neon_project_id`, populated by the helper). PLATFORM-GUIDE gets a short Neon-section note pointing at the new script. The full deployment-models comparison stays scoped to **#109**.

## Tests — 11 cases / 46 new assertions, all passing

**`create-workshop-neon-projects.test.sh`** (10 cases / 38 assertions):
- All rows missing → 3 creates, CSV updated, backup file written
- All rows have IDs → idempotent skip, no POST calls
- Existing org project by name → reuse, write ID back, no POST
- Wrong header (6-column) → exit 1 with clear message
- Missing NEON_API_KEY → exit 1
- Missing NEON_ORG_ID → exit 1
- `--dry-run` → preview, no Neon writes, no CSV change
- POST returns 403 → exit 2 with per-row WARNs (no early-exit)
- Mixed roster → only creates the missing one, preserves prefilled
- `NEON_PROJECT_PREFIX` → applied to project name

**`provision-workshop-roster.test.sh`** (3 new cases / 8 assertions):
- 7-column header accepted, per-row override forwards correctly
- Empty per-row → fallback to env var
- 6-column regression guard (cohort env var still flows through)

## Out of scope (handled in PR-2 = #107)

- Workshop-org-hosted GitHub repo creation (`vibeacademy/<handle>` via `gh repo create --template`)
- WIF org-trust pattern in `provision-gcp-project.sh`
- The `WORKSHOP_ORG` env var

These two PRs decouple the Neon-side change (this) from the GitHub-side change (#107) so review surface stays manageable. Either ships independently; together they implement the May architecture.

## Test plan

- [x] `./scripts/create-workshop-neon-projects.test.sh` — 38/38
- [x] `./scripts/provision-workshop-roster.test.sh` — 40/40 (was 32; +8 new)
- [x] shellcheck clean on all touched files
- [x] markdownlint clean on PLATFORM-GUIDE.md
- [x] All other validators pass
- [x] actionlint clean
- [x] pytest 22/22
- [ ] CI green on PR
- [ ] Real-world: facilitator runs against a throwaway Neon org, verifies per-attendee projects land + CSV updates correctly (deferred to next workshop-org dry-run alongside #107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)