### PR TITLE
feat(upgrade): implement /upgrade command (VIB-23)

### DIFF
--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -1,11 +1,12 @@
 ---
-description: "Upgrade Agile Flow framework files to the latest release"
+description: "Upgrade this fork to the latest changes from upstream Agile Flow"
 ---
 
-# /upgrade — Agile Flow Framework Upgrade
+# /upgrade — Pull Latest Upstream Changes
 
-Check for a newer version of Agile Flow and sync framework files from the
-latest upstream release. User content is never modified.
+Fetch and merge the latest framework changes from this fork's upstream Agile Flow repo.
+Local overrides (`.agile-flow-overrides`) are never stomped. A rollback tag is created
+before every merge so you can recover if something goes wrong.
 
 ## Instructions
 
@@ -13,62 +14,92 @@ latest upstream release. User content is never modified.
    uncommitted changes, STOP and report:
 
    ```
-   Your working tree has uncommitted changes. Please commit or stash them
-   before upgrading:
+   Your working tree has uncommitted changes. Please commit or stash them first:
      git stash
-     /upgrade
+   Then re-run /upgrade.
    ```
 
-2. **Verify GitHub CLI authentication** — run `gh auth status`. If not
-   authenticated, STOP and report:
-
-   ```
-   GitHub CLI is not authenticated. Run:
-     gh auth login
-   ```
-
-3. **Run the sync script**:
+2. **Run the upgrade script**:
 
    ```bash
-   bash scripts/template-sync.sh
+   bash scripts/upgrade.sh
    ```
 
-4. **Parse the output** and report what happened. The script will print one of:
+   The script will:
+   - Read `.agile-flow-meta/upstream` for the upstream URL (or fall back to the
+     `upstream` git remote, or prompt the user if neither is configured)
+   - Create a `pre-upgrade-<timestamp>` rollback tag
+   - Fetch and merge upstream `main` with `--no-commit --no-ff`
+   - Restore all `.agile-flow-overrides` paths to their local versions
+   - Write the new version to `.agile-flow-meta/version` and commit
 
-   - **Already up to date** — no action needed.
-   - **Update available: X -> Y** followed by file-level ADDED/UPDATED/SKIP
-     lines and a PR URL.
-   - **ERROR** — report the error message to the user.
+3. **Handle the exit code**:
 
-5. **If a PR was created**, remind the user:
+   | Code | Meaning | Action |
+   |------|---------|--------|
+   | `0`  | Success — upgrade committed | Report what changed (see step 5) |
+   | `1`  | Error — dirty tree, fetch failure, or abort-on-conflict | Report the error message |
+   | `2`  | Conflicts in interactive mode | Proceed to step 4 |
 
+4. **Resolve conflicts (exit code 2 only)**:
+
+   The script printed the conflicting files. For each file:
+   - Show the user the conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>> FETCH_HEAD`)
+   - Explain what upstream changed vs. what we have locally
+   - Ask the user which version to keep (or whether to hand-merge)
+   - Apply the resolution with `git add <file>`
+
+   Once all conflicts are resolved, complete the upgrade:
+   ```bash
+   bash scripts/upgrade.sh --continue
    ```
-   A sync PR has been created. Review the changes, then merge when ready:
-     gh pr view <PR_NUMBER> --web
+
+   If the user wants to abort instead:
+   ```bash
+   git merge --abort
    ```
 
-## Important
+5. **Report the result**. Parse the script output and summarise:
 
-- This command calls `scripts/template-sync.sh` as-is. Do not modify the script.
-- The sync only updates framework-controlled files. User content (app code,
-  config customizations, product docs) is never touched. See
-  [DISTRIBUTION.md](../../docs/DISTRIBUTION.md) for the full classification.
-- The created PR requires human review and merge. Do not auto-merge.
-- For details on what gets synced and troubleshooting, see
-  [UPGRADING.md](../../docs/UPGRADING.md).
+   - **Upgraded** — show the version written to `.agile-flow-meta/version` and list
+     files that changed (from the diff stat the script printed)
+   - **Already up to date** — tell the user no changes were needed
+   - **Override warnings** — if the script printed `NOTE: These override-protected paths
+     also changed upstream`, list them and suggest the user review them manually
 
-### Output Format
+## Conflict modes (advanced)
 
-End your output with a Result Block:
+If the user wants non-interactive upgrade (e.g. in CI or for automated runs):
+
+```bash
+# Accept upstream version for all conflicts (non-override paths)
+bash scripts/upgrade.sh --accept-upstream
+
+# Abort and roll back if any conflict is found
+bash scripts/upgrade.sh --abort-on-conflict
+```
+
+## Rollback
+
+If the upgrade broke something, restore the pre-upgrade state:
+
+```bash
+git reset --hard pre-upgrade-<timestamp>
+```
+
+The rollback tag is shown in the script output and is always created before the merge.
+
+## Output Format
+
+End your response with a Result Block:
 
 ```
 ---
 
 **Result:** Upgrade complete
