### PR TITLE
fix(upgrade): use gh auth token to avoid false-negative on stale keyring accounts

### DIFF
--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -21,7 +21,7 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 # Check if gh is authenticated
-if ! gh auth status >/dev/null 2>&1; then
+if ! gh auth token >/dev/null 2>&1; then
   echo "ERROR: GitHub CLI is not authenticated."
   echo "Please run: gh auth login"
   echo "Then retry the upgrade command."


### PR DESCRIPTION
## Problem

`gh auth status` returns exit code 1 if ANY keyring account is invalid, even if GH_TOKEN auth works. This causes false failures in the /upgrade pre-flight auth check.

## Solution

Changed the auth check in `scripts/template-sync.sh` from:
```bash
if ! gh auth status >/dev/null 2>&1; then
```

To use `gh auth token` which only checks if we can get a valid token:
```bash
if ! gh auth token >/dev/null 2>&1; then
```

## Testing

- ✅ Test without GH_TOKEN: correctly fails
- ✅ Test with GH_TOKEN: correctly proceeds with upgrade process

This is the same fix as applied to the upstream agile-flow repository.

Fixes the false-negative bug where valid token authentication was rejected due to stale keyring entries.