### PR TITLE
fix(setup): setup-labels.sh treat gh exit code as authoritative (#128)

### DIFF
--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -153,7 +153,15 @@ for entry in "${CANONICAL_LABELS[@]}"; do
     IFS='|' read -r name color description <<< "$entry"
 
     # Look up the existing label (if any) via gh api.
-    existing=$(gh api "repos/${REPO}/labels/${name}" 2>/dev/null || true)
+    # Note: gh api writes the JSON error body to stdout on HTTP errors
+    # (404, 403, etc.) — it does NOT exit with empty stdout. Check the
+    # exit code and capture stdout separately so a 404 produces empty
+    # `existing`, not the error body.
+    if existing=$(gh api "repos/${REPO}/labels/${name}" 2>/dev/null); then
+        : # success — existing holds the label JSON
+    else
+        existing=""
+    fi
 
     if [ -z "$existing" ]; then
         # Label does not exist: create.

--- a/scripts/setup-labels.test.sh
+++ b/scripts/setup-labels.test.sh
@@ -108,7 +108,14 @@ if [[ "$1" == "api" ]]; then
 
         case "$effective_state" in
             missing)
-                # 404 — non-zero exit, no output (mirrors `gh api` behavior)
+                # 404 — gh api writes the JSON error body to STDOUT (not just
+                # stderr) AND exits 1. Pre-#128 the stub returned "no output,
+                # exit 1" which let the script's wrong `var=$(... || true) &&
+                # [ -z "$var" ]` pattern pass tests but fail in production.
+                # Now mirror real gh behavior: emit the body to stdout, exit 1.
+                cat <<'JSON'
+{"message":"Not Found","documentation_url":"https://docs.github.com/rest/issues/labels#get-a-label","status":"404"}
+JSON
                 exit 1
                 ;;
             canonical)
@@ -222,6 +229,17 @@ assert_not_contains() {
 }
 
 # ── Test 1: All labels missing → 5 creates, exit 0 ────────────────────
+#
+# Regression guard for #128: when the gh stub returns a 404 JSON body on
+# stdout AND exits 1, the script must take the CREATE path (not the
+# UPDATE path). Pre-#128 the script used `existing=$(gh api ... 2>/dev/null
+# || true)` and then `[ -z "$existing" ]` to detect "label missing" — but
+# with realistic gh behavior, `existing` contained the 404 JSON, the
+# emptiness check failed, and the script wrongly tried PATCH instead of
+# POST. Every label appeared as "Failed to update" with a misleading
+# "missing admin/write permission" diagnosis. Fix: capture the gh exit
+# code separately via `if existing=$(gh api ...); then ... else
+# existing=""; fi`.
 
 echo ""
 echo "Test 1: empty repo (all labels missing) → creates all 5"


### PR DESCRIPTION
## Summary

Closes #128. Fixes the workshop-facilitator-facing bug where `setup-labels.sh` reported every label as "Failed to update" with a misleading "missing admin/write permission" diagnosis on a fresh repo with no labels — even when the token had admin.

## Root cause

`gh api repos/<owner>/labels/<name>` writes its 404 JSON error body to STDOUT (not just stderr) AND exits 1. The pre-fix pattern:

```bash
existing=$(gh api "repos/${REPO}/labels/${name}" 2>/dev/null || true)
if [ -z "$existing" ]; then
    # create path
else
    # update path
```

captured the error JSON into `existing`, so the emptiness check was false, and the script took the wrong "label exists, update" branch. The PATCH then failed because there was nothing to update, but the error message blamed permissions.

## Fix

Capture gh's exit code separately:

```bash
if existing=$(gh api "repos/${REPO}/labels/${name}" 2>/dev/null); then
    : # success — existing holds the label JSON
else
    existing=""
fi
```

Now a 404 produces empty `existing`, the script takes the CREATE path, and POST succeeds.

## Test stub fix (load-bearing)

The pre-#128 test stub returned "no output, exit 1" for the missing-label state, which let the buggy script pass all 37 tests. With the realistic stub (mirroring gh's actual behavior — JSON on stdout AND exit 1), Test 1's existing "Created: P0" assertions become the regression guard. Without the script fix, those assertions would now fail.

Inline comment in Test 1 names the history.

## Test plan

- [x] `./scripts/setup-labels.test.sh` — 37/37 with realistic stub + script fix
- [x] shellcheck clean
- [x] pytest 22/22
- [ ] CI green on PR
- [ ] Real-world: re-run `bash scripts/setup-labels.sh --repo vibeacademy/<test-repo>` against a fresh repo and verify all 5 canonical labels are CREATED (not "Failed to update")

## Related

- **Audit follow-up:** the `var=$(gh api ... 2>/dev/null || true)` pattern likely affects other framework scripts. `grep -rnE 'gh api[^|]*2>/dev/null' scripts/` would surface candidates.
- Saved as `Lesson-gh-api-writes-error-body-to-stdout` in agent memory for future-proofing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)