### PR TITLE
feat(scripts): scripts/dev-branch.sh — Neon dev-branch lifecycle helper for local Codespaces

### DIFF
--- a/scripts/dev-branch.sh
+++ b/scripts/dev-branch.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# dev-branch.sh — Neon dev-branch lifecycle helper for local Codespaces.
+#
+# Mints a per-developer ephemeral Neon branch off `main`, writes its
+# pooled connection URL into `.env` (gitignored), and runs alembic
+# migrations so the branch matches current schema. The companion
+# `--teardown` flag deletes the branch and removes `.env`.
+#
+# Replaces the manual `neonctl branches create + connection-string`
+# dance documented as the fallback in `docs/LOCAL-DEV.md`. See #157
+# (epic) and #158 (LOCAL-DEV.md) for context.
+#
+# Usage:
+#   bash scripts/dev-branch.sh           # create + migrate
+#   bash scripts/dev-branch.sh --teardown # delete branch + restore .env
+#   bash scripts/dev-branch.sh --help
+#
+# Required environment variables:
+#   NEON_API_KEY     Neon API key with write access to the project
+#   NEON_PROJECT_ID  The Neon project this fork uses (the parent project
+#                    that CI preview branches from). Workshop attendees
+#                    inherit this from a Codespaces org secret per #160.
+#
+# Optional environment variables:
+#   NEON_API_BASE          (default: https://console.neon.tech/api/v2)
+#   NEON_PARENT_BRANCH     (default: main) Branch to fork from.
+#   DEV_BRANCH_PREFIX      (default: dev-${USER}) Prefix for the branch
+#                          name. Full name becomes <prefix>-<epoch>.
+#   ENV_FILE               (default: .env) Where to write DATABASE_URL.
+#   SKIP_MIGRATE           (default: empty) When set, skip the
+#                          `uv run alembic upgrade head` step. Useful
+#                          for tests that don't have alembic installed.
+#
+# Side effects:
+#   - Creates ONE Neon branch per invocation (default mode); name is
+#     unique via the epoch suffix so concurrent invocations don't collide.
+#   - Writes ENV_FILE with `DATABASE_URL=<pooled URL>`. If ENV_FILE
+#     already exists with non-default content, backs it up to
+#     ${ENV_FILE}.bak first and warns.
+#   - Runs `uv run alembic upgrade head` against the new branch unless
+#     SKIP_MIGRATE is set.
+#
+# Exit codes:
+#   0 — branch created (or torn down) successfully
+#   1 — Neon API call failed; ENV_FILE write failed; migration failed
+#   2 — required env vars missing; invalid arguments
+#
+# Idempotency:
+#   Default mode is intentionally non-idempotent — each invocation creates
+#   a fresh branch with a unique epoch suffix. Repeated runs accumulate
+#   branches; use `--teardown` (which deletes ALL branches matching the
+#   user's prefix) to clean up.
+
+set -euo pipefail
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+
+MODE="create"
+case "${1:-}" in
+    --teardown) MODE="teardown" ;;
+    -h|--help)
+        sed -n '1,55p' "$0"
+        exit 0
+        ;;
+    "") ;;  # no flag, default mode
+    *)
+        echo "ERROR: unknown flag: $1" >&2
+        echo "Usage: $0 [--teardown | --help]" >&2
+        exit 2
+        ;;
+esac
+
+# ── Pre-flight ───────────────────────────────────────────────────────────
+
+if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ]; then
+    echo "ERROR: NEON_API_KEY and NEON_PROJECT_ID must be set" >&2
+    echo "" >&2
+    echo "  In a Codespace, configure both as Codespaces secrets at" >&2
+    echo "  https://github.com/settings/codespaces — or inherit from" >&2
+    echo "  the workshop-org Codespaces secrets your facilitator set." >&2
+    echo "" >&2
+    echo "  See docs/LOCAL-DEV.md for the full setup story." >&2
+    exit 2
+fi
+
+NEON_API_BASE="${NEON_API_BASE:-https://console.neon.tech/api/v2}"
+NEON_PARENT_BRANCH="${NEON_PARENT_BRANCH:-main}"
+DEV_BRANCH_PREFIX="${DEV_BRANCH_PREFIX:-dev-${USER:-dev}}"
+ENV_FILE="${ENV_FILE:-.env}"
+
+# ── Neon API helpers (pattern from create-workshop-neon-projects.sh) ────
+
+# GET — echoes body to stdout, returns curl exit code
+neon_get() {
+    local path="$1"
+    curl --silent --show-error --fail \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        -H "Accept: application/json" \
+        "${NEON_API_BASE}${path}"
+}
+
+# POST — body to a tempfile, http_code to stdout, curl exit code returned
+neon_post() {
+    local path="$1"
+    local body="$2"
+    local out_file="$3"
+    curl --silent --show-error \
+        --output "$out_file" \
+        --write-out '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        "${NEON_API_BASE}${path}"
+}
+
+# DELETE — http_code to stdout, curl exit code returned
+neon_delete() {
+    local path="$1"
+    curl --silent --show-error \
+        --output /dev/null \
+        --write-out '%{http_code}' \
+        -X DELETE \
+        -H "Authorization: Bearer $NEON_API_KEY" \
+        "${NEON_API_BASE}${path}"
+}
+
+# ── Mode: teardown ──────────────────────────────────────────────────────
+
+if [ "$MODE" = "teardown" ]; then
+    echo "──────────────────────────────────────────────────"
+    echo "  Tearing down dev branches matching prefix: ${DEV_BRANCH_PREFIX}-*"
+    echo "──────────────────────────────────────────────────"
+
+    # List all branches in the project, filter by prefix.
+    branches_json="$(neon_get "/projects/${NEON_PROJECT_ID}/branches")" || {
+        echo "ERROR: failed to list Neon branches" >&2
+        exit 1
+    }
+
+    # Extract branch IDs whose name starts with our prefix.
+    matching_ids="$(echo "$branches_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+prefix = sys.argv[1]
+for b in data.get('branches', []):
+    if b.get('name', '').startswith(prefix):
+        print(b.get('id', ''))
+" "$DEV_BRANCH_PREFIX-")"
+
+    if [ -z "$matching_ids" ]; then
+        echo "  No matching branches to delete."
+    else
+        deleted=0
+        while IFS= read -r branch_id; do
+            [ -z "$branch_id" ] && continue
+            http_code="$(neon_delete "/projects/${NEON_PROJECT_ID}/branches/${branch_id}")"
+            if [ "$http_code" = "200" ] || [ "$http_code" = "202" ] || [ "$http_code" = "204" ]; then
+                echo "  [delete] $branch_id"
+                deleted=$((deleted + 1))
+            else
+                echo "  WARN: delete returned HTTP $http_code for $branch_id" >&2
+            fi
+        done <<< "$matching_ids"
+        echo "  Deleted $deleted branch(es)."
+    fi
+
+    # Restore .env.bak if present, else remove .env
+    if [ -f "${ENV_FILE}.bak" ]; then
+        mv "${ENV_FILE}.bak" "$ENV_FILE"
+        echo "  [restore] ${ENV_FILE} (from ${ENV_FILE}.bak)"
+    elif [ -f "$ENV_FILE" ]; then
+        rm -f "$ENV_FILE"
+        echo "  [remove]  ${ENV_FILE}"
+    fi
+
+    echo "Teardown complete."
+    exit 0
+fi
+
+# ── Mode: create (default) ──────────────────────────────────────────────
+
+BRANCH_NAME="${DEV_BRANCH_PREFIX}-$(date +%s)"
+
+echo "──────────────────────────────────────────────────"
+echo "  Creating Neon dev branch: ${BRANCH_NAME}"
+echo "  Project:  ${NEON_PROJECT_ID}"
+echo "  Parent:   ${NEON_PARENT_BRANCH}"
+echo "──────────────────────────────────────────────────"
+
+# Resolve parent branch ID (Neon's API takes branch IDs, not names, for
+# the parent-branch reference inside branch creation).
+parent_id="$(neon_get "/projects/${NEON_PROJECT_ID}/branches" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+target = sys.argv[1]
+for b in data.get('branches', []):
+    if b.get('name', '') == target:
+        print(b.get('id', ''))
+        sys.exit(0)
+sys.exit(1)
+" "$NEON_PARENT_BRANCH")" || {
+    echo "ERROR: could not resolve parent branch '$NEON_PARENT_BRANCH' in project $NEON_PROJECT_ID" >&2
+    exit 1
+}
+
+# Build the request body.
+# `endpoints: [{type: read_write}]` ensures a compute endpoint is created
+# (without it the branch has no connection URL).
+request_body=$(cat <<EOF
+{
+  "branch": {
+    "name": "${BRANCH_NAME}",
+    "parent_id": "${parent_id}"
+  },
+  "endpoints": [
+    { "type": "read_write" }
+  ]
+}
+EOF
+)
+
+response_file="$(mktemp -t aflow-devbranch-XXXX)"
+trap 'rm -f "$response_file"' EXIT
+
+http_code="$(neon_post "/projects/${NEON_PROJECT_ID}/branches" "$request_body" "$response_file")"
+if [ "$http_code" != "201" ] && [ "$http_code" != "200" ]; then
+    echo "ERROR: Neon branch creation returned HTTP $http_code" >&2
+    cat "$response_file" >&2 || true
+    exit 1
+fi
+
+# Extract the pooled connection URI. Neon's response includes
+# `connection_uris[0].connection_uri` (direct) and
+# `connection_uris[0].connection_uri_pooled` for the pgbouncer URL.
+pooled_url="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+uris = data.get('connection_uris') or []
+if not uris:
+    sys.exit('ERROR: response missing connection_uris')
+# Prefer pooled URL when available; fall back to direct.
+print(uris[0].get('connection_uri_pooled') or uris[0].get('connection_uri', ''))
+" "$response_file")"
+
+if [ -z "$pooled_url" ]; then
+    echo "ERROR: could not extract connection URI from Neon response" >&2
+    exit 1
+fi
+
+# Backup existing .env if it has non-default content
+if [ -f "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then
+    cp "$ENV_FILE" "${ENV_FILE}.bak"
+    echo "  [backup] ${ENV_FILE} → ${ENV_FILE}.bak"
+fi
+
+# Write the new .env. Don't echo the URL to stdout.
+{
+    echo "# Generated by scripts/dev-branch.sh on $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Branch: ${BRANCH_NAME}"
+    echo "# Teardown: bash scripts/dev-branch.sh --teardown"
+    echo "DATABASE_URL=${pooled_url}"
+} > "$ENV_FILE"
+echo "  [write]  ${ENV_FILE} (DATABASE_URL configured)"
+
+# Run migrations against the new branch unless SKIP_MIGRATE
+if [ -z "${SKIP_MIGRATE:-}" ]; then
+    echo ""
+    echo "  [migrate] Running: uv run alembic upgrade head"
+    if ! DATABASE_URL="$pooled_url" uv run alembic upgrade head; then
+        echo "ERROR: migration failed against new branch" >&2
+        echo "       Branch ${BRANCH_NAME} is created but in unknown schema state" >&2
+        echo "       Run: bash scripts/dev-branch.sh --teardown" >&2
+        exit 1
+    fi
+fi
+
+echo ""
+echo "──────────────────────────────────────────────────"
+echo "Dev branch ready."
+echo "  Run your app:    uv run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload"
+echo "  Tear down later: bash scripts/dev-branch.sh --teardown"
+echo "──────────────────────────────────────────────────"

--- a/scripts/dev-branch.test.sh
+++ b/scripts/dev-branch.test.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+#
+# Tests for dev-branch.sh.
+#
+# Stubs `curl` via PATH injection — the script's only network surface
+# is curl calls to the Neon API. Stub responds with deterministic
+# JSON for the GET/POST/DELETE paths the script actually uses.
+#
+# Run: ./scripts/dev-branch.test.sh
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/dev-branch.sh"
+
+new_tmp() {
+    mktemp -d -t aflowdevbranch-XXXX
+}
+
+# Build a fake `curl` in $tmp/bin that responds to the Neon API endpoints
+# the script invokes. The stub:
+#   - GET /projects/<id>/branches      → returns a JSON list including a
+#                                         `main` branch with a known ID
+#   - POST /projects/<id>/branches     → writes a fake creation response
+#                                         to the --output file, echoes 201
+#   - DELETE /projects/<id>/branches/X → echoes 204
+make_stubs() {
+    local tmp="$1"
+    mkdir -p "$tmp/bin"
+
+    cat > "$tmp/bin/curl" <<EOF
+#!/usr/bin/env bash
+# Log every call. Last arg is the URL.
+echo "curl \$*" >> "$tmp/curl.log"
+
+# Find --output and --write-out values + the URL (last positional)
+out_file=""
+write_out=""
+method="GET"
+url=""
+data=""
+prev=""
+for arg in "\$@"; do
+    case "\$prev" in
+        --output) out_file="\$arg"; prev=""; continue ;;
+        --write-out) write_out="\$arg"; prev=""; continue ;;
+        -X) method="\$arg"; prev=""; continue ;;
+        -d) data="\$arg"; prev=""; continue ;;
+    esac
+    case "\$arg" in
+        --output|--write-out|-X|-d) prev="\$arg" ;;
+        *) url="\$arg" ;;
+    esac
+done
+
+# Route by method + URL pattern.
+if [ "\$method" = "GET" ] && [[ "\$url" == *"/branches" ]]; then
+    cat <<JSON
+{"branches":[{"id":"br-main-fake","name":"main"},{"id":"br-existing-fake","name":"\${DEV_BRANCH_PREFIX:-dev-someuser}-prior"}]}
+JSON
+    exit 0
+fi
+
+if [ "\$method" = "POST" ] && [[ "\$url" == *"/branches" ]]; then
+    cat > "\$out_file" <<JSON
+{
+  "branch": {"id": "br-new-fake", "name": "fake"},
+  "connection_uris": [
+    {
+      "connection_uri": "postgresql://user:pass@host/db?sslmode=require",
+      "connection_uri_pooled": "postgresql://user:pass@host-pooler/db?sslmode=require"
+    }
+  ]
+}
+JSON
+    echo -n "201"
+    exit 0
+fi
+
+if [ "\$method" = "DELETE" ] && [[ "\$url" == *"/branches/"* ]]; then
+    echo -n "204"
+    exit 0
+fi
+
+# Unhandled — fail loud
+echo "TEST STUB: unhandled curl call: method=\$method url=\$url" >&2
+exit 1
+EOF
+    chmod +x "$tmp/bin/curl"
+}
+
+assert_contains() {
+    local needle="$1" file="$2" label="$3"
+    if grep -q "$needle" "$file"; then
+        echo -e "  ${GREEN}✓${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}✗${NC} $label  (looking for: $needle)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo -e "  ${GREEN}✓${NC} $label"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}✗${NC} $label  (expected: $expected; got: $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Test 1: env vars missing → exits 2 with clear message ───────────────
+
+echo ""
+echo "Test 1: missing env vars rejected with helpful message"
+
+T1=$(new_tmp)
+make_stubs "$T1"
+
+set +e
+PATH="$T1/bin:$PATH" \
+    NEON_API_KEY="" NEON_PROJECT_ID="" \
+    bash "$SCRIPT" > "$T1/stdout.log" 2> "$T1/stderr.log"
+exit_code=$?
+set -e
+
+assert_eq "2" "$exit_code" "exits 2 when env vars unset"
+assert_contains "NEON_API_KEY and NEON_PROJECT_ID must be set" "$T1/stderr.log" "error names both required vars"
+assert_contains "docs/LOCAL-DEV.md" "$T1/stderr.log" "error points at LOCAL-DEV.md"
+
+# ── Test 2: create mode posts to branches endpoint with right body ──────
+
+echo ""
+echo "Test 2: create mode POSTs branch creation with parent_id resolved"
+
+T2=$(new_tmp)
+make_stubs "$T2"
+
+set +e
+PATH="$T2/bin:$PATH" \
+    NEON_API_KEY="fake-key" \
+    NEON_PROJECT_ID="proj-test" \
+    DEV_BRANCH_PREFIX="dev-tester" \
+    ENV_FILE="$T2/.env" \
+    SKIP_MIGRATE="1" \
+    bash "$SCRIPT" > "$T2/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "exits 0 on successful create"
+# Two curl invocations expected: GET parent-branch list + POST creation.
+# Count via line-prefix since the stub logs each call as `curl <args>` and
+# the POST body's multi-line JSON inflates a naive line count.
+calls=$(grep -c '^curl ' "$T2/curl.log")
+assert_eq "2" "$calls" "exactly 2 curl invocations (GET parent + POST create)"
+assert_contains "POST" "$T2/curl.log" "POST called (branch creation)"
+assert_contains "/projects/proj-test/branches" "$T2/curl.log" "URL targets the right project"
+
+# ── Test 3: writes .env with DATABASE_URL extracted from response ───────
+
+echo ""
+echo "Test 3: writes ENV_FILE with DATABASE_URL=<pooled url from response>"
+
+# T2 already ran; verify its .env
+assert_contains "DATABASE_URL=postgresql://user:pass@host-pooler" "$T2/.env" "ENV_FILE contains pooled URL"
+assert_contains "# Branch: dev-tester-" "$T2/.env" "ENV_FILE comment names the branch"
+assert_contains "# Teardown:" "$T2/.env" "ENV_FILE comment includes teardown reminder"
+# Verify the URL is NOT echoed to stdout
+if grep -q "host-pooler" "$T2/stdout.log"; then
+    echo -e "  ${RED}✗${NC} pooled URL leaked to stdout (security: don't log secrets)"
+    FAIL=$((FAIL + 1))
+else
+    echo -e "  ${GREEN}✓${NC} pooled URL not echoed to stdout (secret hygiene)"
+    PASS=$((PASS + 1))
+fi
+
+# ── Test 4: --teardown deletes matching branches ────────────────────────
+
+echo ""
+echo "Test 4: --teardown deletes branches matching DEV_BRANCH_PREFIX-*"
+
+T4=$(new_tmp)
+make_stubs "$T4"
+# Pre-create a fake .env to verify teardown removes it
+echo "DATABASE_URL=postgresql://stale" > "$T4/.env"
+
+set +e
+PATH="$T4/bin:$PATH" \
+    NEON_API_KEY="fake-key" \
+    NEON_PROJECT_ID="proj-test" \
+    DEV_BRANCH_PREFIX="dev-someuser" \
+    ENV_FILE="$T4/.env" \
+    bash "$SCRIPT" --teardown > "$T4/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "teardown exits 0"
+# Stub returns one branch named dev-someuser-prior matching the prefix
+assert_contains "DELETE" "$T4/curl.log" "DELETE called for matching branch"
+assert_contains "br-existing-fake" "$T4/curl.log" "deleted the right branch ID"
+if [ -f "$T4/.env" ]; then
+    echo -e "  ${RED}✗${NC} ENV_FILE still exists after teardown"
+    FAIL=$((FAIL + 1))
+else
+    echo -e "  ${GREEN}✓${NC} ENV_FILE removed by teardown"
+    PASS=$((PASS + 1))
+fi
+
+# ── Test 5: idempotent teardown — second run finds nothing, exits 0 ─────
+
+echo ""
+echo "Test 5: idempotent teardown — re-running with no matching branches exits 0"
+
+T5=$(new_tmp)
+mkdir -p "$T5/bin"
+# Custom stub: GET returns ZERO matching branches (no prefix match)
+cat > "$T5/bin/curl" <<EOF
+#!/usr/bin/env bash
+echo "curl \$*" >> "$T5/curl.log"
+method="GET"
+prev=""
+for arg in "\$@"; do
+    case "\$prev" in -X) method="\$arg"; prev="" ;; esac
+    case "\$arg" in -X) prev="\$arg" ;; esac
+done
+if [ "\$method" = "GET" ]; then
+    echo '{"branches":[{"id":"br-main","name":"main"},{"id":"br-other","name":"unrelated"}]}'
+fi
+exit 0
+EOF
+chmod +x "$T5/bin/curl"
+
+set +e
+PATH="$T5/bin:$PATH" \
+    NEON_API_KEY="fake-key" \
+    NEON_PROJECT_ID="proj-test" \
+    DEV_BRANCH_PREFIX="dev-nonexistent" \
+    ENV_FILE="$T5/.env" \
+    bash "$SCRIPT" --teardown > "$T5/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "teardown exits 0 when no matching branches"
+assert_contains "No matching branches to delete" "$T5/stdout.log" "reports nothing to delete cleanly"
+# Verify NO DELETE call was made
+if grep -q "DELETE" "$T5/curl.log"; then
+    echo -e "  ${RED}✗${NC} DELETE called despite no matching branches"
+    FAIL=$((FAIL + 1))
+else
+    echo -e "  ${GREEN}✓${NC} no DELETE call when nothing to delete"
+    PASS=$((PASS + 1))
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "─────────────────────────────────"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #159. Part of #157 (local-dev story epic). Sibling to #158 (LOCAL-DEV.md, just landed) which references this script.

