### PR TITLE
fix(provisioner): drop --include-all-branches from gh repo create (#129)

### DIFF
--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -301,10 +301,18 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
       echo "[skip] repo ${github_full_repo} already exists"
     else
       echo "[create] repo ${github_full_repo} from template ${WORKSHOP_TEMPLATE_REPO}"
+      # NOTE: --include-all-branches is intentionally OMITTED (#129).
+      # gh repo create --template starts the new repo's main as a fresh
+      # single commit (the template's main history is squashed). If we
+      # also copy template branches, those branches retain their pre-
+      # squash history and share ZERO commits with the new main —
+      # GitHub's compare view reports "entirely different commit
+      # histories" and any "create PR from this branch" attempt errors.
+      # Default behavior (no --include-all-branches) creates only main,
+      # which is what attendees actually need for a fresh workshop start.
       if ! "$GH_REPO_CREATE" repo create "${github_full_repo}" \
         --template "${WORKSHOP_TEMPLATE_REPO}" \
-        --public \
-        --include-all-branches >/dev/null; then
+        --public >/dev/null; then
         echo "ERROR: failed to create repo ${github_full_repo}" >&2
         echo "       The facilitator's gh token must have admin write on the org." >&2
         exit 1

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -600,6 +600,27 @@ assert_eq "0" "$exit_code" "wrapper exits 0 with --workshop-org"
 # Each row should have a `gh repo create vibeacademy/<handle>` call
 assert_contains "gh repo create vibeacademy/alice" "$T16/gh.log" "alice repo created under vibeacademy"
 assert_contains "gh repo create vibeacademy/bob" "$T16/gh.log" "bob repo created under vibeacademy"
+# Each create call must include --public (not --private). Use grep -F
+# directly so the leading -- isn't interpreted as a grep flag.
+if grep -qF -- "--public" "$T16/gh.log"; then
+  echo -e "  ${GREEN}✓${NC} repo create includes --public flag"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} expected --public in repo create call"
+  FAIL=$((FAIL + 1))
+fi
+# Regression guard (#129): --include-all-branches must NOT be present.
+# That flag copies template branches verbatim while gh squashes the
+# template's main into a fresh single commit, leaving the template
+# branches with no common ancestor — GitHub's compare view reports
+# "entirely different commit histories" and PR creation fails.
+if grep -q "include-all-branches" "$T16/gh.log"; then
+  echo -e "  ${RED}✗${NC} --include-all-branches still present in gh repo create (#129 regression)"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} --include-all-branches correctly absent (only main is copied; #129)"
+  PASS=$((PASS + 1))
+fi
 # github_full_repo was overridden — alice's CSV said personal-acme/foo
 # but the inner script should see vibeacademy/alice
 assert_contains "GITHUB_REPOSITORY=vibeacademy/alice" "$T16/provision.log" "alice's github_full_repo overridden to vibeacademy/alice"


### PR DESCRIPTION
## Summary

Closes #129. Single-flag removal that fixes a workshop-attendee-facing bug surfaced 2026-05-02 in the dry-run on `vibeacademy/worker`: every fresh attendee repo shipped with leftover template branches that had no common ancestor with main.

## Root cause

`gh repo create --template` always squashes the template's `main` history into a single fresh initial commit. Adding `--include-all-branches` (in the wrapper since #107) copied every other template branch verbatim, but those branches retained their pre-squash history and shared zero commits with the new `main`.

Effect on attendees: GitHub's compare view reports "These branches are entirely different commit histories" and PR creation against those branches errors. Confusing UI and broken PRs from any non-main template branch.

## Fix

Remove the `--include-all-branches` flag. Default behavior creates only `main`, which is what attendees actually need for a fresh workshop start. Inline comment in the script explains the why so future contributors don't restore it.

## Tests

`scripts/provision-workshop-roster.test.sh` Test 16 grew two assertions (61/61 passing, was 59):
- Positive guard: `--public` flag still present
- Regression guard: `--include-all-branches` NOT present

## Cleanup for already-provisioned repos

Each affected repo needs the orphaned branches deleted manually:

```bash
gh api repos/vibeacademy/<handle>/branches --jq '.[].name' | grep -v '^main$'
gh api -X DELETE repos/vibeacademy/<handle>/git/refs/heads/<branch-name>
```

Already done for `vibeacademy/worker` during the dry-run. `vibeacademy/reviewer` and any future cohort repos provisioned before this PR ships need the same cleanup.

## Test plan

- [x] `./scripts/provision-workshop-roster.test.sh` — 61/61
- [x] shellcheck clean
- [x] pytest 22/22
- [x] actionlint clean
- [ ] CI green on PR
- [ ] Real-world: next workshop-org provision creates a repo with only `main` (no template branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)