### PR TITLE
fix(scripts): template-sync creates pre-upgrade rollback tag

### DIFF
--- a/.claude/commands/upgrade.md
+++ b/.claude/commands/upgrade.md
@@ -47,6 +47,34 @@ latest upstream release. User content is never modified.
      gh pr view <PR_NUMBER> --web
    ```
 
+## Rollback
+
+Before any file mutation, `template-sync.sh` creates a local-only tag named
+`pre-upgrade-YYYYMMDD-HHMMSS` pointing at HEAD. The script's final summary
+prints the exact recovery command, for example:
+
+```
+Rollback: git reset --hard pre-upgrade-20260511-213045
+```
+
+If the sync PR contains a broken file, an unwanted upstream change, or a
+lost customization, recover with:
+
+```bash
+git reset --hard pre-upgrade-YYYYMMDD-HHMMSS
+```
+
+Tags are **not pushed to the remote** — they stay local so upstream tag
+namespaces remain clean. List your local rollback points anytime:
+
+```bash
+git tag --list 'pre-upgrade-*'
+```
+
+If the sync PR has already been merged to `main`, the rollback approach is
+to `git revert` the merge commit on a new branch instead — the local tag
+only restores your local working tree, not the published merge.
+
 ## Important
 
 - This command calls `scripts/template-sync.sh` as-is. Do not modify the script.

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -73,7 +73,37 @@ if [ -z "$EXTRACTED_DIR" ]; then
 fi
 
 ###############################################################################
-# 5. Sync each directory/file from syncDirectories
+# 5. Create pre-upgrade rollback tag (local-only safety net)
+###############################################################################
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "ERROR: not inside a git repository — cannot create rollback tag."
+  rm -rf "$WORK_DIR"
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  echo "ERROR: working tree has uncommitted changes — refusing to upgrade without a clean rollback point."
+  echo "Commit or stash your changes, then retry."
+  rm -rf "$WORK_DIR"
+  exit 1
+fi
+
+if ! git symbolic-ref -q HEAD >/dev/null; then
+  echo "ERROR: HEAD is detached — refusing to upgrade without a branch to roll back to."
+  rm -rf "$WORK_DIR"
+  exit 1
+fi
+
+ROLLBACK_TAG="pre-upgrade-$(date +%Y%m%d-%H%M%S)"
+if ! git tag "$ROLLBACK_TAG" 2>/dev/null; then
+  echo "ERROR: failed to create rollback tag '$ROLLBACK_TAG'. Aborting."
+  rm -rf "$WORK_DIR"
+  exit 1
+fi
+echo "Created rollback tag: $ROLLBACK_TAG (local-only)"
+
+###############################################################################
+# 6. Sync each directory/file from syncDirectories
 ###############################################################################
 FILES_CHANGED=()
 
@@ -131,12 +161,12 @@ while IFS= read -r sync_path; do
 done <<< "$SYNC_DIRS"
 
 ###############################################################################
-# 6. Clean up
+# 7. Clean up
 ###############################################################################
 rm -rf "$WORK_DIR"
 
 ###############################################################################
-# 7. If no files changed, exit
+# 8. If no files changed, exit
 ###############################################################################
 if [ ${#FILES_CHANGED[@]} -eq 0 ]; then
   echo "Already up to date. All synced files match the latest release."
@@ -144,7 +174,7 @@ if [ ${#FILES_CHANGED[@]} -eq 0 ]; then
 fi
 
 ###############################################################################
-# 8. Create branch, commit, and open PR
+# 9. Create branch, commit, and open PR
 ###############################################################################
 SYNC_BRANCH="agile-flow-sync/v${LATEST_VERSION}"
 
@@ -203,4 +233,8 @@ gh pr create \
   --base main \
   --head "$SYNC_BRANCH"
 
+echo ""
+echo "===================== Summary ====================="
 echo "PR created successfully for v${LATEST_VERSION}."
+echo "Rollback: git reset --hard $ROLLBACK_TAG"
+echo "==================================================="


### PR DESCRIPTION
## Ticket

Paperclip: [VIB-58 — DEF-002: template-sync.sh must create pre-upgrade rollback tag](/VIB/issues/VIB-58)

(No corresponding GitHub issue. Tracking lives in Paperclip.)

## Summary

`scripts/template-sync.sh` had no rollback path — if a sync PR introduced a broken file or wiped a customisation, recovery required either rejecting the PR pre-merge or hand-crafting `git revert` against the merge commit (undocumented). The previous `scripts/upgrade.sh` flow created a `pre-upgrade-<timestamp>` tag; that safety net was lost when /upgrade switched to `template-sync.sh`.

This PR restores the safety net. Before any `cp`, the script creates a local-only tag `pre-upgrade-YYYYMMDD-HHMMSS` at HEAD and prints the exact recovery command in its final summary: `Rollback: git reset --hard <tag>`.

## Changes Made

- `scripts/template-sync.sh` — new section 5 creates the rollback tag after the version-comparison gate (so steady-state runs stay a no-op) and before the sync loop (so the tag is created before any mutation). Existing section numbers shifted by one. Final summary now prints a Summary block with the PR creation message and the `Rollback:` recovery command.
- Safety guards: aborts fast with a clear error if not inside a git repo, the working tree has uncommitted changes, HEAD is detached, or tag creation otherwise fails (e.g., name collision on rapid re-run).
- `.claude/commands/upgrade.md` — new "Rollback" section documents the tag pattern, the recovery command, the local-only nature of the tag, and notes that post-merge recovery requires `git revert` instead.

## Testing

### Automated checks

- [x] `bash -n scripts/template-sync.sh` — no syntax errors
- [x] Pre-push hook (lint + tests) passed

### Manual repro

Simulated each guard in a throwaway git repo:

| Scenario | Expected | Result |
|----------|----------|--------|
| Clean tree, on branch | tag created, `Rollback:` line printed | ✓ |
| Dirty tree (uncommitted change) | abort with clear error | ✓ |
| Detached HEAD | abort with clear error | ✓ |
| Tag already exists (rapid re-run, same second) | abort with clear error | ✓ |

Confirmed the steady-state path (LOCAL_VERSION == LATEST_VERSION) exits at line 60 — before the tag creation block — so no tag is created when no upgrade is needed.

## Acceptance Criteria Mapping

- [x] Before the first `cp`, runs `git tag pre-upgrade-$(date +%Y%m%d-%H%M%S)` locally
- [x] Tag name captured and printed as `Rollback: git reset --hard <tag>` in the final summary
- [x] Tag is NOT pushed to the remote (no `git push --tags`, no per-tag push; stays local-only)
- [x] If tag creation fails (uncommitted changes, detached HEAD, name collision), script fails fast with a clear error
- [x] `.claude/commands/upgrade.md` has a "Rollback" section documenting the tag pattern
- [x] Steady-state run (no upgrade needed) does NOT create a tag — exits before section 5

## Guardrails Honored

- Tag is local-only; no `git push --tags` added.
- Tag created BEFORE any file mutation; on failure the script aborts.
- Timestamp format `YYYYMMDD-HHMMSS` is sortable; the tag-collision guard catches the rare same-second rapid re-run.
- CI runs (`template-sync.yml`) keep working — `actions/checkout@v4` produces a clean tree on a branch, so all guards pass. The created tag is harmless in CI since the clone is ephemeral.

## Companion PR

Companion PR opens in `agile-flow`: https://github.com/vibeacademy/agile-flow/pull/195. Both repos receive the same change because their `template-sync.sh` scripts are essentially identical.

## Checklist

- [x] All pre-push checks pass
- [x] Code follows project conventions (matches existing script style)
- [x] No new linter warnings
- [x] Manual repro confirms each acceptance criterion