-From: v0.9.0
-To: v1.0.0
-PR: #42 — chore(sync): update Agile Flow framework to v1.0.0
-Action: Review and merge the PR to finalize the upgrade
+Version: v2.1.0 @ abc123def456
+Files changed: 4 updated, 1 added
+Rollback tag: pre-upgrade-20260508-143022
 ```
 
 Or if already up to date:
@@ -77,5 +108,15 @@ Or if already up to date:
 ---
 
 **Result:** Already up to date
-Version: v0.9.0
+```
+
+Or if conflicts were found and resolved interactively:
+
+```
+---
+
+**Result:** Upgrade complete (conflicts resolved interactively)
+Version: abc123def456
+Files changed: 6 updated
+Conflicts resolved: scripts/doctor.sh
 ```

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,41 @@
+name: Upgrade from upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Conflict resolution mode"
+        required: false
+        default: "abort-on-conflict"
+        type: choice
+        options:
+          - abort-on-conflict
+          - accept-upstream
+
+# Only one upgrade at a time
+concurrency:
+  group: upgrade
+  cancel-in-progress: false
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "upgrade-bot"
+          git config user.email "noreply@github.com"
+
+      - name: Run upgrade script
+        run: bash scripts/upgrade.sh --${{ inputs.mode }}
+
+      - name: Push upgraded branch
+        run: git push origin HEAD

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# upgrade.sh — Upgrade Agile Flow framework from upstream.
+#
+# Usage:
+#   bash scripts/upgrade.sh [--interactive|--accept-upstream|--abort-on-conflict]
+#   bash scripts/upgrade.sh --continue   (after manually resolving conflicts)
+#
+# Exit codes:
+#   0  — success (up to date or changes applied)
+#   1  — error (dirty tree, fetch failure, abort-on-conflict with conflicts)
+#   2  — conflicts found in interactive mode; resolve and re-run with --continue
+
+set -euo pipefail
+
+META_DIR=".agile-flow-meta"
+OVERRIDES_FILE=".agile-flow-overrides"
+PENDING_SHA_FILE="$META_DIR/.upgrade-pending-sha"
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+
+MODE="interactive"
+CONTINUE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --interactive)       MODE="interactive" ;;
+    --accept-upstream)   MODE="accept-upstream" ;;
+    --abort-on-conflict) MODE="abort-on-conflict" ;;
+    --continue)          CONTINUE=true ;;
+    *) echo "ERROR: Unknown flag: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+list_conflicts() {
+  git ls-files --unmerged 2>/dev/null | awk '{print $4}' | sort -u
+}
+
+# ── Continue path (after manual conflict resolution) ─────────────────────────
+
+if $CONTINUE; then
+  CONFLICT_FILES=$(list_conflicts)
+  if [ -n "$CONFLICT_FILES" ]; then
+    echo "ERROR: Unresolved conflicts remain:" >&2
+    echo "$CONFLICT_FILES" | while read -r f; do echo "  - $f" >&2; done
+    echo "" >&2
+    echo "Resolve all conflicts, then run: bash scripts/upgrade.sh --continue" >&2
+    exit 1
+  fi
+
+  UPSTREAM_SHA=""
+  if [ -f "$PENDING_SHA_FILE" ]; then
+    UPSTREAM_SHA=$(cat "$PENDING_SHA_FILE")
+  elif git rev-parse MERGE_HEAD >/dev/null 2>&1; then
+    UPSTREAM_SHA=$(git rev-parse MERGE_HEAD)
+  else
+    echo "ERROR: No pending upgrade found. Was git merge --abort run?" >&2
+    exit 1
+  fi
+
+  UPSTREAM_REF=$(git describe --tags "$UPSTREAM_SHA" 2>/dev/null || echo "${UPSTREAM_SHA:0:12}")
+  echo "$UPSTREAM_REF @ $UPSTREAM_SHA" > "$META_DIR/version"
+  git add "$META_DIR/version"
+
+  git -c user.name="upgrade" -c user.email="noreply@github.com" \
+    commit -m "chore(upgrade): sync from upstream @ ${UPSTREAM_SHA:0:7}"
+
+  rm -f "$PENDING_SHA_FILE"
+  echo ""
+  echo "Upgrade complete!"
+  echo "Version: $(cat "$META_DIR/version")"
+  exit 0
+fi
+
+# ── Pre-flight: clean working tree ────────────────────────────────────────────
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: Working tree has uncommitted changes." >&2
+  echo "Commit or stash before upgrading:" >&2
+  echo "  git stash" >&2
+  echo "  bash scripts/upgrade.sh" >&2
+  exit 1
+fi
+
+# ── Discover upstream URL ────────────────────────────────────────────────────
+
+UPSTREAM_URL=""
+if [ -f "$META_DIR/upstream" ]; then
+  UPSTREAM_URL=$(cat "$META_DIR/upstream")
+elif git remote get-url upstream >/dev/null 2>&1; then
+  UPSTREAM_URL=$(git remote get-url upstream)
+else
+  printf "What upstream does this fork track?\n(e.g., https://github.com/vibeacademy/agile-flow)\n> "
+  read -r UPSTREAM_URL
+  if [ -z "$UPSTREAM_URL" ]; then
+    echo "ERROR: No upstream URL provided." >&2
+    exit 1
+  fi
+  mkdir -p "$META_DIR"
+  echo "$UPSTREAM_URL" > "$META_DIR/upstream"
+  git add "$META_DIR/upstream"
+  git -c user.name="upgrade" -c user.email="noreply@github.com" \
+    commit -m "chore: record upstream URL in .agile-flow-meta/upstream"
+  echo "Upstream URL saved to $META_DIR/upstream."
+fi
+
+echo "Upstream : $UPSTREAM_URL"
+
+# ── Create rollback tag ───────────────────────────────────────────────────────
+
+ROLLBACK_TAG="pre-upgrade-$(date +%Y%m%d-%H%M%S)"
+git tag -f "$ROLLBACK_TAG"
+echo "Rollback : $ROLLBACK_TAG"
+
+# ── Fetch upstream ────────────────────────────────────────────────────────────
+
+echo "Fetching..."
+if ! git fetch "$UPSTREAM_URL" main 2>&1; then
+  echo "" >&2
+  echo "ERROR: Could not fetch from $UPSTREAM_URL" >&2
+  echo "Check your network connection or upstream URL and try again." >&2
+  exit 1
+fi
+
+UPSTREAM_SHA=$(git rev-parse FETCH_HEAD)
+echo "Upstream : ${UPSTREAM_SHA:0:12}"
+
+# Save SHA for --continue path
+echo "$UPSTREAM_SHA" > "$PENDING_SHA_FILE"
+
+# ── Show diff summary ─────────────────────────────────────────────────────────
+
+DIFF_STAT=$(git diff --stat HEAD FETCH_HEAD 2>/dev/null || true)
+if [ -z "$DIFF_STAT" ]; then
+  echo ""
+  echo "Already up to date with upstream."
+  rm -f "$PENDING_SHA_FILE"
+  exit 0
+fi
+
+echo ""
+echo "Changes incoming from upstream:"
+echo "$DIFF_STAT"
+echo ""
+
+# ── Attempt merge ─────────────────────────────────────────────────────────────
+
+echo "Merging (no-commit)..."
+MERGE_EXIT=0
+git merge --no-commit --no-ff FETCH_HEAD 2>&1 || MERGE_EXIT=$?
+
+# ── Apply overrides — restore our version for each protected path ─────────────
+
+OVERRIDES_APPLIED=()
+OVERRIDES_UPSTREAM_CHANGED=()
+
+if [ -f "$OVERRIDES_FILE" ]; then
+  while IFS= read -r pattern; do
+    [[ "$pattern" =~ ^#.*$ || -z "$pattern" ]] && continue
+
+    # Warn if this path changed upstream
+    if ! git diff --quiet HEAD FETCH_HEAD -- "$pattern" 2>/dev/null; then
+      OVERRIDES_UPSTREAM_CHANGED+=("$pattern")
+    fi
+
+    # Restore our version (resolves conflicts in override paths to ours)
+    if git checkout HEAD -- "$pattern" 2>/dev/null; then
+      git add "$pattern" 2>/dev/null || true
+      OVERRIDES_APPLIED+=("$pattern")
+    fi
+  done < "$OVERRIDES_FILE"
+fi
+
+if [ ${#OVERRIDES_APPLIED[@]} -gt 0 ]; then
+  echo "Override-protected (kept local version):"
+  for p in "${OVERRIDES_APPLIED[@]}"; do echo "  - $p"; done
+fi
+
+if [ ${#OVERRIDES_UPSTREAM_CHANGED[@]} -gt 0 ]; then
+  echo ""
+  echo "NOTE: These override-protected paths also changed upstream."
+  echo "      Review manually if you want to adopt the upstream changes:"
+  for p in "${OVERRIDES_UPSTREAM_CHANGED[@]}"; do echo "  ! $p"; done
+fi
+
+# ── Handle remaining conflicts (non-override paths) ───────────────────────────
+
+CONFLICT_FILES=$(list_conflicts)
+
+if [ -n "$CONFLICT_FILES" ]; then
+  echo ""
+  echo "Conflicts in:"
+  echo "$CONFLICT_FILES" | while read -r f; do echo "  - $f"; done
+
+  case "$MODE" in
+    abort-on-conflict)
+      echo ""
+      echo "Mode: abort-on-conflict — rolling back."
+      git merge --abort
+      rm -f "$PENDING_SHA_FILE"
+      echo "Rolled back. Rollback tag: $ROLLBACK_TAG"
+      exit 1
+      ;;
+    accept-upstream)
+      echo ""
+      echo "Mode: accept-upstream — taking upstream version for conflicted files."
+      echo "$CONFLICT_FILES" | while read -r f; do
+        git checkout --theirs "$f"
+        git add "$f"
+      done
+      ;;
+    interactive)
+      echo ""
+      echo "Mode: interactive — resolve conflicts, then run:"
+      echo "  bash scripts/upgrade.sh --continue"
+      echo ""
+      echo "To abort and roll back:"
+      echo "  git merge --abort"
+      echo "  git tag -d $ROLLBACK_TAG"
+      exit 2
+      ;;
+  esac
+fi
+
+# ── Write version and commit ──────────────────────────────────────────────────
+
+UPSTREAM_REF=$(git describe --tags FETCH_HEAD 2>/dev/null || echo "${UPSTREAM_SHA:0:12}")
+echo "$UPSTREAM_REF @ $UPSTREAM_SHA" > "$META_DIR/version"
+git add "$META_DIR/version"
+
+git -c user.name="upgrade" -c user.email="noreply@github.com" \
+  commit -m "chore(upgrade): sync from upstream @ ${UPSTREAM_SHA:0:7}"
+
+rm -f "$PENDING_SHA_FILE"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Upgrade complete!"
+echo "Version : $(cat "$META_DIR/version")"
+echo "Rollback: git checkout $ROLLBACK_TAG  (if needed)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

Implements the `/upgrade` command per VIB-16 architecture plan §5 — same implementation as `agile-flow` PR #183.

- `scripts/upgrade.sh` — git-based upstream merge with rollback, override protection, and three conflict modes
- `.claude/commands/upgrade.md` — Claude orchestration prompt (replaces template-sync.sh approach)
- `.github/workflows/upgrade.yml` — manual-dispatch GitHub Actions trigger

The script is track-agnostic: it reads `.agile-flow-meta/upstream` to determine which upstream to pull from, so it works identically for founder-track, GCP-track, and AWS-track forks.

## Notes

- Stacks on `feature/vib-22-agile-flow-meta` (should be merged first)
- agile-flow-aws does not exist yet — will be deployed when that repo is created

## Test plan

- [ ] Run `bash scripts/upgrade.sh` in a GCP fork — confirm it reads `.agile-flow-meta/upstream` (should point to agile-flow-gcp)
- [ ] Verify rollback tag is created before merge
- [ ] Verify GCP-specific `.agile-flow-overrides` paths are not overwritten
- [ ] Test `--abort-on-conflict` exits cleanly with rollback
- [ ] Test `--accept-upstream` resolves conflicts to upstream version
- [ ] Verify `.agile-flow-meta/version` is written correctly after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)