### PR TITLE
feat(bootstrap-workflow): explicit "commit and ship bootstrap output" finalizer step

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -234,6 +234,74 @@ Update CLAUDE.md with:
 - Team/org information
 - Any final configuration
 
+### 7. Commit and ship the bootstrap output
+
+By this point you've accumulated **a lot** of uncommitted output across
+the bootstrap pipeline (`/research`, `/jtbd`, `/positioning`,
+`/bootstrap-product`, `/bootstrap-architecture`, `/bootstrap-agents`,
+plus this phase's CLAUDE.md edits). None of the bootstrap commands
+commit on your behalf — that's intentional, so you can review the
+output before it lands. But leaving it uncommitted creates two real
+problems:
+
+1. **`/work-ticket`'s pre-flight will catch it.** The first time you
+   try to pick up a real ticket, the worker's pre-push hook trips on
+   the dirty working tree. You then have to recover with a Quick Fix
+   PR — exactly what this step is here to prevent you from having to
+   discover the hard way.
+2. **The bootstrap output gets entangled with your first feature
+   commit.** Every `feature/issue-*` branch from `main` would carry
+   the bootstrap diff alongside the actual feature code, making the
+   review messy and the PR diff misleading.
+
+**Ship the bootstrap output as a single Quick Fix PR (no linked ticket)
+before starting any other work.** Quick Fix Protocol applies — branch
++ commit + PR, no ticket ceremony, since this is content/config not a
+tracked feature. From your repo root:
+
+```bash
+# Make sure you're on main with no other in-flight changes
+git status   # should show ONLY bootstrap-output files
+
+# Branch with a clear name; date suffix avoids collisions on re-bootstrap
+git checkout -b content/bootstrap-output-$(date +%Y-%m-%d)
+
+# Stage everything bootstrap created — adjust if your stack diverged
+git add CLAUDE.md docs/ .claude/agents/ .claude/PROJECT.md
+
+# Conventional commit; replace <product-name> with what you locked in
+# during /bootstrap-product (the value sitting in CLAUDE.md right now).
+git commit -m "chore(config): initial <product-name> bootstrap"
+
+# Push and open the PR. Mark it explicitly as Quick Fix.
+git push -u origin HEAD
+gh pr create \
+    --title "chore(config): initial <product-name> bootstrap" \
+    --body "Quick fix — no linked ticket. All bootstrap pipeline output (research, PRD, roadmap, architecture, agents, project config) in one commit." \
+    --base main
+```
+
+A couple of details worth knowing:
+
+- **Single commit vs phase-by-phase:** the framework prescribes a
+  single commit for simplicity. If you want phase-by-phase attribution,
+  you can split into multiple commits within the same PR — but keep
+  the PR singular. Multi-PR bootstrap is rejected — see
+  CLAUDE.md "Quick Fix Protocol" + the trunk-based development rule.
+- **`Closes #N` is NOT applicable** — this is a Quick Fix PR with no
+  linked ticket. Don't add a `Closes #` line; the PR body's "Quick fix
+  — no linked ticket" sentence is the canonical marker.
+- **Don't move any board items.** There's no ticket to move. The
+  Quick Fix flow specifically says skip board moves (CLAUDE.md → Quick
+  Fix Workflow step 5).
+- **Branch protection (Step 3) means you cannot push directly to
+  `main`.** This step's PR is how the bootstrap output reaches `main`
+  — through the same review/merge gate every other change uses.
+
+After this lands, `main` has a clean baseline: bootstrap output in
+one PR, your first feature ticket starts from a tidy state, and
+`/work-ticket`'s pre-flight passes on the first try.
+
 ## Pre-Flight Checklist
 
 Before running this phase, ensure you have:

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -27,11 +27,24 @@ Before any work, verify the following. STOP and report if any check fails.
 - Bug fixes found during development (not from a ticket)
 - Content or copy updates (data files, presets, text changes)
 - Config tweaks (linter rules, CI fixes, dependency bumps)
+- **Bootstrap-pipeline output PR #1** — after running `/research` →
+  `/jtbd` → `/positioning` → `/bootstrap-product` → `/bootstrap-architecture` →
+  `/bootstrap-agents` → `/bootstrap-workflow`, the accumulated config
+  + docs land as a single Quick Fix PR. See
+  `bootstrap-workflow.md` Step 7 for the exact `git`/`gh` sequence.
+- Session journal commits — same Quick Fix shape, no linked ticket
 - Any change the user explicitly requests without a ticket
 
 **Do NOT use this for feature work.** If the change introduces new behavior,
 touches more than 3 files, or takes longer than ~1 hour, create a ticket with
 `/create-ticket` and use `/work-ticket` instead.
+
+> **Note on the bootstrap exception:** the bootstrap-output PR routinely
+> touches 10+ files (research artifacts, PRD, roadmap, architecture,
+> agent specs, CLAUDE.md). That breaks the "≤3 files" guideline above
+> on purpose — bootstrap is a one-shot project-creation event, not
+> ongoing feature work. The "≤3 files" rule still holds for normal
+> Quick Fixes.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

Closes #161. Part of #157 (local-dev story epic).

The `/bootstrap-*` pipeline writes 12+ files but doesn't commit them. Each fork independently invents "PR #1 = bootstrap output" via Quick Fix Protocol. Both the 2026-05-03 reviewer-fork and 2026-05-04 worker-fork journals captured this friction; the worker fork explicitly flagged "no clear inflection point for committing bootstrap artifacts" as one of the four day-1 face-rakes.

This PR makes the close-out explicit. The slash command's existing 6-step flow stays intact; Step 7 is the new finalizer.

### Changes

- **`.claude/commands/bootstrap-workflow.md` Step 7** — "Commit and ship the bootstrap output" with copy-pasteable `git checkout -b ... && git add ... && git commit ... && git push ... && gh pr create ...` sequence. Three gotchas called out from real sessions:
  - Single commit vs phase-by-phase split (single is prescribed; multi-PR rejected)
  - `Closes #N` NOT applicable (no linked ticket — Quick Fix shape)
  - Don't move any board items (Quick Fix step 5)
  - Branch protection (Step 3) blocks direct push to `main`, so this PR is the gate the bootstrap output reaches `main` through
- **`.claude/commands/quick-fix.md`** — adds bootstrap-pipeline output as a canonical Quick Fix use case in the "When to Use" list, with an explicit note that the ≤3-files heuristic doesn't apply (one-shot project-creation event, not ongoing work)

### What's NOT changed

- No automation: the slash command does NOT run `git commit` itself, per the ticket guardrail "user-controls-git-state principle"
- No restructure of the existing 6 steps; Step 7 is a close-out, not a new phase
- No script changes; doc-only

## Test plan

- [ ] Read `bootstrap-workflow.md` Step 7 — confirm the `git`/`gh` sequence is correct, idempotent on re-run, and uses Quick Fix flow correctly
- [ ] Read `quick-fix.md`'s new "When to Use" entry — confirm the ≤3-files exception is clear and bootstrap is appropriately scoped
- [ ] Verify cross-references resolve: bootstrap-workflow.md Step 7 → CLAUDE.md "Quick Fix Protocol"; quick-fix.md → bootstrap-workflow.md Step 7
- [ ] Mental walkthrough: a fresh-fork user runs the bootstrap pipeline, hits Step 7, follows the snippet — does the PR they end up with cleanly capture all bootstrap output? (Yes if the user's stack matches the framework's Python/FastAPI default; non-Python forks may need to adjust the `git add` line — worth a future enhancement)
- [ ] markdownlint clean (CI handles)
- [ ] lint-agent-policies still passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)