### PR TITLE
ci(release): skip release creation if tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --notes-file /tmp/release-notes.md
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "Release ${{ steps.version.outputs.tag }} already exists — skipping creation."
+          else
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --notes-file /tmp/release-notes.md
+          fi


### PR DESCRIPTION
Idempotency fix for release.yml — same change applied to agile-flow in [vibeacademy/agile-flow#180](https://github.com/vibeacademy/agile-flow/pull/180). Prevents workflow failure when a release is pre-created manually before the CHANGELOG PR lands on main.