### PR TITLE
fix(workflows): fail-loud when GCP_PROJECT_ID set but NEON_API_KEY missing (#131)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -60,6 +60,29 @@ jobs:
             echo "neon_configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify Neon is configured when GCP deploy is active
+        # Silent-failure guard (#131, #52 class). When ENVIRONMENT=preview is
+        # set in the deployed container, the framework's startup validator
+        # (app/config.py) requires DATABASE_URL to be a postgres:// URL. If
+        # neon_configured is false, no DATABASE_URL is injected, the container
+        # crashes at startup, and Cloud Run reports a generic "container failed
+        # to start" timeout — with no indication that a Neon secret is missing.
+        # Catch it here with a clear message so the developer knows exactly
+        # which secret to add before the deploy even begins.
+        if: steps.check_secrets.outputs.skip != 'true' && steps.check_secrets.outputs.neon_configured != 'true'
+        run: |
+          echo "::error::Preview deploy is configured (GCP_PROJECT_ID is set)"
+          echo "::error::but Neon is NOT configured (NEON_API_KEY is missing"
+          echo "::error::from repo Actions secrets). The deploy would start a"
+          echo "::error::container with no DATABASE_URL, which the framework's"
+          echo "::error::startup validator rejects when ENVIRONMENT=preview."
+          echo "::error::"
+          echo "::error::To fix: add NEON_API_KEY (and NEON_PROJECT_ID) as"
+          echo "::error::repo Actions secrets. See docs/PLATFORM-GUIDE.md for"
+          echo "::error::instructions. Alternatively, remove GCP_PROJECT_ID to"
+          echo "::error::skip preview deploys entirely for this fork."
+          exit 1
+
       - name: Checkout code
         if: steps.check_secrets.outputs.skip != 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds a fail-loud guard step in `preview-deploy.yml` between `Check for required secrets` and `Checkout code`
- The step fires when `skip != 'true'` (GCP is configured) and `neon_configured != 'true'` (Neon is absent)
- Emits clear `::error::` annotations identifying the missing secret and how to fix it, then exits 1

## Problem

When a fork has `GCP_PROJECT_ID` configured but `NEON_API_KEY` absent, the workflow previously continued all the way to `gcloud run deploy` — injecting no `DATABASE_URL`. The container would start, hit the startup validator (`_refuse_sqlite_in_production` in `app/config.py`), and crash. Cloud Run reported a generic "container failed to start and listen on PORT 8080" timeout with no indication that a Neon secret was missing. Developers were sent to Cloud Run logs to diagnose an opaque startup failure.

## Fix

The new step catches this case before any GCP resources are touched and produces an actionable workflow annotation:

```
::error::Preview deploy is configured (GCP_PROJECT_ID is set)
::error::but Neon is NOT configured (NEON_API_KEY is missing
::error::from repo Actions secrets). The deploy would start a
::error::container with no DATABASE_URL, which the framework's
::error::startup validator rejects when ENVIRONMENT=preview.
::error::
::error::To fix: add NEON_API_KEY (and NEON_PROJECT_ID) as
::error::repo Actions secrets. See docs/PLATFORM-GUIDE.md for
::error::instructions. Alternatively, remove GCP_PROJECT_ID to
::error::skip preview deploys entirely for this fork.
```

This is the same silent-skip-cascade pattern diagnosed in #52 and #78.

## Test plan

- [x] `uv run pytest` — 22 tests pass
- [x] `uv run ruff check` — clean
- [x] Pre-push hook passes
- [ ] Manual: push a PR to a fork with `GCP_PROJECT_ID` set but `NEON_API_KEY` missing — confirm the new step fires with the clear error before checkout

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)