### PR TITLE
fix(sync): protect template-sync script in overrides

### DIFF
--- a/.agile-flow-overrides
+++ b/.agile-flow-overrides
@@ -24,6 +24,7 @@ scripts/provision-workshop-roster.sh
 scripts/diagnose-cloudrun.sh
 scripts/populate-claude-md.sh
 scripts/dev-branch.sh
+scripts/template-sync.sh
 scripts/setup-labels.sh
 scripts/setup-repo-protection.sh
 scripts/setup-solo-mode.sh


### PR DESCRIPTION
## Summary\n- add `scripts/template-sync.sh` to `.agile-flow-overrides`\n- prevent future sync from silently reverting ADR-001 upstream repo fix\n\n## Context\n- closes DEF-UPS-001 path from VIB-115 audit fail\n