### PR TITLE
docs: add /report-issue to README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ Once bootstrap is complete, use the standard workflow:
 /evaluate-feature       # Assess feature requests
 /release-decision       # Go/no-go for releases
 /architect-review       # Design guidance
+
+# Feedback
+/report-issue           # Report issues to upstream template maintainers
 ```
+
+Use `/report-issue` to send structured bug reports or suggestions back to the
+upstream Agile Flow maintainers. This creates a feedback loop that helps improve
+the framework for everyone. See [`.claude/commands/report-issue.md`](.claude/commands/report-issue.md) for details.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
Sync from upstream agile-flow. Add `/report-issue` command to the After Bootstrap section of README.md with a brief description of the upstream feedback loop benefit.

## Changes
- Added `/report-issue` to the Feedback category in the slash commands list
- Added description paragraph explaining the upstream feedback loop
- Linked to `.claude/commands/report-issue.md` for details

## Related
Syncs with vibeacademy/agile-flow#215