### PR TITLE
docs(journal): session journal for 2026-05-17 — broken /report-issue flow

### DIFF
--- a/reports/session-journals/2026-05-17.md
+++ b/reports/session-journals/2026-05-17.md
@@ -1,0 +1,58 @@
+# Session Journal — 2026-05-17
+
+## 1. Session Summary
+
+The `/report-issue` command is broken on a fresh checkout of `main`: it requires `.agile-flow-meta/upstream`, but no bootstrap or sync script on `main` creates that file, and the `/report-issue` documentation incorrectly directs users to `/upgrade` for initialization. No tickets shipped; this session is a discovery-and-handoff journal so the next worker can land the fix without re-discovering the chain.
+
+The session also surfaced a recurring framing trap: a user invoked `/log-session` describing this repo as a "downstream fork of vibeacademy/agile-flow-gcp" when it IS `vibeacademy/agile-flow-gcp` (parent: null). Worth a defensive heuristic on commands that read "upstream" relative to the current repo.
+
+## 2. Tickets Delivered
+
+None.
+
+## 3. Tickets In Review
+
+None at session open. This journal will land via a `content/session-journal-2026-05-17` PR per CLAUDE.md's "no direct commits to main" rule.
+
+## 4. Challenges and Mitigations
+
+| Challenge | Root cause | Mitigation | Prevention |
+|-----------|-----------|------------|------------|
+| `/report-issue` fails on `main` with `ERROR: .agile-flow-meta/ directory not found` | `scripts/report-issue.sh` (lines 15, 38–55) and `.claude/commands/report-issue.md` both depend on `.agile-flow-meta/upstream`, but no script on `main` creates it. The directory was scaffolded on `origin/docs/sdlc-VIB-46` in commit `ca0498e` (ticket VIB-22, "Engineer (Paperclip)" co-author, 2026-05-08) but that branch never merged | Documented here; ticket(s) to be filed | Either land VIB-22 from `origin/docs/sdlc-VIB-46`, or add `.agile-flow-meta/upstream` initialization to a bootstrap path (`scripts/setup-solo-mode.sh` / `scripts/workshop-setup.sh`). Add a CI smoke test that runs `bash scripts/report-issue.sh --non-interactive ...` so this regresses loudly next time |
+| `/upgrade` does not create `.agile-flow-meta/` despite `/report-issue` doc claiming it does | `.claude/commands/report-issue.md` line 24: "If the file is missing, run `/upgrade` first to initialise the metadata directory." But `scripts/template-sync.sh`'s sync targets are only `.claude/agents`, `.claude/commands`, `.claude/hooks`, `.claude/skills`, `scripts`, `starters`. The doc was written ahead of the bootstrap implementation (VIB-22), and the bootstrap then never landed | Doc correction in scope of the follow-up ticket | When a command doc references another command's effect, add an integration test that runs both in sequence on a fresh checkout |
+| Misframing: user described this repo as a "downstream fork" | `gh repo view --json parent` returns `null`. The remote (`git@github.com:vibeacademy/agile-flow-gcp.git`) is `origin`, not a fork's `upstream`. Easy to confuse because the working directory path (`/Users/teddykim/projects/tck517/agile-flow-gcp`) contains the user's GH login `tck517`, suggesting a personal fork that isn't there | Surfaced to the user before pushing any cross-repo artifact; treated the PR as a normal in-repo PR | `/report-issue` (and any other "upstream" command) should run `gh repo view --json parent --jq '.parent'` as its first precondition. If parent is null, short-circuit with: "You are running this against the framework repo itself. File the issue directly with `gh issue create`." |
+
+## 5. Insights and Learnings
+
+- **`/report-issue` has no working precondition on `main`.** The chain `/report-issue → /upgrade → /report-issue` loops forever because `/upgrade` doesn't create the required file. This blocks the entire downstream feedback loop the command was designed to enable.
+- **VIB-22 work exists but is stranded.** `origin/docs/sdlc-VIB-46` carries a complete scaffold (`.agile-flow-meta/{upstream,version,overrides,reports/}` plus `.agile-flow-overrides` updates so upstream syncs don't stomp the dir) authored by "Engineer (Paperclip) <engineer@paperclip.ing>". Check whether to fast-forward the branch or re-author after drift review.
+- **`gh repo view --json parent --jq '.parent'` is the canonical framework-vs-fork check.** Returns `null` on the framework, a non-null object on a fork. Cheaper and more reliable than guessing from remote URL strings.
+- **Session-journal precedent is mixed.** Past journals landed via PR (#56, #75, #148, #156) and via direct push (`cd38c85`, `299a179`, `88ed3ac`). CLAUDE.md mandates the PR path; this journal follows it. Once #137 (`/ship-docs`) lands, the friction argument goes away entirely.
+
+## 6. Tickets Created
+
+To be filed against `vibeacademy/agile-flow-gcp` after this journal lands, pending user confirmation on scope:
+
+| Proposed | Pri/Size | Why |
+|----------|----------|-----|
+| `fix(framework): /report-issue requires .agile-flow-meta/ but no bootstrap creates it` | P1/S | Blocks the downstream feedback path the command was designed for. Two reasonable fix paths: (a) land VIB-22 from `origin/docs/sdlc-VIB-46`, (b) add init to `scripts/setup-solo-mode.sh` / `scripts/workshop-setup.sh`. Must also correct `.claude/commands/report-issue.md` line 24 |
+| `fix(framework): /report-issue should detect when run against the framework itself` | P2/XS | Run `gh repo view --json parent --jq '.parent'` first; if null, redirect user to `gh issue create` instead of bouncing to `/upgrade` |
+| `test(framework): CI smoke test for /report-issue non-interactive flow` | P2/S | Would have caught both bugs above. Run `bash scripts/report-issue.sh --non-interactive --severity p3 --component docs --title "smoke"` against a representative fork checkout in CI |
+
+## 7. Metrics
+
+- PRs created: 1 (this journal — `content/session-journal-2026-05-17`)
+- PRs merged: 0
+- PRs reviewed: 0
+- Tickets completed: 0
+- Tickets created: 0 (3 proposed, pending confirmation)
+- Tests added: 0
+- Board state changes: 0
+- Discovery commands run: `/report-issue`, `/upgrade`, `git remote -v`, `gh repo view --json nameWithOwner,parent`, `git log --all -- .agile-flow-meta/`
+
+## 8. Next Up
+
+1. **File the three proposed tickets in §6** against this repo after user confirmation.
+2. **Decide between landing VIB-22 vs. re-implementing.** `origin/docs/sdlc-VIB-46@ca0498e` has the scaffold. Diff against current `main` to see what drifted before fast-forwarding.
+3. **Add the CI smoke test** as part of the same delivery, not a separate ticket — pairing test + fix prevents the regression class from recurring.
+4. **Cross-check other "upstream"-aware commands** (`/upgrade`, anything that reads `.agile-flow-meta/`) for the same framework-vs-fork detection gap surfaced in §4 row 3.


### PR DESCRIPTION
## Summary

- Adds `reports/session-journals/2026-05-17.md` capturing today's discovery: `/report-issue` is unusable on `main` because `.agile-flow-meta/upstream` is required but never created by any bootstrap path.
- VIB-22 (commit `ca0498e` on `origin/docs/sdlc-VIB-46`, "Engineer (Paperclip)") scaffolded `.agile-flow-meta/` but the branch never merged — the framework still ships docs that depend on it.
- `.claude/commands/report-issue.md` line 24 misdirects users to `/upgrade` for an initialization step `scripts/template-sync.sh` does not perform.

## Findings worth triage

1. **`/report-issue` precondition gap (P1/S)** — `scripts/report-issue.sh` requires `.agile-flow-meta/upstream`; nothing on `main` creates it. Two fix paths: (a) land VIB-22 from `origin/docs/sdlc-VIB-46`, (b) initialize from `scripts/setup-solo-mode.sh` / `scripts/workshop-setup.sh`. Doc correction at `.claude/commands/report-issue.md:24` either way.
2. **No framework-vs-fork detection (P2/XS)** — `/report-issue` should call `gh repo view --json parent --jq '.parent'` first; if null, redirect to plain `gh issue create` instead of bouncing to `/upgrade`. Today's session surfaced the same confusion at the user level.
3. **No CI smoke test for `/report-issue` (P2/S)** — A non-interactive run of `scripts/report-issue.sh` against a fork-like checkout would have caught both gaps. Should pair with the fix, not file separately.

Full context, root-cause analysis, and the proposed ticket scope are in §4–§6 of the journal.

## Test plan

- [ ] Review the journal for factual accuracy (commit refs, branch names, line numbers).
- [ ] Confirm the three follow-up tickets in §6 are worth filing.
- [ ] If yes, file them as separate issues and link from this PR before merge.
- [ ] Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)