### PR TITLE
fix(workshop-setup): accept 7-column rosters in pre-flight check

### DIFF
--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -90,16 +90,19 @@ else
   expected_header_4="handle,github_user,email,cohort"
   expected_header_5="handle,github_user,email,cohort,neon_branch"
   expected_header_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
+  expected_header_7="handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id"
   actual_header="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
   if [[ "$actual_header" == "$expected_header_4" \
      || "$actual_header" == "$expected_header_5" \
-     || "$actual_header" == "$expected_header_6" ]]; then
+     || "$actual_header" == "$expected_header_6" \
+     || "$actual_header" == "$expected_header_7" ]]; then
     echo "  [ok]   roster header is valid"
   else
     echo "  [fail] roster header must be one of:" >&2
     echo "           $expected_header_4" >&2
     echo "           $expected_header_5" >&2
     echo "           $expected_header_6" >&2
+    echo "           $expected_header_7" >&2
     echo "         got: $actual_header" >&2
     fail=1
   fi

--- a/scripts/workshop-setup.test.sh
+++ b/scripts/workshop-setup.test.sh
@@ -261,6 +261,27 @@ ec=$?
 assert_eq "0" "$ec" "exit 0 with 6-column header"
 assert_contains "ok.*roster header is valid" "$T8/stdout.log" "logs header ok"
 
+# ── Test 9: 7-column header is accepted by pre-flight ───────────────────
+
+echo ""
+echo "Test 9: 7-column roster header passes pre-flight"
+
+T9=$(new_tmp)
+make_stubs "$T9" "ok"
+cat > "$T9/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@acme.com,2026-05,alice,acme/agile-flow-alice,np-alice-123
+EOF
+
+PATH="$T9/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  ROSTER_WRAPPER="$T9/bin/roster-wrapper.sh" \
+  "$SCRIPT" "$T9/roster.csv" > "$T9/stdout.log" 2>&1
+ec=$?
+
+assert_eq "0" "$ec" "exit 0 with 7-column header"
+assert_contains "ok.*roster header is valid" "$T9/stdout.log" "logs header ok"
+
 # ── Summary ─────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #168

- Added `expected_header_7` to `workshop-setup.sh` pre-flight check so 7-column rosters (`neon_project_id` column) pass validation
- Updated error message to list all 4 valid header formats
- Added Test 9 to `workshop-setup.test.sh` covering the 7-column happy path

## Root Cause

`workshop-setup.sh` validated only 4/5/6-column roster headers. The 7-column format (used when per-attendee Neon projects are in play) was silently rejected, forcing facilitators to bypass the pre-flight entry point and call `provision-workshop-roster.sh` directly — skipping gcloud auth and billing account checks.

## Test Plan

- [x] All 9 existing+new workshop-setup tests pass (`bash scripts/workshop-setup.test.sh`)
- [x] Lint clean (`uv run ruff check .`)
- [x] Python tests pass (`uv run pytest`)
- [x] No regression in 4/5/6-column acceptance (Tests 1, 7, 8 still green)