### PR TITLE
docs+chore: WIF format clarification and setup-uv Node 24 bump (#50, #54)

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install uv
         if: steps.check_python.outputs.is_python == 'true'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
 
       - name: Run ruff fix
         if: steps.check_python.outputs.is_python == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install uv
         if: steps.check_python.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
 
       - name: Lint with ruff
         if: steps.check_python.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `astral-sh/setup-uv` from `@v4` to `@v5` in `auto-fix.yml` and `ci.yml`
+  to use the Node 24 runtime ahead of the GitHub-enforced June 2026 cutover (#54)
+
 ## [0.9.0] - 2025-12-07
 
 Pre-upgrade baseline — the first tagged release of Agile Flow.

--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -32,6 +32,7 @@
 
 13. [Workload Identity Federation vs Service Account Keys](#13-workload-identity-federation-vs-service-account-keys)
 14. [GCP: iam.serviceAccountUser Is Required to Deploy to Cloud Run](#14-gcp-iamserviceaccountuser-is-required-to-deploy-to-cloud-run)
+34. [GCP WIF invalid_target error](#34-gcp-wif-invalid_target-error)
 
 ### FastAPI / Python
 
@@ -1332,6 +1333,60 @@ single CI run had failed loud at the missing output. Conversion to
 fail-loud is therefore a *retroactive* defense: it doesn't fix the
 specific bugs the cascade hid, but it ensures the next bug surfaces
 within one run instead of months.
+
+---
+
+## 34. GCP WIF invalid\_target error
+
+**Gotcha:** The `google-github-actions/auth` step fails with:
+
+```
+Error: failed to generate Google Cloud federated token for
+//iam.googleapis.com/...: {"error":"invalid_target","error_description":
+"The target service indicated by the \"audience\" parameters is invalid.
+This might either be because the pool or provider is disabled or deleted
+or because it doesn't exist."}
+```
+
+The error lists three possible causes but gives no diagnostic to distinguish them.
+In practice, almost every first-time occurrence is a **malformed
+`GCP_WORKLOAD_IDENTITY_PROVIDER` secret**. Search for `invalid_target` to land here.
+
+**Three common causes and how to tell them apart:**
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Provider path contains your project **ID** (letters/hyphens) | Project number was confused with project ID | Use project **number** (12-digit integer) |
+| Provider path starts with a billing account ID (`XXXXXX-XXXXXX-XXXXXX`) | Billing account confused with project | Get the project number from `gcloud projects describe PROJECT_ID --format='value(projectNumber)'` |
+| Provider path starts with `//iam.googleapis.com/` | Leading prefix should be stripped | Remove the `//iam.googleapis.com/` prefix — the secret value starts with `projects/` |
+| Provider path ends at the pool (`.../workloadIdentityPools/github`) | Missing `/providers/PROVIDER_ID` segment | Append `/providers/github` (or whatever you named the provider) |
+
+**Correct format:**
+
+```
+projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID
+```
+
+Where `PROJECT_NUMBER` is the 12-digit integer (not the project ID string).
+
+**Fastest diagnostic — fetch the correct value directly:**
+
+```bash
+gcloud iam workload-identity-pools providers list \
+  --location=global \
+  --workload-identity-pool=github \
+  --project=YOUR_PROJECT_ID \
+  --format='value(name)'
+```
+
+The output is the full provider path in the correct format, ready to paste
+into the `GCP_WORKLOAD_IDENTITY_PROVIDER` GitHub secret.
+
+**See also:** `docs/PLATFORM-GUIDE.md` → Step 5 → the "Common mistakes" callout
+for a quick-reference table.
+
+Surfaced in the 2026-04-29 dry-run (`tck517/agile-flow-gcp`) finding #2 (#50).
+Every manual fork bring-up before #49 (bootstrap automation) hit this.
 
 ---
 

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -244,6 +244,31 @@ The WIF provider resource name to paste into GitHub secrets is:
 projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/github
 ```
 
+> **Common mistakes with `GCP_WORKLOAD_IDENTITY_PROVIDER`** — this secret causes
+> the majority of first-time bring-up failures. Three frequent errors:
+>
+> | Wrong value | Right value |
+> |---|---|
+> | Project **ID** (`my-project-abc`) | Project **number** (`123456789012`) |
+> | GCP billing account ID (`XXXXXX-XXXXXX-XXXXXX`) | Project number |
+> | Path with `//iam.googleapis.com/` prefix | Bare `projects/...` — no leading `//iam...` |
+> | Pool path (missing `/providers/...`) | Full provider path including `/providers/PROVIDER_ID` |
+>
+> The project number is different from the project ID. Fetch it with:
+>
+> ```bash
+> gcloud iam workload-identity-pools providers list \
+>   --location=global \
+>   --workload-identity-pool=github \
+>   --project=YOUR_PROJECT_ID \
+>   --format='value(name)'
+> ```
+>
+> The output is the full provider path, ready to paste into the GitHub secret.
+> If you see an `invalid_target` error in CI, see the
+> [GCP WIF invalid_target error](#gcp-wif-invalid_target-error) entry in
+> `docs/PATTERN-LIBRARY.md`.
+
 ### Step 5 (Alternative): Service Account Key (Workshop Shortcut)
 
 If WIF feels like too much setup for your timeline (e.g., for a workshop),

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -266,7 +266,7 @@ projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/provide
 >
 > The output is the full provider path, ready to paste into the GitHub secret.
 > If you see an `invalid_target` error in CI, see the
-> [GCP WIF invalid_target error](#gcp-wif-invalid_target-error) entry in
+> [GCP WIF invalid\_target error](PATTERN-LIBRARY.md#34-gcp-wif-invalid_target-error) entry in
 > `docs/PATTERN-LIBRARY.md`.
 
 ### Step 5 (Alternative): Service Account Key (Workshop Shortcut)


### PR DESCRIPTION
## Summary

- Adds a "Common mistakes" callout to `docs/PLATFORM-GUIDE.md` Step 5 with the correct `GCP_WORKLOAD_IDENTITY_PROVIDER` format, common wrong values, and the `gcloud` lookup command that outputs the correct value directly
- Adds `PATTERN-LIBRARY.md` entry #34 "GCP WIF `invalid_target` error" — searchable by the literal error string, lists the three causes and how to distinguish them
- Bumps `astral-sh/setup-uv` from `@v4` to `@v5` in `auto-fix.yml` and `ci.yml` to use the Node 24 runtime
- Adds `CHANGELOG.md` entry under `[Unreleased] → Changed`

## Closes #50: WIF format docs

The `invalid_target` error in `google-github-actions/auth` is the most common
first-time bring-up failure. Users consistently pass the project ID (letters)
instead of the project number (12-digit int), include the `//iam.googleapis.com/`
prefix that should be stripped, or pass a billing account ID. The new callout box
in PLATFORM-GUIDE.md makes the correct format explicit with a table of wrong vs.
right values and the `gcloud --format='value(name)'` lookup command.

PATTERN-LIBRARY.md entry #34 is cross-referenced from the callout and searchable
by the literal `invalid_target` error string.

## Partially addresses #54: Node 20 → Node 24 actions bump

The `astral-sh/setup-uv@v4` references in `auto-fix.yml` and `ci.yml` have been
updated to `@v5`. The remaining affected actions (`actions/checkout@v4`,
`actions/github-script@v7`, `google-github-actions/auth@v2`, etc.) need manual
verification against their latest release notes to confirm which version runs on
Node 24 — tracked in issue #54 for follow-up. Those bumps should be verified on
a test fork before landing.

If needed as an interim measure before the June 2 cutover, add
`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the job `env:` block in affected
workflows — GitHub explicitly supports this as a migration stopgap.

## Test plan

- [x] `uv run pytest` — 22 tests pass
- [x] `uv run ruff check` — clean
- [x] Pre-push hook passes
- [ ] Reviewer: verify PATTERN-LIBRARY.md #34 cross-reference from PLATFORM-GUIDE.md resolves
- [ ] Follow-up: #54 tracking issue for remaining action version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)