### PR TITLE
feat(setup-repo-protection): add --approvals N flag for workshop-mode protection

### DIFF
--- a/scripts/setup-repo-protection.sh
+++ b/scripts/setup-repo-protection.sh
@@ -76,6 +76,7 @@ print_info()    { echo -e "${BLUE}→ $1${NC}"; }
 REPO=""
 BRANCH="main"
 DRY_RUN=false
+APPROVALS=1
 
 show_help() {
     sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
@@ -88,14 +89,22 @@ while [ $# -gt 0 ]; do
         --branch)      BRANCH="$2"; shift 2 ;;
         --branch=*)    BRANCH="${1#--branch=}"; shift ;;
         --dry-run)     DRY_RUN=true; shift ;;
+        --approvals)   APPROVALS="$2"; shift 2 ;;
+        --approvals=*) APPROVALS="${1#--approvals=}"; shift ;;
         -h|--help)     show_help; exit 0 ;;
         *)
             print_error "Unknown argument: $1"
-            print_info "Usage: setup-repo-protection.sh [--repo owner/name] [--branch main] [--dry-run]"
+            print_info "Usage: setup-repo-protection.sh [--repo owner/name] [--branch main] [--dry-run] [--approvals N]"
             exit 1
             ;;
     esac
 done
+
+# Validate --approvals: must be an integer 0-6 (GitHub's allowed range).
+if ! [[ "$APPROVALS" =~ ^[0-6]$ ]]; then
+    print_error "--approvals must be an integer from 0 to 6 (got: $APPROVALS)"
+    exit 1
+fi
 
 # ───────────────────────────────────────────────────────────────────
 #  Pre-flight
@@ -141,14 +150,14 @@ fi
 #  Format reference:
 #  https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection
 # ───────────────────────────────────────────────────────────────────
-read -r -d '' PROTECTION_JSON <<'JSON' || true
+PROTECTION_JSON=$(cat <<JSON
 {
   "required_status_checks": null,
   "enforce_admins": false,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": false,
     "require_code_owner_reviews": false,
-    "required_approving_review_count": 1,
+    "required_approving_review_count": ${APPROVALS},
     "require_last_push_approval": false
   },
   "restrictions": null,
@@ -161,6 +170,7 @@ read -r -d '' PROTECTION_JSON <<'JSON' || true
   "allow_fork_syncing": false
 }
 JSON
+)
 
 # Notes on the chosen settings:
 #
@@ -198,7 +208,7 @@ if [ -n "$current" ]; then
     cur_force=$(echo "$current" | jq -r 'if .allow_force_pushes.enabled == null then "true" else (.allow_force_pushes.enabled | tostring) end')
     cur_delete=$(echo "$current" | jq -r 'if .allow_deletions.enabled == null then "true" else (.allow_deletions.enabled | tostring) end')
 
-    if [ "$cur_pr_reviews" = "1" ] \
+    if [ "$cur_pr_reviews" = "$APPROVALS" ] \
        && [ "$cur_linear" = "true" ] \
        && [ "$cur_force" = "false" ] \
        && [ "$cur_delete" = "false" ]; then
@@ -225,7 +235,7 @@ if echo "$PROTECTION_JSON" | gh api -X PUT \
     "repos/${REPO}/branches/${BRANCH}/protection" \
     --input - >/dev/null 2>&1; then
     print_success "Branch protection applied to ${REPO}:${BRANCH}"
-    print_info "  Reviews required:    1 approving review"
+    print_info "  Reviews required:    ${APPROVALS} approving review(s)"
     print_info "  Status checks:       not required (configure per-cohort)"
     print_info "  Linear history:      required"
     print_info "  Force-push:          blocked"

--- a/scripts/setup-repo-protection.test.sh
+++ b/scripts/setup-repo-protection.test.sh
@@ -390,6 +390,78 @@ set -e
 assert_eq "1" "$ec" "exit 1 on unknown flag"
 assert_contains "Unknown argument" "$T8/run.log" "names the issue"
 
+# ── Test 9: --approvals 0 applies workshop-mode protection ────────────
+
+echo ""
+echo "Test 9: --approvals 0 applies workshop-mode (0 required reviewers)"
+
+T9=$(new_sandbox)
+make_gh_stub "$T9"
+
+set +e
+env -i \
+    HOME="$T9" \
+    PATH="$T9/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T9" \
+    STUB_BRANCH_EXISTS=true \
+    STUB_PROTECTION_STATE=missing \
+    TERM="${TERM:-dumb}" \
+    bash "$SCRIPT" --repo test-org/test-repo --approvals 0 \
+    > "$T9/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 with --approvals 0"
+assert_contains "0 approving review(s)" "$T9/run.log" "success message shows 0 reviews"
+assert_contains "PUT" "$T9/gh.log" "PUT branch protection called"
+
+# ── Test 10: --approvals 1 (default) is unchanged ────────────────────
+
+echo ""
+echo "Test 10: --approvals 1 (default behavior preserved)"
+
+T10=$(new_sandbox)
+make_gh_stub "$T10"
+
+set +e
+env -i \
+    HOME="$T10" \
+    PATH="$T10/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T10" \
+    STUB_BRANCH_EXISTS=true \
+    STUB_PROTECTION_STATE=missing \
+    TERM="${TERM:-dumb}" \
+    bash "$SCRIPT" --repo test-org/test-repo --approvals 1 \
+    > "$T10/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "0" "$ec" "exit 0 with --approvals 1"
+assert_contains "1 approving review(s)" "$T10/run.log" "success message shows 1 review"
+assert_contains "PUT" "$T10/gh.log" "PUT branch protection called"
+
+# ── Test 11: --approvals with invalid value rejects ───────────────────
+
+echo ""
+echo "Test 11: --approvals 7 (out of range) → exit 1"
+
+T11=$(new_sandbox)
+make_gh_stub "$T11"
+
+set +e
+env -i \
+    HOME="$T11" \
+    PATH="$T11/bin:/usr/bin:/bin:/usr/local/bin" \
+    STUB_STATE="$T11" \
+    TERM="${TERM:-dumb}" \
+    bash "$SCRIPT" --repo test-org/test-repo --approvals 7 \
+    > "$T11/run.log" 2>&1
+ec=$?
+set -e
+
+assert_eq "1" "$ec" "exit 1 on --approvals 7"
+assert_contains "must be an integer from 0 to 6" "$T11/run.log" "actionable error message"
+
 # ── Summary ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #154

Adds `--approvals N` flag to `scripts/setup-repo-protection.sh`. Workshop facilitators can now run:
```
bash scripts/setup-repo-protection.sh --repo vibeacademy/<handle> --approvals 0
```
to set up protection without requiring a second human reviewer — keeping all other protections (PR required, linear history, no force-push/delete).

## Changes

- Added `APPROVALS=1` variable with `--approvals N` / `--approvals=N` flag parsing
- Validation: value must be integer 0–6 (GitHub's allowed range), otherwise exit 1
- Protection JSON now uses `${APPROVALS}` instead of hardcoded `1`
- Idempotency check compares against `$APPROVALS` (re-run with same value is a no-op)
- Success message shows actual approval count
- Default behavior unchanged: omitting `--approvals` uses 1

## Test Plan

- [x] Test 9: `--approvals 0` applies, success message shows 0 reviews, PUT called
- [x] Test 10: `--approvals 1` (explicit default) — success message shows 1 review
- [x] Test 11: `--approvals 7` (out of range) — exit 1 with actionable error
- [x] All 34 tests pass (`bash scripts/setup-repo-protection.test.sh`)
- [x] Lint and Python tests green