The framework's documented local-dev story (LOCAL-DEV.md) prescribes a per-developer Neon branch flow but had no helper script. Developers fell back to SQLite (hides Postgres-only bugs — the `sqltypes.GUID` incident in the worker fork) or hand-rolled raw `neonctl` calls. This PR adds the helper that LOCAL-DEV.md was already pointing at, fully closing the epic's chicken-and-egg from yesterday.

### Changes

- **`scripts/dev-branch.sh`** — main lifecycle helper. Default mode mints a per-session branch; `--teardown` cleans up.
  - Helpers (`neon_get` / `neon_post` / `neon_delete`) follow `create-workshop-neon-projects.sh:186-210`'s pattern
  - Resolves parent branch ID via `GET /projects/<id>/branches` then `POST /projects/<id>/branches` with `endpoints: [{type: read_write}]` (so a compute endpoint is provisioned alongside)
  - Extracts `connection_uri_pooled` from response, writes to `.env`
  - Runs `uv run alembic upgrade head` against the new branch (skippable via `SKIP_MIGRATE=1` for tests)
  - Pooled URL never echoed to stdout (secret hygiene)
  - Backs up existing `.env` to `.env.bak` if non-empty before writing
  - `--teardown` lists `DEV_BRANCH_PREFIX-*` branches and DELETEs each; restores `.env.bak` or removes `.env`
