### PR TITLE
feat(upstream): add /pull-upstream slash command for workshop forks

### DIFF
--- a/.agile-flow-overrides
+++ b/.agile-flow-overrides
@@ -1,0 +1,29 @@
+# .agile-flow-overrides
+#
+# Files in syncDirectories that are intentionally customised for this fork.
+# pull-upstream.sh and template-sync.sh will never overwrite these.
+#
+# One path per line. Lines starting with # are comments.
+# Paths are relative to the repo root.
+
+# Agent prompts rewritten for GCP / FastAPI / Neon
+.claude/agents/github-ticket-worker.md
+.claude/agents/devops-engineer.md
+.claude/agents/system-architect.md
+
+# Commands with GCP-specific checks / instructions
+.claude/commands/doctor.md
+.claude/commands/bootstrap-architecture.md
+
+# GCP-specific scripts (these don't exist in upstream, but listed for clarity)
+scripts/provision-gcp-project.sh
+scripts/create-workshop-neon-projects.sh
+scripts/workshop-setup.sh
+scripts/workshop-teardown.sh
+scripts/provision-workshop-roster.sh
+scripts/diagnose-cloudrun.sh
+scripts/populate-claude-md.sh
+scripts/dev-branch.sh
+scripts/setup-labels.sh
+scripts/setup-repo-protection.sh
+scripts/setup-solo-mode.sh

--- a/.claude/commands/pull-upstream.md
+++ b/.claude/commands/pull-upstream.md
@@ -1,0 +1,98 @@
+---
+description: "Pull the latest framework updates from vibeacademy/agile-flow into this fork"
+---
+
+# /pull-upstream — Apply Upstream Framework Updates
+
+Pulls the latest agent prompts, commands, hooks, and skills from the upstream
+`vibeacademy/agile-flow` repo into this GCP fork. Safe to run mid-workshop.
+Only framework files are updated — your application code is never touched.
+
+## Instructions
+
+1. **Verify clean working tree** — run `git status --porcelain`.
+   If there are uncommitted changes, STOP and report:
+
+   ```
+   Your working tree has uncommitted changes. Please commit or stash them
+   before running /pull-upstream:
+     git stash
+     /pull-upstream
+   ```
+
+2. **Run the sync script**:
+
+   ```bash
+   bash scripts/pull-upstream.sh
+   ```
+
+3. **Parse the output** and report what happened. The script will print one of:
+
+   - **Already up to date** — no action needed.
+   - A list of `UPDATED` / `ADDED` file lines, followed by a commit
+     confirmation and a push reminder.
+   - **ERROR** — report the error message with the suggested fix.
+
+4. **If changes were applied**, push immediately so Codespace participants
+   get the update:
+
+   ```bash
+   git push origin HEAD
+   ```
+
+   Then report:
+
+   ```
+   Upstream sync complete. N file(s) updated and pushed.
+   Participants can pull the latest with:
+     git pull
+   ```
+
+5. **If already up to date**, report:
+
+   ```
+   Already up to date with upstream. No changes applied.
+   ```
+
+## Important
+
+- This command is designed for facilitators running it mid-workshop from a
+  Codespace. It commits and pushes automatically.
+- Files listed in `.agile-flow-overrides` are intentionally GCP-customised
+  and will never be overwritten.
+- Only files that exist in the upstream repo AND are in the syncDirectories
+  list (`.agile-flow-version`) are updated.
+- Application code, migrations, infrastructure files, and GCP-specific
+  scripts are never touched.
+
+### Output Format
+
+End your output with a Result Block:
+
+```
+---
+
+**Result:** Upstream sync complete
+Files updated: N
+Commit: <short SHA>
+Pushed: yes
+```
+
+Or if already up to date:
+
+```
+---
+
+**Result:** Already up to date
+No changes applied.
+```
+
+Or if an error occurred:
+
+```
+---
+
+**Result:** Sync failed
+Error: <message>
+Fix: <suggested action>
+```

--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -34,10 +34,12 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --cached --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
+          # Script commits if it applied updates; check log vs HEAD~1
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$COMMIT_MSG" | grep -q "^chore(upstream): sync framework files"; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Push directly to main
@@ -62,20 +64,9 @@ jobs:
           BRANCH="upstream-sync/$(date -u +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git push origin "$BRANCH"
