### PR TITLE
[#VIB-24] feat: add /report-issue command (recreated)

### DIFF
--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -1,0 +1,130 @@
+---
+description: "Report a bug or issue from this fork back to the upstream Agile Flow repo"
+---
+
+# /report-issue — Report an Issue to Upstream
+
+File a structured bug report or feedback item against the upstream Agile Flow repo
+from this downstream fork. The report is delivered as a GitHub issue with a
+`downstream-report` label so upstream maintainers can triage it automatically.
+
+## When to use this command
+
+Use `/report-issue` when you have found:
+- A bug in a framework script, workflow, or slash command
+- A workflow that does not work as documented
+- Missing or incorrect documentation
+- A pattern or architectural suggestion
+
+Do **not** use this for issues specific to your fork's customisations (those are local
+issues you own). Use it for problems that exist in the upstream framework files.
+
+## Instructions
+
+1. **Verify `.agile-flow-meta/upstream` exists**. If the file is missing, run `/upgrade`
+   first to initialise the metadata directory.
+
+2. **Gather context before running the script**. Before invoking, note:
+   - What went wrong (be specific)
+   - Severity: p1 (critical, blocks everyone), p2 (significant, workaround exists),
+     p3 (minor or improvement)
+   - Component: provisioning, ci, claude-commands, patterns, docs, or other
+
+3. **Run the report script**:
+
+   ```bash
+   bash scripts/report-issue.sh
+   ```
+
+   The script will:
+   - Read .agile-flow-meta/upstream to identify the target repo
+   - Capture fork_commit (current HEAD) and upstream_version automatically
+   - Prompt for severity, component, and title
+   - Open your $EDITOR (or use inline input) for the description
+   - Submit via gh issue create with label downstream-report
+   - Fall back to clipboard copy + pre-filled browser URL if gh access is denied
+
+4. **Fill in the description**. Provide:
+   - Description: what is happening and why it is a problem
+   - Steps to Reproduce: numbered list, minimal and specific
+   - Expected Behaviour: what should happen
+   - Actual Behaviour: what actually happens
+   - Error Output: paste relevant terminal output
+   - Context: workshop date, participant count, track (Founder/GCP/AWS)
+
+5. **Handle the exit code**:
+
+   | Code | Meaning | Action |
+   |------|---------|--------|
+   | 0 | Success - issue filed or fallback URL provided | Report the issue URL to the user |
+   | 1 | Error - missing config or invalid input | Show the error message and fix the root cause |
+
+6. **If gh access is denied** (fallback path):
+
+   The script will save the report to .agile-flow-meta/reports/report-<timestamp>.md,
+   copy the body to clipboard if available, and print a pre-filled GitHub issue URL.
+
+   Tell the user:
+   > The report was saved locally and a pre-filled GitHub issue URL was generated.
+   > Open the URL in your browser to submit it manually.
+
+## Non-interactive mode (CI / automation)
+
+```bash
+bash scripts/report-issue.sh \
+  --non-interactive \
+  --severity p2 \
+  --component provisioning \
+  --title "Provision script fails when roster has special characters"
+```
+
+## Report format reference
+
+The script generates a YAML front-matter Markdown file in .agile-flow-meta/reports/:
+
+```
+---
+agile_flow_report: true
+upstream: https://github.com/vibeacademy/agile-flow
+fork_commit: abc123def456...
+upstream_version: v2.1.0 @ def789abc012
+severity: p2
+component: provisioning
+title: "Provision script fails when roster has special characters"
+---
+```
+
+The upstream field is written automatically from .agile-flow-meta/upstream.
+
+## Output Format
+
+End your response with a Result Block:
+
+```
+---
+
+**Result:** Issue filed
+URL: https://github.com/vibeacademy/agile-flow/issues/42
+Severity: p2
+Component: provisioning
+Report: .agile-flow-meta/reports/report-20260508-143022.md
+```
+
+Or if fallback was used:
+
+```
+---
+
+**Result:** Report saved (manual submission required)
+Report: .agile-flow-meta/reports/report-20260508-143022.md
+Browser URL: https://github.com/vibeacademy/agile-flow/issues/new?...
+```
+
+Or on error:
+
+```
+---
+
+**Result:** Error
+Reason: .agile-flow-meta/upstream not found - run /upgrade first
+```

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+#
+# Usage:
+#   bash scripts/report-issue.sh
+#   bash scripts/report-issue.sh --severity p2 --component provisioning --title "short title"
+#   bash scripts/report-issue.sh --non-interactive --severity p3 --component docs --title "typo in guide"
+#
+# Exit codes:
+#   0  — report filed successfully (or saved for manual submission via fallback)
+#   1  — error (missing config, invalid inputs)
+
+set -euo pipefail
+
+META_DIR=".agile-flow-meta"
+REPORTS_DIR="$META_DIR/reports"
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+
+SEVERITY=""
+COMPONENT=""
+TITLE=""
+NON_INTERACTIVE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --severity)        SEVERITY="$2";       shift 2 ;;
+    --component)       COMPONENT="$2";      shift 2 ;;
+    --title)           TITLE="$2";          shift 2 ;;
+    --non-interactive) NON_INTERACTIVE=true; shift ;;
+    *) echo "ERROR: Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Verify .agile-flow-meta/ exists ──────────────────────────────────────────
+
+if [ ! -d "$META_DIR" ]; then
+  echo "ERROR: .agile-flow-meta/ directory not found." >&2
+  echo "This fork does not have upstream metadata. Run /upgrade to initialise." >&2
+  exit 1
+fi
+
+if [ ! -f "$META_DIR/upstream" ]; then
+  echo "ERROR: .agile-flow-meta/upstream not found." >&2
+  echo "Run /upgrade to record this fork's upstream URL." >&2
+  exit 1
+fi
+
+# ── Read upstream URL and derive repo slug ────────────────────────────────────
+
+UPSTREAM_URL=$(cat "$META_DIR/upstream")
+UPSTREAM_URL="${UPSTREAM_URL%$'\n'}"  # strip trailing newline if any
+
+if [ -z "$UPSTREAM_URL" ]; then
+  echo "ERROR: .agile-flow-meta/upstream is empty." >&2
+  exit 1
+fi
+
+# Extract org/repo from https or git@ GitHub URLs
+UPSTREAM_REPO=""
+if [[ "$UPSTREAM_URL" =~ github\.com[:/]([^/]+/[^/]+?)(\.git)?$ ]]; then
+  UPSTREAM_REPO="${BASH_REMATCH[1]}"
+else
+  echo "ERROR: Cannot parse GitHub repo from: $UPSTREAM_URL" >&2
+  echo "Expected format: https://github.com/org/repo" >&2
+  exit 1
+fi
+
+# ── Gather git metadata ───────────────────────────────────────────────────────
+
+FORK_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+UPSTREAM_VERSION="unknown"
+if [ -f "$META_DIR/version" ]; then
+  UPSTREAM_VERSION=$(cat "$META_DIR/version")
+  UPSTREAM_VERSION="${UPSTREAM_VERSION%$'\n'}"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Report Issue to Upstream"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Upstream : $UPSTREAM_URL"
+echo "Fork     : ${FORK_COMMIT:0:12}"
+echo "Version  : $UPSTREAM_VERSION"
+echo ""
+
+# ── Prompt: severity ─────────────────────────────────────────────────────────
+
+if [ -z "$SEVERITY" ]; then
+  if $NON_INTERACTIVE; then
+    echo "ERROR: --severity required in non-interactive mode." >&2
+    exit 1
+  fi
+  echo "Severity:"
+  echo "  p1  Critical — broken for everyone, blocks workshops"
+  echo "  p2  High — significant problem, workaround exists"
+  echo "  p3  Low — minor issue or improvement suggestion"
+  printf "> "
+  read -r SEVERITY
+fi
+
+case "$SEVERITY" in
+  p1|p2|p3) ;;
+  *)
+    echo "ERROR: --severity must be p1, p2, or p3. Got: '$SEVERITY'" >&2
+    exit 1
+    ;;
+esac
+
+# ── Prompt: component ─────────────────────────────────────────────────────────
+
+if [ -z "$COMPONENT" ]; then
+  if $NON_INTERACTIVE; then
+    echo "ERROR: --component required in non-interactive mode." >&2
+    exit 1
+  fi
+  echo ""
+  echo "Component:"
+  echo "  provisioning    setup, roster, env provisioning scripts"
+  echo "  ci              GitHub Actions, CI/CD workflows"
+  echo "  claude-commands /slash commands"
+  echo "  patterns        architectural patterns and practices"
+  echo "  docs            documentation"
+  echo "  other           anything else"
+  printf "> "
+  read -r COMPONENT
+fi
+
+case "$COMPONENT" in
+  provisioning|ci|claude-commands|patterns|docs|other) ;;
+  *)
+    echo "ERROR: --component must be one of: provisioning, ci, claude-commands, patterns, docs, other." >&2
+    echo "Got: '$COMPONENT'" >&2
+    exit 1
+    ;;
+esac
+
+# ── Prompt: title ─────────────────────────────────────────────────────────────
+
+if [ -z "$TITLE" ]; then
+  if $NON_INTERACTIVE; then
+    echo "ERROR: --title required in non-interactive mode." >&2
+    exit 1
+  fi
+  echo ""
+  echo "Short title (one line, describes the problem):"
+  printf "> "
+  read -r TITLE
+fi
+
+if [ -z "$TITLE" ]; then
+  echo "ERROR: Title is required." >&2
+  exit 1
+fi
+
+# Sanitise the title for safe interpolation into a YAML double-quoted scalar:
+# backslashes first, then double quotes. YAML's double-quoted form allows
+# \\ and \" as escapes, so this round-trips correctly for any title text.
+SAFE_TITLE="${TITLE//\\/\\\\}"
+SAFE_TITLE="${SAFE_TITLE//\"/\\\"}"
+
+# ── Build description ─────────────────────────────────────────────────────────
+
+DESCRIPTION_FILE=$(mktemp /tmp/agile-flow-report-XXXXXX.md)
+trap 'rm -f "$DESCRIPTION_FILE"' EXIT
+
+cat > "$DESCRIPTION_FILE" <<'TEMPLATE'
+## Description
+
+<!-- What is the problem? Be specific. -->
+
+## Steps to Reproduce
+
+1.
+2.
+
+## Expected Behaviour
+
+<!-- What should happen? -->
+
+## Actual Behaviour
+
+<!-- What actually happens? -->
+
+## Error Output
+
+```
+(paste error output here if applicable)
+```
+
+## Context
+
+- Workshop date:
+- Participants:
+- Track:
+TEMPLATE
+
+if ! $NON_INTERACTIVE; then
+  EDITOR="${EDITOR:-}"
+  if [ -n "$EDITOR" ] && command -v "$EDITOR" >/dev/null 2>&1; then
+    echo ""
+    echo "Opening $EDITOR for description. Save and close when done."
+    "$EDITOR" "$DESCRIPTION_FILE"
+  else
+    echo ""
+    echo "Paste your description below."
+    echo "Include: what happened, steps to reproduce, expected vs actual behaviour."
+    echo "Enter a line with just '.' when done:"
+    echo ""
+    DESC_LINES=""
+    while IFS= read -r line; do
+      [ "$line" = "." ] && break
+      DESC_LINES+="${line}"$'\n'
+    done
+    printf '%s' "$DESC_LINES" > "$DESCRIPTION_FILE"
+  fi
+fi
+
+DESCRIPTION=$(cat "$DESCRIPTION_FILE")
+
+# ── Write report file ─────────────────────────────────────────────────────────
+
+mkdir -p "$REPORTS_DIR"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+REPORT_FILE="$REPORTS_DIR/report-${TIMESTAMP}.md"
+
+cat > "$REPORT_FILE" <<REPORT
+---
+agile_flow_report: true
+upstream: $UPSTREAM_URL
+fork_commit: $FORK_COMMIT
+upstream_version: $UPSTREAM_VERSION
+severity: $SEVERITY
+component: $COMPONENT
+title: "$SAFE_TITLE"
+---
+
+$DESCRIPTION
+REPORT
+
+echo "Report   : $REPORT_FILE"
+echo ""
+
+# ── Deliver via gh issue create ───────────────────────────────────────────────
+
+ISSUE_TITLE="[downstream-report] $TITLE"
+GH_FAILED=false
+
+if command -v gh >/dev/null 2>&1; then
+  echo "Submitting to $UPSTREAM_REPO..."
+  if gh issue create \
+      --repo "$UPSTREAM_REPO" \
+      --title "$ISSUE_TITLE" \
+      --label "downstream-report" \
+      --body-file "$REPORT_FILE"; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Issue filed successfully."
+    echo "Report saved: $REPORT_FILE"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 0
+  else
+    GH_FAILED=true
+    echo "" >&2
+    echo "WARNING: gh issue create failed. Falling back to manual submission." >&2
+  fi
+else
+  GH_FAILED=true
+  echo "gh CLI not found. Falling back to manual submission." >&2
+fi
+
+# ── Fallback: clipboard + browser URL ────────────────────────────────────────
+
+ENCODED_TITLE=""
+ENCODED_BODY=""
+if command -v python3 >/dev/null 2>&1; then
+  ENCODED_TITLE=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$ISSUE_TITLE" 2>/dev/null || echo "")
+  ENCODED_BODY=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(open(sys.argv[1]).read()))" "$REPORT_FILE" 2>/dev/null || echo "")
+fi
+
+BROWSER_URL="https://github.com/${UPSTREAM_REPO}/issues/new?title=${ENCODED_TITLE}&body=${ENCODED_BODY}&labels=downstream-report"
+
+# Try clipboard
+CLIPBOARD_CMD=""
+if command -v pbcopy >/dev/null 2>&1; then
+  CLIPBOARD_CMD="pbcopy"
+elif command -v xclip >/dev/null 2>&1; then
+  CLIPBOARD_CMD="xclip -selection clipboard"
+elif command -v xsel >/dev/null 2>&1; then
+  CLIPBOARD_CMD="xsel --clipboard --input"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "GitHub access unavailable — manual submission required."
+echo ""
+echo "Report saved: $REPORT_FILE"
+echo ""
+
+if [ -n "$CLIPBOARD_CMD" ]; then
+  if $CLIPBOARD_CMD < "$REPORT_FILE" 2>/dev/null; then
+    echo "Report body copied to clipboard."
+    echo ""
+  fi
+fi
+
+echo "Open this URL to file the issue in your browser:"
+echo "$BROWSER_URL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+exit 0


