### PR TITLE
fix: sync report-issue.sh with upstream bash 3.2 compatibility fix

### DIFF
--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -57,8 +57,10 @@ if [ -z "$UPSTREAM_URL" ]; then
 fi
 
 # Extract org/repo from https or git@ GitHub URLs
+# Strip .git suffix before matching (bash 3.2 doesn't support non-greedy regex)
+UPSTREAM_URL_CLEAN="${UPSTREAM_URL%.git}"
 UPSTREAM_REPO=""
-if [[ "$UPSTREAM_URL" =~ github\.com[:/]([^/]+/[^/]+?)(\.git)?$ ]]; then
+if [[ "$UPSTREAM_URL_CLEAN" =~ github\.com[:/]([^/]+/[^/]+)$ ]]; then
   UPSTREAM_REPO="${BASH_REMATCH[1]}"
 else
   echo "ERROR: Cannot parse GitHub repo from: $UPSTREAM_URL" >&2


### PR DESCRIPTION
## Summary
Syncs `scripts/report-issue.sh` with the upstream fix for bash 3.2 compatibility.

## Changes
The upstream repo has a fix that properly handles URLs ending in `.git` by stripping the suffix before regex matching, instead of using non-greedy regex (which doesn't work in bash 3.2).

## Related
Part of vibeacademy/agile-flow#214

## Intentional Differences Preserved
`.claude/commands/report-issue.md` has a minor intentional difference: downstream adds `(Founder/GCP/AWS)` track examples, which is appropriate for this GCP-specific fork.