### PR TITLE
feat(framework): per-PR evidence page for non-technical reviewers (#170)

### DIFF
--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -123,8 +123,15 @@ ask the user to run `gh auth login` (solo) or
 7. **Commit**: Make atomic, well-described commits
 8. **Push Branch**: `git push origin feature/issue-{number}-description`
 9. **Create PR**: Link to issue, provide detailed description
-10. **Move to In Review**: Update project board status to "In Review"
-11. **Your work is done**: pr-reviewer agent will review, then human will merge
+10. **Probe evidence page** (preview deploys only): After the preview deploy succeeds,
+    `curl -s <preview-url>/healthz/evidence | jq .` and check `passed: true`.
+    - If green: proceed normally.
+    - If red: attempt **one repair** (fix the failing probe or its implementation,
+      re-push). If still red after one attempt, post a PR comment listing the failing
+      section(s) and what the reviewer should verify manually, then hand off.
+    - Do NOT block PR creation on a red evidence page — the reviewer needs to see it.
+11. **Move to In Review**: Update project board status to "In Review"
+12. **Your work is done**: pr-reviewer agent will review, then human will merge
 
 **YOU CANNOT:**
 - Merge pull requests (only human does this)

--- a/app/api/evidence.py
+++ b/app/api/evidence.py
@@ -1,0 +1,54 @@
+"""Evidence page routes — preview-only.
+
+Mounted by app/main.py only when ENVIRONMENT=preview. Production routing
+is untouched: this module is never imported in production.
+
+Routes:
+  GET /          — HTML evidence page for non-technical reviewers
+  GET /healthz/evidence — JSON probe results for the agent to check headlessly
+"""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from app.evidence import SECTIONS
+from app.templates import templates
+
+router = APIRouter()
+
+
+def _run_sections() -> list[dict]:
+    results = []
+    for section in SECTIONS:
+        try:
+            passed, observation = section.probe()
+        except Exception as exc:
+            passed = False
+            observation = f"Probe raised an exception: {exc}"
+        results.append(
+            {
+                "name": section.name,
+                "passed": passed,
+                "observation": observation,
+                "explanation": section.explanation,
+            }
+        )
+    return results
+
+
+@router.get("/")
+async def evidence_page(request: Request):
+    sections = _run_sections()
+    all_passed = all(s["passed"] for s in sections)
+    return templates.TemplateResponse(
+        request,
+        "evidence.html",
+        {"sections": sections, "all_passed": all_passed},
+    )
+
+
+@router.get("/healthz/evidence")
+async def evidence_json() -> JSONResponse:
+    sections = _run_sections()
+    all_passed = all(s["passed"] for s in sections)
+    return JSONResponse({"passed": all_passed, "sections": sections})

--- a/app/evidence.py
+++ b/app/evidence.py
@@ -1,0 +1,73 @@
+"""Evidence page model for PR-level verification.
+
+Each EvidenceSection represents one acceptance criterion from the PR.
+The worker agent populates this file per-PR with probes that verify
+the ticket work is real and visible.
+
+Section anatomy:
+  name        — human-readable label shown on the page
+  probe       — callable() → (passed: bool, observation: str)
+  explanation — reviewer-targeted prose: WHAT to look for and WHY
+                it proves the work is real. Written for non-engineers.
+
+Shipped as plain Python — no DSL, no magic. Workshop attendees read it
+and learn the pattern.
+
+Usage (from within the app):
+    from app.evidence import SECTIONS
+
+    results = [
+        {
+            "name": s.name,
+            "passed": s.probe()[0],
+            "observation": s.probe()[1],
+            "explanation": s.explanation,
+        }
+        for s in SECTIONS
+    ]
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass
+class EvidenceSection:
+    name: str
+    probe: Callable[[], tuple[bool, str]]
+    explanation: str
+
+
+def _probe_framework_health() -> tuple[bool, str]:
+    """Verify the app is running and responding to health checks."""
+    try:
+        import urllib.request
+
+        req = urllib.request.urlopen("http://localhost:8080/api/health", timeout=2)
+        body = req.read().decode()
+        if '"ok"' in body:
+            return True, 'GET /api/health returned {"status": "ok"}'
+        return False, f"Unexpected response: {body[:80]}"
+    except Exception as exc:
+        return False, f"Health check failed: {exc}"
+
+
+# ── Starter evidence section ─────────────────────────────────────────────────
+#
+# This section ships with the framework so PR-1 attendees see the pattern
+# immediately. The worker agent adds sections per-ticket, then removes or
+# replaces this one once the app has real acceptance criteria to verify.
+SECTIONS: list[EvidenceSection] = [
+    EvidenceSection(
+        name="Framework health check",
+        probe=_probe_framework_health,
+        explanation=(
+            "The app is running and its health endpoint returns OK. "
+            "If this section is green, the deployment succeeded and the "
+            "service is reachable. A red section means the deploy failed "
+            "or the container is crashing — check the Cloud Run logs."
+        ),
+    ),
+]

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ Run locally:
 Production (Cloud Run) runs the same command — see Dockerfile.
 """
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -22,4 +23,16 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 # Routes
 app.include_router(health.router)
+
+# Evidence page — preview deployments only.
+# ENVIRONMENT=preview is set by preview-deploy.yml. Production either omits
+# the var or sets ENVIRONMENT=production. The check at startup ensures the
+# evidence router is never registered in production (avoids any runtime branch).
+# Registered BEFORE todos so that GET / is handled by the evidence page in
+# preview instead of the todo home route.
+if os.environ.get("ENVIRONMENT") == "preview":
+    from app.api import evidence  # noqa: PLC0415
+
+    app.include_router(evidence.router)
+
 app.include_router(todos.router)

--- a/docs/EVIDENCE-PAGES.md
+++ b/docs/EVIDENCE-PAGES.md
@@ -1,0 +1,129 @@
+# Evidence Pages
+
+Evidence pages solve a real workshop problem: non-technical reviewers cannot
+meaningfully review early infrastructure or schema PRs. The work is real but
+invisible — DB migrations, auth plumbing, API scaffolding have no UI to look at.
+
+Evidence pages give reviewers something concrete: a page (visible on the PR
+preview URL) that explains what changed, runs a live probe against the deployed
+code, and reports pass or fail in plain language.
+
+---
+
+## How it works
+
+### On every preview deploy
+
+Cloud Run preview deployments set `ENVIRONMENT=preview`. The app detects this
+at startup and registers two additional routes:
+
+| Route | Purpose |
+|---|---|
+| `GET /` | HTML evidence page for reviewers |
+| `GET /healthz/evidence` | JSON probe results for the agent |
+
+Production deployments omit `ENVIRONMENT=preview`, so neither route is
+registered and the production home page is unaffected.
+
+### The evidence page
+
+The page at `/` (preview only) shows:
+- A green or red banner summarising whether all checks passed
+- One section per `EvidenceSection` in `app/evidence.py`, each with:
+  - A pass/fail indicator
+  - What the live probe found (e.g. a SQL query result, an HTTP response)
+  - A reviewer-targeted explanation of why this proves the work is real
+
+Reviewers click the preview URL from the PR, read the page, and decide whether
+to approve. They do not need to understand the code.
+
+### The JSON endpoint
+
+`GET /healthz/evidence` returns:
+
+```json
+{
+  "passed": true,
+  "sections": [
+    {
+      "name": "Section name",
+      "passed": true,
+      "observation": "What the probe found",
+      "explanation": "Why this matters"
+    }
+  ]
+}
+```
+
+The worker agent `curl`s this endpoint after the preview deploy to decide
+whether to post a "green" or "red" PR comment before handing off to the
+reviewer.
+
+---
+
+## Writing evidence sections
+
+Edit `app/evidence.py` and add an `EvidenceSection` to the `SECTIONS` list.
+
+```python
+# app/evidence.py
+from app.evidence import EvidenceSection
+
+def _probe_users_table_has_email_verified_at() -> tuple[bool, str]:
+    from app.db import get_sync_session
+    from sqlalchemy import text
+    with get_sync_session() as session:
+        result = session.execute(
+            text("SELECT column_name FROM information_schema.columns "
+                 "WHERE table_name='users' AND column_name='email_verified_at'")
+        ).fetchone()
+    if result:
+        return True, "Column email_verified_at exists in the users table"
+    return False, "Column email_verified_at NOT found in users table"
+
+SECTIONS = [
+    EvidenceSection(
+        name="users.email_verified_at column",
+        probe=_probe_users_table_has_email_verified_at,
+        explanation=(
+            "The migration added an email_verified_at timestamp column to the users "
+            "table. If this section is green, the column exists and the migration ran "
+            "successfully on the preview database. This is the actual schema change "
+            "this PR delivers."
+        ),
+    ),
+]
+```
+
+**Rules for good sections:**
+- One section per acceptance criterion, not per implementation detail
+- `explanation` is for the reviewer, not for engineers. Use plain language.
+  Describe what to look for and what it proves.
+- Probes must be fast (< 2 seconds). Slow probes block the page load.
+- Probes must be safe. No mutations (no INSERT/UPDATE/DELETE).
+- Keep `app/evidence.py` minimal. It runs on every page load in preview.
+
+---
+
+## Worker agent workflow
+
+After pushing a branch and the preview deploy succeeds:
+
+1. `curl -s <preview-url>/healthz/evidence | jq .`
+2. If `passed: true` → post PR description, move to In Review.
+3. If `passed: false` → attempt **one repair** (fix the failing probe or its
+   implementation, re-push). If still red after one attempt, post a PR comment
+   with the failing sections and manual verification instructions, then hand off.
+4. Never block PR creation on a red evidence page — the reviewer makes the call
+   with full information.
+
+---
+
+## Production safety
+
+The evidence router is only registered when the process sees `ENVIRONMENT=preview`
+at startup. This is checked once at module import, not per-request. Production
+Cloud Run services never set this variable, so the evidence routes are never
+registered, and the production home page continues to render normally.
+
+To verify: `curl https://<production-url>/healthz/evidence` should return 404.

--- a/templates/evidence.html
+++ b/templates/evidence.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block title %}PR Evidence — Agile Flow GCP{% endblock %}
+
+{% block content %}
+  <hgroup>
+    <h1>PR Verification</h1>
+    <p>
+      <strong>Preview environment — production will look different.</strong>
+      This page shows what changed in this PR and how to verify the work is
+      real. Read each section below and check the result.
+    </p>
+  </hgroup>
+
+  {% if all_passed %}
+    <article style="border-left: 4px solid var(--pico-color-green-500, #2d8a4e); padding: 1rem; margin-bottom: 1.5rem;">
+      <strong>All checks passed.</strong>
+      The PR is ready for your review. Use the explanations below to
+      understand what was built before approving.
+    </article>
+  {% else %}
+    <article style="border-left: 4px solid var(--pico-color-orange-500, #d4760a); padding: 1rem; margin-bottom: 1.5rem;">
+      <strong>Some checks did not pass.</strong>
+      The agent has been notified and will attempt one repair. If you see
+      this on the final version, check the PR comment for manual
+      verification instructions.
+    </article>
+  {% endif %}
+
+  {% for section in sections %}
+    <section>
+      <h3>
+        {% if section.passed %}
+          ✓
+        {% else %}
+          ✗
+        {% endif %}
+        {{ section.name }}
+      </h3>
+      <p><strong>What the check found:</strong> <code>{{ section.observation }}</code></p>
+      <p>{{ section.explanation }}</p>
+      {% if not section.passed %}
+        <p><em>This check did not pass. See the PR comment for what to verify manually.</em></p>
+      {% endif %}
+    </section>
+    {% if not loop.last %}<hr>{% endif %}
+  {% endfor %}
+
+  <footer>
+    <small>
+      Evidence page — visible on preview deployments only.
+      Production serves the real app at <code>/</code>.
+    </small>
+  </footer>
+{% endblock %}

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,97 @@
+"""Tests for the evidence page routes.
+
+The evidence router is only mounted when ENVIRONMENT=preview. Tests
+create an isolated app instance with that env var set so the routes
+are registered, without affecting the shared `client` fixture.
+"""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.db import get_session
+
+
+@pytest.fixture()
+def preview_client(session: Session) -> TestClient:
+    """TestClient for an app instance running in preview mode."""
+    os.environ["ENVIRONMENT"] = "preview"
+    try:
+        import importlib
+
+        import app.main as main_module
+
+        importlib.reload(main_module)
+        preview_app = main_module.app
+
+        def get_session_override():
+            yield session
+
+        preview_app.dependency_overrides[get_session] = get_session_override
+        client = TestClient(preview_app)
+        yield client
+        preview_app.dependency_overrides.clear()
+    finally:
+        del os.environ["ENVIRONMENT"]
+        import app.main as main_module  # noqa: PLC0415
+
+        importlib.reload(main_module)
+
+
+def test_evidence_json_endpoint_returns_structured_result(
+    preview_client: TestClient,
+) -> None:
+    response = preview_client.get("/healthz/evidence")
+    assert response.status_code == 200
+    body = response.json()
+    assert "passed" in body
+    assert "sections" in body
+    assert isinstance(body["sections"], list)
+    assert len(body["sections"]) >= 1
+    section = body["sections"][0]
+    assert "name" in section
+    assert "passed" in section
+    assert "observation" in section
+    assert "explanation" in section
+
+
+def test_evidence_page_renders_html(preview_client: TestClient) -> None:
+    response = preview_client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "PR Verification" in response.text
+    assert "Preview environment" in response.text
+
+
+def test_evidence_json_all_passed_reflects_sections(
+    preview_client: TestClient,
+) -> None:
+    response = preview_client.get("/healthz/evidence")
+    body = response.json()
+    computed_all_passed = all(s["passed"] for s in body["sections"])
+    assert body["passed"] == computed_all_passed
+
+
+def test_evidence_routes_not_mounted_in_production(session: Session) -> None:
+    """Without ENVIRONMENT=preview the evidence routes must not exist."""
+    os.environ.pop("ENVIRONMENT", None)
+    import importlib
+
+    import app.main as main_module
+
+    importlib.reload(main_module)
+    prod_app = main_module.app
+
+    def get_session_override():
+        yield session
+
+    prod_app.dependency_overrides[get_session] = get_session_override
+    try:
+        client = TestClient(prod_app)
+        response = client.get("/healthz/evidence")
+        assert response.status_code == 404
+    finally:
+        prod_app.dependency_overrides.clear()
+        importlib.reload(main_module)