### PR DESCRIPTION
## Ticket

Implements [VIB-24](https://paperclip.vibeacademy.dev/VIB/issues/VIB-24): part of the downstream issue reporting loop ([VIB-16](https://paperclip.vibeacademy.dev/VIB/issues/VIB-16) §6).

This is a fresh PR replacing the earlier [#186](https://github.com/vibeacademy/agile-flow-gcp/pull/186), which was closed without merge (branch deleted) before landing.

## Summary

- Adds `scripts/report-issue.sh` — generates a YAML front-matter structured report and delivers via `gh issue create` to the upstream repo with label `downstream-report`.
- Adds `.claude/commands/report-issue.md` — Claude-facing slash command prompt that guides the user through reporting.
- Report auto-captures `fork_commit` and `upstream_version` from `.agile-flow-meta/`; upstream URL written by script from `.agile-flow-meta/upstream`.
- Fallback path: clipboard copy + pre-filled browser URL when `gh` access is denied.
- Supports `--non-interactive` mode for CI/automation.

Byte-identical to the [agile-flow companion PR](https://github.com/vibeacademy/agile-flow/pull/191) — upstream URL is read from `.agile-flow-meta/upstream` at runtime, so there is no track-specific code.

## Changes vs. closed PR #186

This PR is **scoped to the two deliverable files only** (per CTO direction):

- `scripts/report-issue.sh`
- `.claude/commands/report-issue.md`

The earlier bundle (`.agile-flow-meta/`, `scripts/upgrade.sh`, `.github/workflows/upgrade.yml`, `.claude/commands/upgrade.md` rewrite) is **not** carried over — those belong to other tickets (VIB-22 was cancelled; the upgrade-flow rewrite is separate).

Addresses one of the two non-blocking items from [Staff Engineer's review](https://paperclip.vibeacademy.dev/VIB/issues/VIB-24#comment-c949a5f6-2d5f-4b31-9e27-92ae588cafdf):

- **YAML-quote sanitisation in title** — fixed. `TITLE` is now escaped (backslash then double-quote) before interpolation into the YAML double-quoted scalar, so titles containing `"`, `\`, or both round-trip through YAML correctly.

The second non-blocking item (`accept-upstream` pipe-subshell `set -e` issue) lives in `scripts/upgrade.sh`, which is **not present on `main`** of this repo and is out of scope for this PR. That fix can be applied in the PR that introduces `scripts/upgrade.sh`.

## Pre-requisite for the script to function

The script reads `.agile-flow-meta/upstream`. That metadata directory is **not currently on `main`** (VIB-22, which would have added it, is `cancelled`). Until a metadata-initialisation path exists, the script exits with a clear error directing the user to `/upgrade`. Suggest opening a follow-up to either:

1. Re-scope VIB-22 (or open VIB-22b) to add `.agile-flow-meta/upstream` to the template.
2. Or relax `report-issue.sh` to fall back to `git remote get-url upstream` if metadata is missing.

Flagging here so reviewers know this PR lands the command but the end-to-end flow requires one more piece of infrastructure.

## Test plan

- [x] `bash -n scripts/report-issue.sh` — syntax check passes (verified in agile-flow companion).
- [x] Local run with a title containing `"`, `\`, and `$` — generated YAML round-trips through a Python regex parser correctly (verified in agile-flow companion; this file is byte-identical).
- [ ] Manual: run on a real fork with `.agile-flow-meta/upstream` populated; verify `gh issue create` opens an issue with the `downstream-report` label.
- [ ] Manual: run without metadata; verify exit code 1 with directional error.