### PR TITLE
fix(agents): remove GitHub MCP references from agent definitions

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -84,15 +84,14 @@ You are an expert Product Owner and Agile Coach specializing in agile digital pr
 
 ## Tools and Capabilities
 
-**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for project board management. This is your **primary method** for all GitHub operations.
+**GitHub CLI (`gh`)**: Use the `gh` CLI for all GitHub operations — issues, project board, PRs.
 
-**Available GitHub MCP Tools (Preferred):**
-- Create, update, and manage issues
-- Move items between project board columns (Backlog, Ready, In Progress, In Review, Done, Icebox)
-- Update issue status, labels, priorities
-- Add comments and assignees
-- Link issues to pull requests and create parent/child relationships
-- Bulk operations on project items
+**Common operations:**
+- Create, update, and manage issues (`gh issue create/edit/comment`)
+- Move items between project board columns (`gh project item-edit`)
+- Update issue status, labels, priorities (`gh issue edit --add-label`, etc.)
+- Add comments and assignees (`gh issue comment`, `gh issue edit --add-assignee`)
+- Link issues to PRs via the PR body (`Closes #N`) or `gh pr edit`
 
 **Memory MCP Server**: You have access to persistent knowledge storage for cross-session context.
 

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -67,7 +67,7 @@ You are a strategic Product Manager responsible for product vision, market fit, 
 
 ## Tools and Capabilities
 
-**GitHub MCP Server**: Access to issues, PRs, and project boards for feature tracking and release management.
+**GitHub CLI (`gh`)**: Issues, PRs, and project boards for feature tracking and release management.
 
 **Memory MCP Server**: Persistent storage for market insights, feature decisions, and strategic context.
 

--- a/.claude/agents/github-ticket-worker.md
+++ b/.claude/agents/github-ticket-worker.md
@@ -73,19 +73,17 @@ ask the user to run `gh auth login` (solo) or
 - Solo-mode users have one personal account; the framework must not
   attempt to switch to bots that don't exist
 
-**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with issues, pull requests, and the project board. This is your **primary method** for all GitHub operations.
+**GitHub CLI (`gh`)**: Use the `gh` CLI for all GitHub operations.
 
-**Available MCP Tools (Preferred):**
-- Query and read issues from the project board
-- Create, update, and comment on issues
-- Move issues between project board columns (Ready, In Progress, In Review, Done)
-- Create and manage pull requests
-- Update PR status and labels
-- Link PRs to issues
-- Read file contents from the repository
-- Search code and issues
-
-**Fallback: GitHub CLI (`gh`)**: If MCP tools are unavailable or encounter errors, use the `gh` CLI for GitHub operations.
+**Common operations:**
+- Query and read issues from the project board (`gh issue list`, `gh issue view`, `gh project item-list`)
+- Create, update, and comment on issues (`gh issue create/edit/comment`)
+- Move issues between project board columns (`gh project item-edit`)
+- Create and manage pull requests (`gh pr create/edit`)
+- Update PR status and labels (`gh pr edit --add-label`)
+- Link PRs to issues (PR body `Closes #N`, or `gh pr edit`)
+- Read file contents from the repository (Read tool or `gh api`)
+- Search code and issues (`gh search code`, `gh issue list --search`)
 
 ## Your Core Responsibilities
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -96,22 +96,20 @@ ask the user to run `gh auth login` (solo) or
 - Solo-mode users have one personal account; the framework must not
   attempt to switch to bots that don't exist
 
-**GitHub MCP Server**: You have access to the GitHub MCP server with native tools for interacting with pull requests, issues, and the project board. This is your **primary method** for all GitHub operations.
+**GitHub CLI (`gh`)**: Use the `gh` CLI for all GitHub operations.
 
-**Available MCP Tools (Preferred):**
-- Query and read pull requests from the project board
-- Review PR diffs, files changed, and commit history
-- Read PR comments and reviews
-- Approve, request changes, or comment on PRs
-- Read file contents from the repository
-- Check CI/CD status and test results
+**Common operations:**
+- Query and read PRs (`gh pr list`, `gh pr view`)
+- Review PR diffs, files, and commits (`gh pr diff`, `gh pr view --json files,commits`)
+- Read PR comments and reviews (`gh pr view --comments`, `gh api repos/{owner}/{repo}/pulls/{n}/reviews`)
+- Comment on PRs with GO/NO-GO recommendation (`gh pr comment`)
+- Read file contents from the repository (Read tool or `gh api`)
+- Check CI/CD status (`gh pr checks`, `gh pr view --json statusCheckRollup`)
 
 **YOU CANNOT USE (Human-only actions):**
 - Merge PRs (human reviewer does this)
 - Move issues to "Done" column (human does this after merge)
 - Close issues (human does this)
-
-**Fallback: GitHub CLI (`gh`)**: If MCP tools are unavailable or encounter errors, use the `gh` CLI for GitHub operations.
 
 ## Your Core Responsibilities
 


### PR DESCRIPTION
## Summary

The GitHub MCP server is no longer in `.mcp.json` (only `memory` and `sequential-thinking` remain), but four agent definitions still told themselves to prefer it as the primary tool with `gh` CLI as fallback. This inverts the framing — `gh` is now canonical — and removes the dead MCP-tool listings that referenced functions no longer registered.

Mirrors upstream [vibeacademy/agile-flow#189](https://github.com/vibeacademy/agile-flow/pull/189). No `/upgrade` path is available yet, so this was applied as a brute-force port — diff stat (`+28/-33`) matches upstream byte-for-byte.

Quick fix per `CLAUDE.md` Quick Fix Protocol: no behavior change, broken doc references only.

## Files changed

- `.claude/agents/agile-product-manager.md` — one-line tool listing
- `.claude/agents/agile-backlog-prioritizer.md` — full MCP block replaced
- `.claude/agents/pr-reviewer.md` — MCP block replaced; "Fallback: GitHub CLI" line removed
- `.claude/agents/github-ticket-worker.md` — MCP block replaced; "Fallback: GitHub CLI" line removed

Memory MCP references retained where present (Memory MCP is still configured).

## Test plan

- [x] `./scripts/validation/validate-agent-policies.sh` — all 7 agents PASS
- [x] `./scripts/lint-agent-policies.sh` — 0 errors, 0 warnings
- [x] `./scripts/verify-agent-restrictions.sh --test protocol` — 5/5 pass
- [x] `./scripts/verify-agent-restrictions.sh --test docs` — 3/3 pass
- [x] `grep -rn -iE 'github mcp|github-mcp|mcp__github' .claude/agents/` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)