### PR TITLE
fix(provisioning): hard-fail when neon_project_id missing and NEON_API_KEY set

### DIFF
--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -265,6 +265,34 @@ if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" \
   exit 2
 fi
 
+# ── Neon pre-flight: hard-fail before any GCP work if neon_project_id missing ──
+#
+# Enforce when the facilitator clearly intends Neon: NEON_API_KEY is set.
+# In that case every 7-column row must have a non-empty neon_project_id so
+# Step 5.7 can create the per-attendee branch secret. A missing ID means
+# create-workshop-neon-projects.sh was not run yet; failing here (before any
+# GCP projects are created) avoids half-provisioned classrooms that look green
+# but fail on the first PR deploy. (Surfaced: 2026-05-05 dry run.)
+#
+# 4/5/6-column rosters are skipped by the check — they have no neon_project_id
+# column and handle the missing-Neon case elsewhere.
+
+if [[ -n "${NEON_API_KEY:-}" && "$ACTUAL_HEADER" == "$EXPECTED_HEADER_7" ]]; then
+  neon_check_row=0
+  while IFS=',' read -r _h _gu _em _co _nb _gfr _npid; do
+    _h="$(echo "$_h" | tr -d '[:space:]\r')"
+    _npid="$(echo "${_npid:-}" | tr -d '[:space:]\r')"
+    [[ -z "$_h" ]] && continue
+    neon_check_row=$((neon_check_row + 1))
+    if [[ -z "$_npid" ]]; then
+      echo "[fail] Row $neon_check_row (handle=$_h) has empty neon_project_id but NEON_API_KEY is set." >&2
+      echo "       Run scripts/create-workshop-neon-projects.sh $ROSTER_CSV first to" >&2
+      echo "       create per-attendee Neon projects, then re-run this script." >&2
+      exit 2
+    fi
+  done < <(tail -n +2 "$ROSTER_CSV")
+fi
+
 # ── Output CSV setup ─────────────────────────────────────────────────────
 
 if [[ ! -f "$OUTPUT_CSV" ]]; then

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -1009,6 +1009,73 @@ else
   PASS=$((PASS + 1))
 fi
 
+# ── Test 24: hard-fail when neon_project_id missing and NEON_API_KEY set ──
+#
+# #167: facilitator forgot to run create-workshop-neon-projects.sh first.
+# The wrapper must exit 2 BEFORE creating any GCP projects, with a message
+# pointing to the fix. Verified: no provision-gcp-project.sh is called.
+
+echo ""
+echo "Test 24: hard-fail when 7-column roster has empty neon_project_id and NEON_API_KEY set"
+
+T24=$(new_tmp)
+make_stubs "$T24" "ok"
+cat > "$T24/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,
+bob,bob-gh,bob@x.com,2026-05,bob,vibeacademy/bob,proj-bob-bbb
+EOF
+
+set +e
+PATH="$T24/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  NEON_API_KEY="neon-fake-key" \
+  PROVISION_SCRIPT="$T24/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T24/roster-output.csv" \
+  "$WRAPPER" "$T24/roster.csv" > "$T24/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "2" "$exit_code" "exits 2 on empty neon_project_id with NEON_API_KEY set"
+assert_contains "empty neon_project_id" "$T24/stdout.log" "error message mentions empty neon_project_id"
+assert_contains "create-workshop-neon-projects.sh" "$T24/stdout.log" "error message points to fix"
+# Must not have called the provisioner (no GCP project creation)
+if [[ ! -f "$T24/provision.log" ]]; then
+  echo -e "  ${GREEN}✓${NC} no GCP provisioning attempted before failing"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}✗${NC} provisioner was called despite pre-flight failure"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Test 25: legitimate skip — no NEON_API_KEY, no neon_project_id ────────
+#
+# #167: a cohort not using Neon at all. The 7-column roster has empty
+# neon_project_id, but NEON_API_KEY is unset, so the pre-flight should
+# pass silently and provisioning should succeed.
+
+echo ""
+echo "Test 25: no NEON_API_KEY set — empty neon_project_id is a legitimate skip"
+
+T25=$(new_tmp)
+make_stubs "$T25" "ok"
+cat > "$T25/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,
+EOF
+
+set +e
+PATH="$T25/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T25/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T25/roster-output.csv" \
+  "$WRAPPER" "$T25/roster.csv" > "$T25/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "exits 0 when NEON_API_KEY unset (no Neon intent)"
+assert_contains "af-alice-2026-05" "$T25/stdout.log" "provisioning proceeds for alice"
+
 echo ""
 echo "─────────────────────────────────"
 echo "  Passed: $PASS"


### PR DESCRIPTION
## Summary

Fixes #167

- Added pre-loop validation in `provision-workshop-roster.sh` that exits 2 before any GCP work when `NEON_API_KEY` is set and any 7-column roster row has an empty `neon_project_id`
- Error message is actionable: names the missing prerequisite (`scripts/create-workshop-neon-projects.sh`) and the exact step to fix it
- Added Test 24 (hard-fail path) and Test 25 (legitimate skip — no `NEON_API_KEY`) to `provision-workshop-roster.test.sh`

## Root Cause

During the 2026-05-05 dry run, a facilitator ran `provision-workshop-roster.sh` directly with a 7-column roster but without first running `create-workshop-neon-projects.sh`. The script silently skipped Step 5.7 (Neon branch + Secret Manager secret) and reported success. The provisioned projects failed on their first PR deploy because Cloud Run could not resolve the `database-url` secret.

## Behavior

| Condition | Before | After |
|---|---|---|
| 7-col roster + empty `neon_project_id` + `NEON_API_KEY` set | Silent skip, green output, broken deploy | `exit 2` before any GCP project created |
| 7-col roster + empty `neon_project_id` + no `NEON_API_KEY` | Silent skip (legitimate) | Still skips (no Neon intent, legitimate) |
| 4/5/6-col roster (no `neon_project_id` column) | Unaffected | Unaffected |

## Test Plan

- [x] Test 24: hard-fail path exits 2, error message actionable, no GCP projects created
- [x] Test 25: legitimate skip when `NEON_API_KEY` unset passes through
- [x] All 84 tests pass (`bash scripts/provision-workshop-roster.test.sh`)
- [x] Lint clean and Python tests pass