- **`scripts/dev-branch.test.sh`** — 18 assertions across 5 DoD cases:
  - **T1:** env vars unset → exits 2 with message pointing at LOCAL-DEV.md
  - **T2:** create POSTs to `/branches` with parent_id resolved (exactly 2 curl invocations)
  - **T3:** writes ENV_FILE with pooled DATABASE_URL; URL never echoed
  - **T4:** `--teardown` DELETEs matching branches + removes ENV_FILE
  - **T5:** idempotent teardown — re-runs with no matches exit 0 cleanly

All 18 dev-branch tests pass locally; ruff + existing 22 pytest tests still green.

### Empirical verification (per #146/#147 rule)

The Neon API endpoints I'm relying on:

```bash
# 1. NEON_API_BASE matches existing usage in create-workshop-neon-projects.sh:183
$ grep NEON_API_BASE scripts/create-workshop-neon-projects.sh
NEON_API_BASE="${NEON_API_BASE:-https://console.neon.tech/api/v2}"

# 2. Branch-creation response shape — connection_uris[0].connection_uri_pooled
#    is consistent with how the framework already consumes Neon API output
#    (deploy + preview workflows). Used the same field name throughout the script.
```

I did NOT empirically test against a real Neon API in CI (would require a real Neon project + key). The test suite mocks `curl` directly, asserting on the call patterns and response handling. A future end-to-end test could verify against a real Neon project but that's a separate concern (and would burn quota on every CI run).

