### PR TITLE
docs(agents): require empirical verification of literal framework-state claims

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -338,6 +338,7 @@ return success signals while doing the wrong thing.
 - [ ] Does the feature work end-to-end?
 - [ ] Is the code appropriately documented?
 - [ ] Do all tests pass?
+- [ ] **Are literal framework-state claims empirically verified?** If the diff includes a literal CLI command, file path, workflow filename, or framework-hook semantics claim, run the verification action before submitting. See `.claude/agents/pr-reviewer.md` → "Empirical Verification of Literal Framework-State Claims" for the four trigger categories and verification actions. The reviewer agent applies the same rule and will NO-GO any unverified claim that fails empirical check — catching it pre-submit saves a review round.
 
 ### Verification Steps:
 Refer to CLAUDE.md for project-specific verification commands.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -430,6 +430,76 @@ This makes the code more maintainable and self-documenting."
 ✅ Very clear comments explaining the pattern
 ```
 
+## Empirical Verification of Literal Framework-State Claims
+
+PRs frequently include literal claims about framework state — CLI commands, file paths, workflow filenames, hook semantics. When the worker ships these claims without running them, they routinely turn out to be wrong. This is a recurring failure mode (see worked examples below). Verifying these claims empirically is part of your review, not optional.
+
+**The rule:** for the four categories below, do not approve the claim by reading. Run the verification action and check the actual output.
+
+### Trigger categories (verify before GO)
+
+| If the diff contains... | Verification action |
+|-------------------------|---------------------|
+| **A literal CLI command** in user-facing docs, agent prompts, or commit messages (e.g. `gh repo view --json owner --jq '.owner.type'`) | Run the command. Confirm the output matches the doc's claim. If the command parses output, confirm the field exists. |
+| **A file path or filename** referenced in docs or commit messages (e.g. `app/api/health.py`, `scripts/setup-foo.sh`) | Confirm the file exists with `Glob` or `ls`. If a directory tree is described, spot-check it. |
+| **A workflow- or script-behavior claim** ("X workflow consumes Y secret", "Z script does W") | Grep the workflow file or read the script. Verify the named secret / behavior actually appears. |
+| **A framework hook semantics claim** in a security-relevant docstring or pattern entry (e.g. "this validator fires on ORM hydration") | If the surface is non-trivial, write a scratch test (`pytest`, scratch script) that exercises the claimed behavior. Read framework source as a secondary check. |
+
+### Boundary — when NOT to apply this
+
+This rule does not require empirical verification of EVERY claim. Do not apply it to:
+
+- Opinions or judgment ("this is the cleanest approach", "this naming is clearer") — those are for human merger discretion
+- General prose explaining why a design decision was made
+- Cross-references to other tickets, PRs, or docs (verify the link target exists if uncertain, but you don't need to read its contents)
+
+### When verification fails → NO-GO
+
+A literal-state claim that fails empirical verification is a Red Flag, same severity as type errors or broken commands. Post NO-GO with:
+
+1. The exact claim from the diff
+2. The verification command you ran
+3. The actual output (in a code block)
+4. A specific corrected replacement the worker can apply
+
+### Worked examples (recent incidents)
+
+**Example 1 — broken CLI command (PR #144, 2026-05-03):**
+
+PR claimed `gh repo view --json owner --jq '.owner.type'` would print `Organization` or `User`. Verification:
+
+```bash
+$ gh repo view vibeacademy/agile-flow-gcp --json owner
+{"owner":{"id":"O_kgDODjeGBw","login":"vibeacademy"}}
+
+$ gh repo view vibeacademy/agile-flow-gcp --json owner --jq '.owner.type'
+# (empty — no `type` field)
+```
+
+The `owner` JSON shape only includes `id` and `login`. NO-GO; recommended replacement `gh repo view --json isInOrganization --jq '.isInOrganization'` (boolean, native gh CLI).
+
+**Example 2 — false workflow-consumption claim (PR #145, 2026-05-03):**
+
+PR's PLATFORM-GUIDE.md update claimed `auto-fix.yml`, `auto-review.yml`, and `auto-triage.yml` consume `ANTHROPIC_API_KEY`. Verification:
+
+```bash
+$ grep -l 'ANTHROPIC_API_KEY' .github/workflows/*.yml
+# (empty — no workflow references it)
+
+$ grep -E 'secrets\.|env:' .github/workflows/auto-{fix,review,triage}.yml
+# (empty — none reference any secrets at all)
+```
+
+Reading `auto-review.yml` confirmed: it just posts a "Ready for review" comment via `actions/github-script@v7` with a manual `/review-pr` invocation hint. The framework does not currently run Claude in CI. NO-GO; recommended replacement was to drop the false CI row from the table and reframe as future-proofing language.
+
+**Example 3 — wrong claim about ORM hook semantics (downstream `vibeacademy/reviewer` PR #29, 2026-05-03):**
+
+PR's `ApiKey.key_hash` docstring claimed "Rows loaded from the database go through the same hook" for SQLAlchemy `@validates`. Verification was a scratch script that corrupted a row via raw SQL, called `session.expire(key)`, accessed `key.key_hash` (forces ORM reload), and got back the plaintext without the validator firing. NO-GO; the claim was empirically false — `@validates` hooks the `set` event, not the `refresh` / load events.
+
+### Why this is a separate section, not just a Red Flag bullet
+
+The Red Flags section names *categories of bug* (hardcoded secrets, security vulnerabilities, type errors). This section names a *review activity* (run the literal claim and check). Without naming the activity explicitly, reviewers consistently approve doc PRs by reading them — which is exactly how the three incidents above shipped.
+
 ## Red Flags (Automatic Rejection)
 
 The following issues are grounds for immediate rejection:


### PR DESCRIPTION
## Summary

Closes #146.

Two consecutive PRs this session (#144, #145) and one downstream PR (`vibeacademy/reviewer:` PR #29) all shipped literal framework-state claims that turned out to be wrong on first execution. Same root cause: the worker put a literal CLI command, workflow filename, or framework-hook claim in user-facing docs without running it. The reviewer caught all three but only because the reviewer happened to verify; the existing `pr-reviewer.md` didn't explicitly require it.

This PR makes the rule explicit on both sides of the worker→reviewer handoff.

### Changes

- **`.claude/agents/pr-reviewer.md`** — new top-level section "Empirical Verification of Literal Framework-State Claims" inserted before "Red Flags". Names the four trigger categories (CLI commands / file paths / workflow-or-script behavior / framework hook semantics), the verification action for each, the boundary (NOT every claim — only those four), and three worked examples drawn from the real incidents (PR #144, PR #145, downstream PR #29). Explicitly notes that this section names a *review activity*, not a bug category — without that, reviewers consistently approve doc PRs by reading them.
- **`.claude/agents/github-ticket-worker.md`** — one new Self-Review Checklist bullet pointing at the same rule. Worker self-verifies pre-submit; saves a review round.

### What's NOT changed

- No script behavior, no workflow change
- No update to existing Red Flags list — the new section is its own activity that can result in NO-GO via the existing Red Flag mechanism

## Test plan

- [ ] Read pr-reviewer.md's new section — confirm the 4 trigger categories cover the recurring failure mode
- [ ] Read each of the 3 worked examples — confirm they're accurate (PR #144's broken `gh` command, PR #145's false workflow claim, PR #29's `@validates` hydration claim)
- [ ] Confirm the boundary statement ("NOT every claim — only the 4 categories") is explicit enough that reviewers don't slow down on judgment calls
- [ ] Read github-ticket-worker.md's new checklist bullet — confirm it cross-references the right pr-reviewer.md section
- [ ] Run `bash scripts/lint-agent-policies.sh` — confirm the agent-policy linter still passes (it does locally)
- [ ] Spot-check by re-reading PR #144's NO-GO comment and confirming the rule, if applied pre-review, would have caught the same issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)