### PR DESCRIPTION
## Summary

- Adds `app/evidence.py` with `EvidenceSection` dataclass and a starter health-check probe
- Adds `app/api/evidence.py` with `GET /` (HTML) and `GET /healthz/evidence` (JSON) routes, registered only when `ENVIRONMENT=preview`
- Registers evidence router **before** the todo router so `GET /` goes to the evidence page in preview instead of the todo home
- Adds `templates/evidence.html` — green/red banner + one section per acceptance criterion, reviewer-targeted prose
- Adds `tests/test_evidence.py` — 4 tests: JSON schema, HTML render, passed-field consistency, production 404 guard
- Documents the authoring guide in `docs/EVIDENCE-PAGES.md`
- Updates `.claude/agents/github-ticket-worker.md` to include the evidence-probe step in the post-deploy workflow

## Why this matters

Non-technical reviewers cannot meaningfully evaluate early infrastructure PRs (DB migrations, auth plumbing, API scaffolding) — the work is real but invisible. Evidence pages give reviewers a concrete preview URL with live pass/fail probes and plain-language explanations. The worker agent also curls `/healthz/evidence` after the preview deploy to decide whether to post a green or red PR comment before handing off.

## Production safety

The evidence router is only registered at startup when `ENVIRONMENT=preview` is set. Production Cloud Run services never set this variable, so neither route is ever registered and the production home page is unaffected. `GET /healthz/evidence` returns 404 in production (verified by the test suite).

## Test plan

- [x] `uv run pytest tests/test_evidence.py` — 4 tests pass
- [x] `uv run pytest` — all 26 tests pass
- [x] `uv run ruff check` — clean
- [x] Pre-push hook passes (ruff + pytest)
- [ ] Preview deploy: visit `GET /` and confirm evidence page renders with green banner
- [ ] Preview deploy: `curl <preview-url>/healthz/evidence | jq .` returns `{"passed": true, "sections": [...]}`
- [ ] Production: `curl <prod-url>/healthz/evidence` returns 404

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)