### PR TITLE
fix(upgrade): make UPSTREAM_REPO configurable in .agile-flow-version (#204)

### DIFF
--- a/.agile-flow-version
+++ b/.agile-flow-version
@@ -1,5 +1,6 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.0",
+  "upstream": "vibeacademy/agile-flow-gcp",
   "installedAt": null,
   "distribution": "template",
   "syncDirectories": [

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# template-sync.sh -- Sync framework files from vibeacademy/agile-flow releases.
+# template-sync.sh -- Sync framework files from upstream releases.
+# Reads the upstream repo from .agile-flow-version (falls back to vibeacademy/agile-flow).
 # Called by .github/workflows/template-sync.yml (workflow_dispatch only).
 # Guardrails:
 #   - Only syncs directories/files listed in syncDirectories (.agile-flow-version)
@@ -8,17 +9,18 @@
 
 set -euo pipefail
 
-UPSTREAM_REPO="vibeacademy/agile-flow"
 VERSION_FILE=".agile-flow-version"
 
 ###############################################################################
-# 1. Read local version and syncDirectories
+# 1. Read local version, upstream repo, and syncDirectories
 ###############################################################################
 if [ ! -f "$VERSION_FILE" ]; then
   echo "ERROR: $VERSION_FILE not found."
   exit 1
 fi
 
+# Read upstream repo from config, fallback to vibeacademy/agile-flow for backward compatibility
+UPSTREAM_REPO=$(python3 -c "import json; print(json.load(open('$VERSION_FILE')).get('upstream', 'vibeacademy/agile-flow'))")
 LOCAL_VERSION=$(python3 -c "import json,sys; print(json.load(open('$VERSION_FILE'))['version'])")
 SYNC_DIRS=$(python3 -c "
 import json, sys


### PR DESCRIPTION
## Summary

Makes the `/upgrade` feature work correctly for workshop participants who fork agile-flow-gcp.

## Changes

- **scripts/template-sync.sh**: Read `upstream` field from `.agile-flow-version` instead of hardcoding
- **.agile-flow-version**: Add `upstream: vibeacademy/agile-flow-gcp` and bump version to 1.0.0

## Testing

```bash
$ bash scripts/template-sync.sh
Local version : 1.0.0
Sync targets  : .claude/agents .claude/commands ...
Latest version: 1.0.0
No updates available. Local version (1.0.0) matches latest release.
```

The script now correctly reads from `vibeacademy/agile-flow-gcp` releases.

## Backward Compatibility

Falls back to `vibeacademy/agile-flow` if `upstream` field is not set.

Closes #204