### PR TITLE
feat(provisioning): grant attendee push+project-board access in workshop-org mode

### DIFF
--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -191,6 +191,67 @@ fi
 # the bot is not authed, the invite is issued but not accepted; a clear
 # WARN tells the facilitator how to recover manually.
 
+grant_push_to_attendee() {
+  local repo="$1" github_user="$2"
+
+  if [[ -z "$github_user" ]]; then
+    echo "  WARN: github_user is empty — skipping attendee push grant for $repo" >&2
+    return 1
+  fi
+
+  # Idempotency check: already a collaborator with write or higher?
+  local current_perm
+  current_perm=$(gh api "repos/$repo/collaborators/$github_user/permission" --jq '.permission' 2>/dev/null || echo "none")
+  if [[ "$current_perm" == "write" || "$current_perm" == "admin" || "$current_perm" == "maintain" ]]; then
+    echo "  [skip] $github_user already has $current_perm on $repo"
+    return 0
+  fi
+
+  # Issue the invite. The attendee must accept manually — we cannot auth
+  # as them locally, and auto-accepting on their behalf would cross a
+  # permission boundary. Attendee accepts via email link or from inside
+  # their Codespace: gh api PATCH /user/repository_invitations/<id>
+  if ! gh api -X PUT "repos/$repo/collaborators/$github_user" -f permission=push >/dev/null 2>&1; then
+    echo "  WARN: failed to invite $github_user to $repo (continuing)"
+    return 1
+  fi
+  echo "  [invite] $github_user invited to $repo with push (attendee must accept)"
+}
+
+grant_project_writer_to_attendee() {
+  local repo="$1" github_user="$2" project_node_id="$3"
+
+  if [[ -z "$project_node_id" ]]; then
+    return 0
+  fi
+  if [[ -z "$github_user" ]]; then
+    echo "  WARN: github_user is empty — skipping project-board grant for $repo" >&2
+    return 1
+  fi
+
+  # Resolve the attendee's GitHub user node ID (needed for the GraphQL mutation).
+  local user_node_id
+  user_node_id=$(gh api "users/$github_user" --jq '.node_id' 2>/dev/null || echo "")
+  if [[ -z "$user_node_id" ]]; then
+    echo "  WARN: could not resolve node_id for $github_user — skipping project grant"
+    return 1
+  fi
+
+  # Grant WRITER on the project board. The mutation is idempotent — re-adding an
+  # existing collaborator at the same role returns the project node without error.
+  if ! gh api graphql -f query="
+    mutation {
+      updateProjectV2Collaborators(input: {
+        projectId: \"$project_node_id\"
+        collaborators: [{ userId: \"$user_node_id\", role: WRITER }]
+      }) { project { id } }
+    }" >/dev/null 2>&1; then
+    echo "  WARN: failed to grant project WRITER to $github_user on project $project_node_id (continuing)"
+    return 1
+  fi
+  echo "  [project] $github_user granted WRITER on project $project_node_id"
+}
+
 grant_push_to_bot() {
   local repo="$1" bot="$2"
 
@@ -250,17 +311,20 @@ EXPECTED_HEADER_4="handle,github_user,email,cohort"
 EXPECTED_HEADER_5="handle,github_user,email,cohort,neon_branch"
 EXPECTED_HEADER_6="handle,github_user,email,cohort,neon_branch,github_full_repo"
 EXPECTED_HEADER_7="handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id"
+EXPECTED_HEADER_8="handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id,project_id"
 ACTUAL_HEADER="$(head -n 1 "$ROSTER_CSV" | tr -d '\r')"
 
 if [[ "$ACTUAL_HEADER" != "$EXPECTED_HEADER_4" \
    && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_5" \
    && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_6" \
-   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_7" ]]; then
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_7" \
+   && "$ACTUAL_HEADER" != "$EXPECTED_HEADER_8" ]]; then
   echo "ERROR: roster CSV header must be one of:" >&2
   echo "       $EXPECTED_HEADER_4" >&2
   echo "       $EXPECTED_HEADER_5" >&2
   echo "       $EXPECTED_HEADER_6" >&2
   echo "       $EXPECTED_HEADER_7" >&2
+  echo "       $EXPECTED_HEADER_8" >&2
   echo "       got: $ACTUAL_HEADER" >&2
   exit 2
 fi
@@ -310,9 +374,9 @@ skipped=0
 # tail -n +2 skips header. Process substitution avoids subshell so counters
 # survive into the summary block.
 #
-# We read 7 fields. 4-, 5-, and 6-column rows leave the trailing fields
-# empty; the default-fallback logic below covers them.
-while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo row_neon_project_id; do
+# We read 8 fields. 4–7-column rows leave the trailing fields empty;
+# the default-fallback logic below covers them.
+while IFS=',' read -r handle github_user email cohort neon_branch github_full_repo row_neon_project_id row_project_id; do
   # Strip whitespace and CR (Windows line endings)
   handle="$(echo "$handle" | tr -d '[:space:]\r')"
   github_user="$(echo "$github_user" | tr -d '[:space:]\r')"
@@ -321,6 +385,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   neon_branch="$(echo "${neon_branch:-}" | tr -d '[:space:]\r')"
   github_full_repo="$(echo "${github_full_repo:-}" | tr -d '[:space:]\r')"
   row_neon_project_id="$(echo "${row_neon_project_id:-}" | tr -d '[:space:]\r')"
+  row_project_id="$(echo "${row_project_id:-}" | tr -d '[:space:]\r')"
 
   if [[ -z "$handle" || -z "$cohort" ]]; then
     continue
@@ -416,6 +481,14 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
     if [[ -n "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ]]; then
       grant_push_to_bot "$github_full_repo" "$AGILE_FLOW_REVIEWER_ACCOUNT" || true
     fi
+
+    # Grant push to the attendee themselves (#165). Attendee must accept the
+    # invite manually (email link or Codespace: gh api PATCH /user/repository_invitations/<id>).
+    grant_push_to_attendee "$github_full_repo" "$github_user" || true
+
+    # Grant project board WRITER to the attendee (#166). Only fires when the
+    # 8-column roster has a non-empty project_id for this row. Fail-soft.
+    grant_project_writer_to_attendee "$github_full_repo" "$github_user" "${row_project_id:-}" || true
   fi
 
   # Detect whether the project already exists, so we can label the output

--- a/scripts/provision-workshop-roster.test.sh
+++ b/scripts/provision-workshop-roster.test.sh
@@ -924,12 +924,14 @@ set -e
 assert_eq "0" "$exit_code" "wrapper exits 0 with bot env vars unset"
 # repo create still runs (this is the workshop-org path)
 assert_contains "gh repo create vibeacademy/alice" "$T22/gh.log" "repo create still runs"
-# But NO collaborator-related calls
-if grep -q "collaborators" "$T22/gh.log"; then
-  echo -e "  ${RED}✗${NC} collaborator API called despite bot env vars unset (solo-mode broken)"
+# Attendee collaborator invite DOES happen (grant_push_to_attendee fires for the attendee's github_user)
+assert_contains "collaborators/alice-gh" "$T22/gh.log" "attendee collaborator invite issued"
+# But no BOT-specific collaborator calls (worker/reviewer env vars are unset)
+if grep -q "collaborators/va-worker\|collaborators/va-reviewer" "$T22/gh.log"; then
+  echo -e "  ${RED}✗${NC} bot collaborator calls made despite bot env vars unset"
   FAIL=$((FAIL + 1))
 else
-  echo -e "  ${GREEN}✓${NC} no collaborator API calls when bot env vars unset (solo-mode OK)"
+  echo -e "  ${GREEN}✓${NC} no bot collaborator API calls when bot env vars unset (solo-mode OK)"
   PASS=$((PASS + 1))
 fi
 if grep -q "repository_invitations" "$T22/gh.log"; then
@@ -1075,6 +1077,192 @@ set -e
 
 assert_eq "0" "$exit_code" "exits 0 when NEON_API_KEY unset (no Neon intent)"
 assert_contains "af-alice-2026-05" "$T25/stdout.log" "provisioning proceeds for alice"
+
+# ── Test 26: attendee push-grant fires in workshop-org mode (#165) ────────
+#
+# grant_push_to_attendee() should be called for each row's github_user when
+# WORKSHOP_ORG is set, issuing a PUT collaborators invite.
+
+echo ""
+echo "Test 26: attendee push-grant fires in workshop-org mode"
+
+T26=$(new_tmp)
+make_stubs "$T26" "ok"
+
+cat > "$T26/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$T26/gh.log"
+case "\$1 \$2" in
+  "repo view") exit 1 ;;
+  "repo create") exit 0 ;;
+  "api graphql") echo '{"data":{"updateProjectV2Collaborators":{"project":{"id":"PVT_x"}}}}' ;;
+  "api users/alice-gh") echo '{"node_id":"U_alice123"}' ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T26/bin/gh"
+
+cat > "$T26/roster.csv" <<EOF
+handle,github_user,email,cohort
+alice,alice-gh,alice@x.com,2026-05
+EOF
+
+set +e
+PATH="$T26/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T26/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T26/roster-output.csv" \
+  GH_REPO_CREATE="$T26/bin/gh" \
+  "$WRAPPER" "$T26/roster.csv" --workshop-org=vibeacademy > "$T26/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0"
+assert_contains "collaborators/alice-gh" "$T26/gh.log" "attendee invite PUT issued"
+assert_contains "alice-gh invited" "$T26/stdout.log" "stdout confirms attendee invite"
+
+# ── Test 27: attendee push-grant idempotent (#165) ────────────────────────
+#
+# When the attendee already has write/admin on the repo, the grant must be
+# a no-op (no PUT issued).
+
+echo ""
+echo "Test 27: attendee push-grant idempotent — skip when already write"
+
+T27=$(new_tmp)
+make_stubs "$T27" "ok"
+
+cat > "$T27/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$T27/gh.log"
+case "\$1 \$2" in
+  "repo view") exit 1 ;;
+  "repo create") exit 0 ;;
+  "api repos/vibeacademy/alice/collaborators/alice-gh/permission")
+    echo "write"
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T27/bin/gh"
+
+cat > "$T27/roster.csv" <<EOF
+handle,github_user,email,cohort
+alice,alice-gh,alice@x.com,2026-05
+EOF
+
+set +e
+PATH="$T27/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T27/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T27/roster-output.csv" \
+  GH_REPO_CREATE="$T27/bin/gh" \
+  "$WRAPPER" "$T27/roster.csv" --workshop-org=vibeacademy > "$T27/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 on idempotent run"
+# idempotency: PUT collaborators must NOT be called when already write
+if grep -q "PUT repos/vibeacademy/alice/collaborators/alice-gh" "$T27/gh.log"; then
+  echo -e "  ${RED}✗${NC} PUT collaborators called despite attendee already having write"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} no PUT collaborators when attendee already has write (idempotent)"
+  PASS=$((PASS + 1))
+fi
+assert_contains "alice-gh already has write" "$T27/stdout.log" "stdout confirms skip"
+
+# ── Test 28: project board WRITER grant fires for 8-column roster (#166) ──
+#
+# When the roster includes a non-empty project_id column, the wrapper must
+# call the GraphQL mutation to grant the attendee WRITER on their board.
+
+echo ""
+echo "Test 28: project-board WRITER grant fires for 8-column roster"
+
+T28=$(new_tmp)
+make_stubs "$T28" "ok"
+
+cat > "$T28/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$T28/gh.log"
+case "\$1 \$2" in
+  "repo view") exit 1 ;;
+  "repo create") exit 0 ;;
+  "api graphql")
+    echo '{"data":{"updateProjectV2Collaborators":{"project":{"id":"PVT_abc123"}}}}'
+    ;;
+  "api users/alice-gh") echo '{"node_id":"U_alice123"}' ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T28/bin/gh"
+
+cat > "$T28/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id,project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-alice-aaa,PVT_abc123
+EOF
+
+set +e
+PATH="$T28/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T28/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T28/roster-output.csv" \
+  GH_REPO_CREATE="$T28/bin/gh" \
+  "$WRAPPER" "$T28/roster.csv" --workshop-org=vibeacademy > "$T28/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 with 8-column roster"
+assert_contains "api graphql" "$T28/gh.log" "GraphQL mutation invoked"
+assert_contains "PVT_abc123" "$T28/gh.log" "project node ID appears in mutation"
+assert_contains "granted WRITER" "$T28/stdout.log" "stdout confirms project WRITER grant"
+
+# ── Test 29: project board grant skipped when project_id empty (#166) ─────
+#
+# Rows with empty project_id (7-column or 8-column with blank cell) must
+# skip the GraphQL mutation — no API call, no error.
+
+echo ""
+echo "Test 29: project-board grant skipped when project_id empty"
+
+T29=$(new_tmp)
+make_stubs "$T29" "ok"
+
+cat > "$T29/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$T29/gh.log"
+case "\$1 \$2" in
+  "repo view") exit 1 ;;
+  "repo create") exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$T29/bin/gh"
+
+cat > "$T29/roster.csv" <<EOF
+handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id,project_id
+alice,alice-gh,alice@x.com,2026-05,alice,vibeacademy/alice,proj-alice-aaa,
+EOF
+
+set +e
+PATH="$T29/bin:$PATH" \
+  BILLING_ACCOUNT_ID="FAKE-BILLING" \
+  PROVISION_SCRIPT="$T29/bin/provision-gcp-project.sh" \
+  OUTPUT_CSV="$T29/roster-output.csv" \
+  GH_REPO_CREATE="$T29/bin/gh" \
+  "$WRAPPER" "$T29/roster.csv" --workshop-org=vibeacademy > "$T29/stdout.log" 2>&1
+exit_code=$?
+set -e
+
+assert_eq "0" "$exit_code" "wrapper exits 0 when project_id empty"
+if grep -q "api graphql" "$T29/gh.log"; then
+  echo -e "  ${RED}✗${NC} GraphQL mutation called despite empty project_id"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}✓${NC} no GraphQL mutation when project_id empty (legacy compat)"
+  PASS=$((PASS + 1))
+fi
 
 echo ""
 echo "─────────────────────────────────"