### What's NOT changed

- LOCAL-DEV.md still references this script + still contains the `neonctl`-direct manual fallback section. The fallback can be slimmed in a follow-up once this lands and is verified against a real Neon project.
- No agent-spec changes (workers/reviewers will read LOCAL-DEV.md naturally and pick this up)
- No devcontainer.json change (doesn't auto-run dev-branch.sh on Codespace start — that's deferred; the `postCreateCommand` already does enough)

## Test plan

- [ ] Run `bash scripts/dev-branch.test.sh` — confirm 18/18 pass
- [ ] Read the script — confirm `set -euo pipefail` is honored, helpers match the existing pattern, secret hygiene (no URL on stdout) is preserved
- [ ] Read LOCAL-DEV.md's "Recipe: bringing up local dev" section — confirm the script's behavior matches what the doc promises
- [ ] **Optional end-to-end (recommended for human merger):** in a Codespace with `NEON_API_KEY` + `NEON_PROJECT_ID` configured, run `bash scripts/dev-branch.sh` and confirm:
  - A new branch appears in the Neon console
  - `.env` has `DATABASE_URL=postgresql://...pooler...`
  - `uv run alembic upgrade head` succeeds against the new branch
  - `bash scripts/dev-branch.sh --teardown` removes the branch and `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)