-          gh pr create \
-            --title "chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}" \
-            --body "## Upstream Framework Sync
-
-Applies the latest agent prompts, commands, hooks, and skills from
-[vibeacademy/agile-flow](https://github.com/vibeacademy/agile-flow).
-
-GCP-specific overrides listed in \`.agile-flow-overrides\` were not modified.
-
----
-> Triggered via the **Pull Upstream** workflow (\`workflow_dispatch\`).
-> Review and merge when ready." \
-            --base main \
-            --head "$BRANCH"
+          PR_TITLE="chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}"
+          PR_BODY="Upstream sync from agile-flow@${UPSTREAM_SHA:0:7}. GCP-specific overrides in .agile-flow-overrides were preserved. Triggered via the Pull Upstream workflow (workflow_dispatch). Review and merge when ready."
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH"
 
       - name: Report no changes
         if: steps.changes.outputs.has_changes == 'false'

--- a/.github/workflows/pull-upstream.yml
+++ b/.github/workflows/pull-upstream.yml
@@ -1,0 +1,82 @@
+name: Pull Upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      push_changes:
+        description: "Push changes directly to main (true) or open a PR (false)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pull-upstream:
+    name: Apply upstream agile-flow framework changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run pull-upstream script
+        id: sync
+        run: bash scripts/pull-upstream.sh
+        continue-on-error: true
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push directly to main
+        if: >
+          steps.changes.outputs.has_changes == 'true' &&
+          inputs.push_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push origin HEAD:main
+
+      - name: Open pull request
+        if: >
+          steps.changes.outputs.has_changes == 'true' &&
+          inputs.push_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UPSTREAM_SHA=$(git rev-parse upstream/main 2>/dev/null || echo "unknown")
+          BRANCH="upstream-sync/$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}" \
+            --body "## Upstream Framework Sync
+
+Applies the latest agent prompts, commands, hooks, and skills from
+[vibeacademy/agile-flow](https://github.com/vibeacademy/agile-flow).
+
+GCP-specific overrides listed in \`.agile-flow-overrides\` were not modified.
+
+---
+> Triggered via the **Pull Upstream** workflow (\`workflow_dispatch\`).
+> Review and merge when ready." \
+            --base main \
+            --head "$BRANCH"
+
+      - name: Report no changes
+        if: steps.changes.outputs.has_changes == 'false'
+        run: echo "Already up to date with upstream. No changes applied."

--- a/docs/FACILITATOR-RUNBOOK.md
+++ b/docs/FACILITATOR-RUNBOOK.md
@@ -1,0 +1,137 @@
+# Workshop Facilitator Runbook
+
+Operational procedures for facilitators running live Agile Flow workshops
+on the GCP edition.
+
+---
+
+## Applying Upstream Framework Updates Mid-Workshop
+
+If the upstream `vibeacademy/agile-flow` repo ships a fix or improvement
+during an active workshop, you can pull it into the GCP fork immediately
+without manual git surgery.
+
+### Prerequisites
+
+- You are running from a participant's Codespace (or your own).
+- The Codespace has network access to GitHub (default: yes).
+- The working tree has no uncommitted changes.
+
+### Option A — Claude Code slash command (recommended)
+
+Open Claude Code in the Codespace and run:
+
+```
+/pull-upstream
+```
+
+Claude will run `scripts/pull-upstream.sh`, report what changed, and push
+the update to `origin`. Participants then pull:
+
+```bash
+git pull
+```
+
+### Option B — Shell script directly
+
+```bash
+bash scripts/pull-upstream.sh
+git push origin HEAD
+```
+
+The script:
+
+1. Adds `vibeacademy/agile-flow` as the `upstream` remote (idempotent).
+2. Fetches `upstream/main`.
+3. For every file in `syncDirectories` (`.agile-flow-version`) that exists
+   in upstream, compares blob hashes.
+4. Applies the upstream version for any file that differs.
+5. Skips files listed in `.agile-flow-overrides` (intentional GCP overrides).
+6. Commits the result.
+
+### Option C — GitHub Actions (no Codespace required)
+
+Trigger the workflow from the GitHub UI:
+
+1. Go to **Actions → Pull Upstream → Run workflow**.
+2. Choose `push_changes`:
+   - `false` (default) — opens a PR for review before merging.
+   - `true` — pushes directly to `main`.
+3. Participants pull after the workflow completes:
+   ```bash
+   git pull
+   ```
+
+---
+
+## What Gets Updated
+
+Only files that are:
+- Listed in `syncDirectories` in `.agile-flow-version`, AND
+- Present in the upstream repo, AND
+- **Not** listed in `.agile-flow-overrides`
+
+are ever modified. Application code (`app/`, `alembic/`, `templates/`,
+`static/`), infrastructure files (`Dockerfile`, `.github/workflows/deploy.yml`),
+and GCP-specific scripts are never touched.
+
+### GCP-override files (never overwritten)
+
+| File | Reason |
+|------|--------|
+| `.claude/agents/github-ticket-worker.md` | FastAPI / SQLModel / Neon guardrails |
+| `.claude/agents/devops-engineer.md` | GCP-only operations |
+| `.claude/agents/system-architect.md` | GCP platform ecosystems |
+| `.claude/commands/doctor.md` | GCP / Neon secret checks |
+| `.claude/commands/bootstrap-architecture.md` | Hardcoded to Cloud Run |
+
+---
+
+## Conflict Handling
+
+The script prefers **upstream** for all tracked files. There are no 3-way
+merges — it takes the upstream blob directly. Files in `.agile-flow-overrides`
+are protected and never touched, so true conflicts are prevented by design.
+
+If a conflict cannot be resolved automatically (e.g. a tracked file was
+hand-edited locally), the script will abort with a clear error. Fix:
+
+```bash
+git diff HEAD <file>          # See what changed locally
+git checkout HEAD -- <file>   # Discard local change
+bash scripts/pull-upstream.sh # Re-run
+```
+
+---
+
+## Troubleshooting
+
+### "Working tree has uncommitted changes"
+
+```bash
+git stash
+bash scripts/pull-upstream.sh
+git push origin HEAD
+git stash pop   # restore local work if needed
+```
+
+### "Could not fetch from upstream"
+
+Check network connectivity from the Codespace:
+
+```bash
+curl -sf https://api.github.com/repos/vibeacademy/agile-flow/commits/main | jq .sha
+```
+
+If the API is unreachable, use the GitHub Actions option (runs from GitHub's
+network) or wait for connectivity to be restored.
+
+### "Nothing changed but I expected updates"
+
+Verify the upstream has newer commits than the files you're tracking:
+
+```bash
+git remote get-url upstream 2>/dev/null || echo "No upstream remote yet"
+git fetch upstream main
+git log --oneline upstream/main -- .claude/commands/ | head -5
+```

--- a/scripts/pull-upstream.sh
+++ b/scripts/pull-upstream.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# pull-upstream.sh — Apply latest framework changes from vibeacademy/agile-flow.
+#
+# Safe to run mid-workshop from a Codespace. Only updates files that exist in
+# the upstream repo AND are in the syncDirectories list. Files listed in
+# .agile-flow-overrides are never touched.
+#
+# Usage:
+#   bash scripts/pull-upstream.sh
+#
+# Exit codes:
+#   0  — success (up to date or changes applied)
+#   1  — error (clean tree required, gh auth required, fetch failure)
+
+set -euo pipefail
+
+UPSTREAM_REPO="https://github.com/vibeacademy/agile-flow.git"
+UPSTREAM_REMOTE="upstream"
+VERSION_FILE=".agile-flow-version"
+OVERRIDES_FILE=".agile-flow-overrides"
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+
+# 1. Clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: Working tree has uncommitted changes." >&2
+  echo "Stash or commit them first:" >&2
+  echo "  git stash" >&2
+  echo "  /pull-upstream" >&2
+  exit 1
+fi
+
+# 2. Version file
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "ERROR: $VERSION_FILE not found. Is this an Agile Flow fork?" >&2
+  exit 1
+fi
+
+# ── Read config ───────────────────────────────────────────────────────────────
+
+SYNC_DIRS=$(python3 -c "
+import json
+dirs = json.load(open('$VERSION_FILE')).get('syncDirectories', [])
+print('\n'.join(dirs))
+")
+
+# Load overrides (one path per line; lines starting with # are comments)
+declare -A OVERRIDE_MAP
+if [ -f "$OVERRIDES_FILE" ]; then
+  while IFS= read -r line; do
+    [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+    OVERRIDE_MAP["$line"]=1
+  done < "$OVERRIDES_FILE"
+fi
+
+OVERRIDE_COUNT="${#OVERRIDE_MAP[@]}"
+echo "Sync directories : $(echo "$SYNC_DIRS" | tr '\n' ' ')"
+echo "Protected overrides: $OVERRIDE_COUNT file(s)"
+
+# ── Add / fetch upstream remote ───────────────────────────────────────────────
+
+if ! git remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1; then
+  echo "Adding upstream remote..."
+  git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_REPO"
+fi
+
+echo "Fetching from upstream..."
+if ! git fetch "$UPSTREAM_REMOTE" main --quiet 2>&1; then
+  echo "ERROR: Could not fetch from upstream ($UPSTREAM_REPO)." >&2
+  echo "Check your network connection and try again." >&2
+  exit 1
+fi
+
+UPSTREAM_SHA=$(git rev-parse "$UPSTREAM_REMOTE/main")
+echo "Upstream HEAD    : ${UPSTREAM_SHA:0:12}"
+
+# ── Apply upstream files ──────────────────────────────────────────────────────
+
+FILES_UPDATED=()
+FILES_SKIPPED_OVERRIDE=()
+FILES_ALREADY_CURRENT=0
+
+while IFS= read -r sync_dir; do
+  [ -z "$sync_dir" ] && continue
+
+  # List every file that exists in this directory on upstream/main
+  while IFS= read -r filepath; do
+    [ -z "$filepath" ] && continue
+
+    # Skip if this file is a local override
+    if [[ -n "${OVERRIDE_MAP[$filepath]+_}" ]]; then
+      FILES_SKIPPED_OVERRIDE+=("$filepath")
+      continue
+    fi
+
+    # Get upstream content (as blob hash for fast comparison)
+    upstream_blob=$(git ls-tree "$UPSTREAM_REMOTE/main" "$filepath" 2>/dev/null | awk '{print $3}')
+    if [ -z "$upstream_blob" ]; then
+      continue
+    fi
+
+    # Compare blob hash with local HEAD
+    local_blob=$(git ls-tree HEAD "$filepath" 2>/dev/null | awk '{print $3}')
+
+    if [ "$upstream_blob" = "$local_blob" ]; then
+      FILES_ALREADY_CURRENT=$((FILES_ALREADY_CURRENT + 1))
+      continue
+    fi
+
+    # File differs — apply upstream version
+    mkdir -p "$(dirname "$filepath")"
+    git show "$UPSTREAM_REMOTE/main:$filepath" > "$filepath"
+    git add "$filepath"
+    FILES_UPDATED+=("$filepath")
+
+    if [ -n "$local_blob" ]; then
+      echo "UPDATED : $filepath"
+    else
+      echo "ADDED   : $filepath"
+    fi
+
+  done < <(git ls-tree -r --name-only "$UPSTREAM_REMOTE/main" "$sync_dir" 2>/dev/null)
+
+done <<< "$SYNC_DIRS"
+
+# ── Summarise and commit ──────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "${#FILES_UPDATED[@]}" -eq 0 ]; then
+  echo "Already up to date with upstream."
+  echo "  Already current: $FILES_ALREADY_CURRENT file(s)"
+  if [ "${#FILES_SKIPPED_OVERRIDE[@]}" -gt 0 ]; then
+    echo "  Skipped (local overrides): ${#FILES_SKIPPED_OVERRIDE[@]} file(s)"
+  fi
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 0
+fi
+
+# Build commit body
+BODY=""
+for f in "${FILES_UPDATED[@]}"; do
+  BODY+="- $f"$'\n'
+done
+
+git -c user.name="pull-upstream" \
+    -c user.email="noreply@github.com" \
+    commit -m "chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}
+
+${BODY}"
+
+echo "Applied ${#FILES_UPDATED[@]} upstream change(s) — committed."
+echo ""
+echo "Updated files:"
+for f in "${FILES_UPDATED[@]}"; do
+  echo "  - $f"
+done
+
+if [ "${#FILES_SKIPPED_OVERRIDE[@]}" -gt 0 ]; then
+  echo ""
+  echo "Skipped (local overrides — intentionally GCP-customised):"
+  for f in "${FILES_SKIPPED_OVERRIDE[@]}"; do
+    echo "  - $f"
+  done
+fi
+
+echo ""
+echo "Next step: push to origin so Codespace participants get the update"
+echo "  git push origin HEAD"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

Implements [VIB-2](/VIB/issues/VIB-2): a `/pull-upstream` slash command that lets facilitators apply the latest framework updates from `vibeacademy/agile-flow` mid-workshop, without manual git surgery.

- **`scripts/pull-upstream.sh`** — core script: adds upstream remote, fetches `main`, compares blob hashes for every file in `syncDirectories`, applies upstream for diffs, skips GCP overrides, auto-commits
- **`.claude/commands/pull-upstream.md`** — Claude Code slash command that drives the script and reports results
- **`.agile-flow-overrides`** — machine-readable list of GCP-customised files that are never overwritten
- **`.github/workflows/pull-upstream.yml`** — optional `workflow_dispatch` path (opens PR or pushes direct to main)
- **`docs/FACILITATOR-RUNBOOK.md`** — facilitator operational guide covering all three invocation paths and troubleshooting

## How it works

1. Facilitator runs `/pull-upstream` in a participant's Codespace
2. Script fetches `upstream/main`, diffs blob hashes against local HEAD for every tracked file
3. Applies upstream content for any file that differs (prefers upstream on conflict by design)
4. Skips `.agile-flow-overrides` entries (GCP-specific agent prompts / commands)
5. Auto-commits; facilitator pushes; participants `git pull`

## Test plan

- [ ] Run `bash scripts/pull-upstream.sh` from a clean clone — should report "already up to date"
- [ ] Manually revert a tracked file (e.g. `.claude/agents/agile-product-manager.md`) and re-run — should show `UPDATED` and commit
- [ ] Verify `.claude/commands/doctor.md` (listed in overrides) is never overwritten
- [ ] Trigger `pull-upstream` workflow from GitHub Actions UI with `push_changes=false` — verify PR is created
- [ ] Run `/pull-upstream` via Claude Code in a Codespace — verify clean output and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)