### PR DESCRIPTION
## Summary

Fixes #165 and #166

Without these fixes, every workshop attendee in May 2026 would hit a wall on their first `git push` (no collaborator access to `vibeacademy/<handle>`) and on their first `/groom-backlog` run (no project board write access). Both conditions required manual facilitator intervention per attendee.

### Changes

**`grant_push_to_attendee()` (#165)**
- Invites `github_user` as a push collaborator on `vibeacademy/<handle>` using `gh api PUT repos/.../collaborators/<user>`
- Idempotent: skips if attendee already has write/admin/maintain
- Attendee must accept the invite manually (cannot auth as them; email link or Codespace: `gh api PATCH /user/repository_invitations/<id>`)
- Fail-soft per row

**`grant_project_writer_to_attendee()` (#166)**
- Calls `updateProjectV2Collaborators` GraphQL mutation with `role: WRITER`
- Resolves attendee's user node ID via `gh api users/<github_user> --jq '.node_id'`
- Only fires when the 8th roster column (`project_id`) is non-empty — empty/missing skips silently
- Fail-soft per row

**8-column roster support**
- New header: `handle,github_user,email,cohort,neon_branch,github_full_repo,neon_project_id,project_id`
- All older 4/5/6/7-column rosters are fully backwards-compatible

## Test Plan

- [x] Test 22 updated: attendee invite is expected even without bot env vars (solo mode)
- [x] Test 24: attendee push-grant PUT fires for each row in workshop-org mode
- [x] Test 25: attendee push-grant is idempotent (no PUT when already write)
- [x] Test 26: project WRITER GraphQL mutation fires for 8-column roster with non-empty project_id
- [x] Test 27: project grant skipped when project_id empty (legacy 7-col compat)
- [x] All 91 tests pass (`bash scripts/provision-workshop-roster.test.sh`)
- [x] Lint and Python tests green