### PR TITLE
fix: sync report-issue with upstream Epic #224 improvements

### DIFF
--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -21,47 +21,49 @@ issues you own). Use it for problems that exist in the upstream framework files.
 
 ## Instructions
 
-1. **Verify `.agile-flow-meta/upstream` exists**. If the file is missing, run `/upgrade`
-   first to initialise the metadata directory.
+1. **Verify `.agile-flow-version` exists**. If the file is missing, run `/upgrade`
+   first to initialise the metadata file.
 
 2. **Gather context before running the script**. Before invoking, note:
    - What went wrong (be specific)
    - Severity: p1 (critical, blocks everyone), p2 (significant, workaround exists),
      p3 (minor or improvement)
-   - Component: provisioning, ci, claude-commands, patterns, docs, or other
+   - Component: You'll be prompted to select from available components in a two-step process
 
-3. **Run the report script**:
+3. **Validate severity input**. Before running the script, ensure the severity is one of the valid values: p1, p2, or p3. If invalid, return error: "Invalid severity. Valid options: p1, p2, p3"
+
+4. **Run the report script**:
 
    ```bash
    bash scripts/report-issue.sh
    ```
 
    The script will:
-   - Read .agile-flow-meta/upstream to identify the target repo
+   - Read .agile-flow-version to identify the target repo and version
    - Capture fork_commit (current HEAD) and upstream_version automatically
    - Prompt for severity, component, and title
    - Open your $EDITOR (or use inline input) for the description
    - Submit via gh issue create with label downstream-report
    - Fall back to clipboard copy + pre-filled browser URL if gh access is denied
 
-4. **Fill in the description**. Provide:
+5. **Fill in the description**. Provide:
    - Description: what is happening and why it is a problem
    - Steps to Reproduce: numbered list, minimal and specific
    - Expected Behaviour: what should happen
    - Actual Behaviour: what actually happens
    - Error Output: paste relevant terminal output
-   - Context: workshop date, participant count, track (Founder/GCP/AWS)
+   - Context: workshop date, participant count, track
 
-5. **Handle the exit code**:
+6. **Handle the exit code**:
 
    | Code | Meaning | Action |
    |------|---------|--------|
    | 0 | Success - issue filed or fallback URL provided | Report the issue URL to the user |
    | 1 | Error - missing config or invalid input | Show the error message and fix the root cause |
 
-6. **If gh access is denied** (fallback path):
+7. **If gh access is denied** (fallback path):
 
-   The script will save the report to .agile-flow-meta/reports/report-<timestamp>.md,
+   The script will save the report to .agile-flow-reports/report-<timestamp>.md,
    copy the body to clipboard if available, and print a pre-filled GitHub issue URL.
 
    Tell the user:
@@ -80,7 +82,7 @@ bash scripts/report-issue.sh \
 
 ## Report format reference
 
-The script generates a YAML front-matter Markdown file in .agile-flow-meta/reports/:
+The script generates a YAML front-matter Markdown file in .agile-flow-reports/:
 
 ```
 ---
@@ -94,7 +96,7 @@ title: "Provision script fails when roster has special characters"
 ---
 ```
 
-The upstream field is written automatically from .agile-flow-meta/upstream.
+The upstream field is read automatically from .agile-flow-version.
 
 ## Output Format
 
@@ -107,7 +109,7 @@ End your response with a Result Block:
 URL: https://github.com/vibeacademy/agile-flow/issues/42
 Severity: p2
 Component: provisioning
-Report: .agile-flow-meta/reports/report-20260508-143022.md
+Report: .agile-flow-reports/report-20260508-143022.md
 ```
 
 Or if fallback was used:
@@ -116,7 +118,7 @@ Or if fallback was used:
 ---
 
 **Result:** Report saved (manual submission required)
-Report: .agile-flow-meta/reports/report-20260508-143022.md
+Report: .agile-flow-reports/report-20260508-143022.md
 Browser URL: https://github.com/vibeacademy/agile-flow/issues/new?...
 ```
 
@@ -126,5 +128,5 @@ Or on error:
 ---
 
 **Result:** Error
-Reason: .agile-flow-meta/upstream not found - run /upgrade first
+Reason: .agile-flow-version not found - run /upgrade first
 ```

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -4,7 +4,10 @@
 # Usage:
 #   bash scripts/report-issue.sh
 #   bash scripts/report-issue.sh --severity p2 --component provisioning --title "short title"
+#   bash scripts/report-issue.sh --dry-run --severity p2 --component docs --title "preview test" --body "Sample body"
 #   bash scripts/report-issue.sh --non-interactive --severity p3 --component docs --title "typo in guide"
+#   bash scripts/report-issue.sh --non-interactive --severity p2 --component docs --title "bug fix" --body-file issue-body.txt
+#   bash scripts/report-issue.sh --non-interactive --severity p1 --component ci --title "build failure" --body "The CI pipeline fails consistently."
 #
 # Exit codes:
 #   0  — report filed successfully (or saved for manual submission via fallback)
@@ -12,8 +15,8 @@
 
 set -euo pipefail
 
-META_DIR=".agile-flow-meta"
-REPORTS_DIR="$META_DIR/reports"
+VERSION_FILE=".agile-flow-version"
+REPORTS_DIR=".agile-flow-reports"
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 
@@ -21,6 +24,51 @@ SEVERITY=""
 COMPONENT=""
 TITLE=""
 NON_INTERACTIVE=false
+BODY_FILE=""
+BODY=""
+FORCE_CODESPACES_TOKEN=false
+DRY_RUN=false
+
+show_help() {
+  cat <<'HELP'
+report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+
+Usage:
+  bash scripts/report-issue.sh [FLAGS]
+
+Flags:
+  --severity LEVEL       Issue severity: p1 (critical), p2 (high), p3 (low)
+  --component COMP       Component: provisioning, ci, claude-commands, patterns, docs, other
+  --title "TITLE"        Issue title (required)
+  --non-interactive      Run without prompts (requires all flags)
+  --body-file FILE       Read issue body from file (non-interactive only)
+  --body "TEXT"          Provide issue body as text (non-interactive only)
+  --dry-run              Preview what would be created without submitting
+  --force-codespaces-token  Continue despite Codespaces token limitations
+  --help, -h             Show this help message
+
+Examples:
+  # Interactive mode (prompts for inputs)
+  bash scripts/report-issue.sh
+  
+  # Preview mode (shows what would be created)
+  bash scripts/report-issue.sh --dry-run --severity p2 --component docs --title "Fix typo" --body "Sample body"
+  
+  # Non-interactive with inline body
+  bash scripts/report-issue.sh --non-interactive \
+    --severity p2 --component docs --title "Fix typo in README" \
+    --body "The README file has a spelling error on line 42."
+  
+  # Non-interactive with body from file
+  bash scripts/report-issue.sh --non-interactive \
+    --severity p1 --component ci --title "Build pipeline broken" \
+    --body-file issue-description.md
+
+Exit codes:
+  0  — Report filed successfully (or saved for manual submission via fallback)
+  1  — Error (missing config, invalid inputs)
+HELP
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -28,32 +76,48 @@ while [[ $# -gt 0 ]]; do
     --component)       COMPONENT="$2";      shift 2 ;;
     --title)           TITLE="$2";          shift 2 ;;
     --non-interactive) NON_INTERACTIVE=true; shift ;;
+    --body-file)       BODY_FILE="$2";      shift 2 ;;
+    --body)            BODY="$2";           shift 2 ;;
+    --dry-run)         DRY_RUN=true;        shift ;;
+    --force-codespaces-token) FORCE_CODESPACES_TOKEN=true; shift ;;
+    --help|-h)         show_help; exit 0 ;;
     *) echo "ERROR: Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
 
-# ── Verify .agile-flow-meta/ exists ──────────────────────────────────────────
+# ── Verify .agile-flow-version exists ──────────────────────────────────────────
 
-if [ ! -d "$META_DIR" ]; then
-  echo "ERROR: .agile-flow-meta/ directory not found." >&2
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "ERROR: .agile-flow-version file not found." >&2
   echo "This fork does not have upstream metadata. Run /upgrade to initialise." >&2
   exit 1
 fi
 
-if [ ! -f "$META_DIR/upstream" ]; then
-  echo "ERROR: .agile-flow-meta/upstream not found." >&2
+# ── Read upstream URL and version from .agile-flow-version ────────────────────
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to parse .agile-flow-version but is not installed." >&2
+  exit 1
+fi
+
+UPSTREAM_URL=$(jq -r '.upstream' "$VERSION_FILE" 2>/dev/null || echo "null")
+if [ "$UPSTREAM_URL" = "null" ] || [ -z "$UPSTREAM_URL" ]; then
+  echo "ERROR: .agile-flow-version does not contain 'upstream' field." >&2
   echo "Run /upgrade to record this fork's upstream URL." >&2
   exit 1
 fi
 
-# ── Read upstream URL and derive repo slug ────────────────────────────────────
+UPSTREAM_VERSION=$(jq -r '.version' "$VERSION_FILE" 2>/dev/null || echo "unknown")
 
-UPSTREAM_URL=$(cat "$META_DIR/upstream")
-UPSTREAM_URL="${UPSTREAM_URL%$'\n'}"  # strip trailing newline if any
-
-if [ -z "$UPSTREAM_URL" ]; then
-  echo "ERROR: .agile-flow-meta/upstream is empty." >&2
-  exit 1
+# Handle empty, null, whitespace-only, or missing version field
+if [ "$UPSTREAM_VERSION" = "null" ] || [ -z "$UPSTREAM_VERSION" ]; then
+  UPSTREAM_VERSION="unknown"
+else
+  # Strip leading and trailing whitespace, then check if empty
+  UPSTREAM_VERSION=$(echo "$UPSTREAM_VERSION" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ -z "$UPSTREAM_VERSION" ]; then
+    UPSTREAM_VERSION="unknown"
+  fi
 fi
 
 # Extract org/repo from https or git@ GitHub URLs
@@ -68,15 +132,64 @@ else
   exit 1
 fi
 
+# ── Check for Codespaces token limitations ────────────────────────────────────
+
+check_codespaces_token() {
+  local is_codespaces=false
+  local has_ghu_token=false
+  
+  # Check if we're running in GitHub Codespaces
+  if [ "${CODESPACES:-}" = "true" ]; then
+    is_codespaces=true
+  fi
+  
+  # Check for ghu_* token pattern in gh auth status or GH_TOKEN
+  if command -v gh >/dev/null 2>&1; then
+    local auth_status
+    auth_status=$(gh auth status 2>&1 || true)
+    if echo "$auth_status" | grep -q "ghu_"; then
+      has_ghu_token=true
+    fi
+  fi
+  
+  # Also check GH_TOKEN environment variable for ghu_* pattern
+  if [ -n "${GH_TOKEN:-}" ] && [[ "${GH_TOKEN:-}" =~ ^ghu_ ]]; then
+    has_ghu_token=true
+  fi
+  
+  # Warn if both conditions are met and user hasn't forced through (skip check in dry-run mode)
+  if $is_codespaces && $has_ghu_token && ! $FORCE_CODESPACES_TOKEN && ! $DRY_RUN; then
+    echo "⚠️  WARNING: Codespaces Token Limitation Detected" >&2
+    echo "" >&2
+    echo "You are running in GitHub Codespaces with a default ghu_* token." >&2
+    echo "This token cannot create issues on upstream repositories." >&2
+    echo "" >&2
+    echo "To resolve this issue:" >&2
+    echo "1. Create a Personal Access Token (PAT) at:" >&2
+    echo "   https://github.com/settings/tokens/new" >&2
+    echo "" >&2
+    echo "2. Grant these scopes:" >&2
+    echo "   • repo (Full control of private repositories)" >&2
+    echo "   • write:org (Write org and team membership)" >&2
+    echo "" >&2
+    echo "3. Set the token in your Codespace:" >&2
+    echo "   export GH_TOKEN=ghp_your_token_here" >&2
+    echo "   gh auth login --with-token <<<\"\$GH_TOKEN\"" >&2
+    echo "" >&2
+    echo "4. Re-run this script" >&2
+    echo "" >&2
+    echo "To continue anyway (advanced users only):" >&2
+    echo "   $0 --force-codespaces-token [other flags]" >&2
+    echo "" >&2
+    exit 1
+  fi
+}
+
+check_codespaces_token
+
 # ── Gather git metadata ───────────────────────────────────────────────────────
 
 FORK_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-
-UPSTREAM_VERSION="unknown"
-if [ -f "$META_DIR/version" ]; then
-  UPSTREAM_VERSION=$(cat "$META_DIR/version")
-  UPSTREAM_VERSION="${UPSTREAM_VERSION%$'\n'}"
-fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Report Issue to Upstream"
@@ -116,16 +229,49 @@ if [ -z "$COMPONENT" ]; then
     echo "ERROR: --component required in non-interactive mode." >&2
     exit 1
   fi
-  echo ""
-  echo "Component:"
-  echo "  provisioning    setup, roster, env provisioning scripts"
-  echo "  ci              GitHub Actions, CI/CD workflows"
-  echo "  claude-commands /slash commands"
-  echo "  patterns        architectural patterns and practices"
-  echo "  docs            documentation"
-  echo "  other           anything else"
-  printf "> "
-  read -r COMPONENT
+  
+  # Two-tier component selection to handle AskUserQuestion 4-option limit
+  while true; do
+    echo ""
+    echo "Component (select main components or see more):"
+    echo "  provisioning    setup, roster, env provisioning scripts"
+    echo "  ci              GitHub Actions, CI/CD workflows"
+    echo "  claude-commands /slash commands"
+    echo "  docs            documentation"
+    echo "  more            see additional components"
+    printf "> "
+    read -r COMPONENT
+    
+    case "$COMPONENT" in
+      provisioning|ci|claude-commands|docs)
+        break
+        ;;
+      more)
+        echo ""
+        echo "Additional components:"
+        echo "  patterns        architectural patterns and practices"
+        echo "  other           anything else"
+        echo "  back            return to main components"
+        printf "> "
+        read -r COMPONENT
+        
+        case "$COMPONENT" in
+          patterns|other)
+            break
+            ;;
+          back)
+            continue  # Go back to main component selection
+            ;;
+          *)
+            echo "ERROR: Please select 'patterns', 'other', or 'back'." >&2
+            ;;
+        esac
+        ;;
+      *)
+        echo "ERROR: Please select a valid component or 'more' for additional options." >&2
+        ;;
+    esac
+  done
 fi
 
 case "$COMPONENT" in
@@ -157,16 +303,57 @@ fi
 
 # Sanitise the title for safe interpolation into a YAML double-quoted scalar:
 # backslashes first, then double quotes. YAML's double-quoted form allows
-# \\ and \" as escapes, so this round-trips correctly for any title text.
+# \\\\ and \\\" as escapes, so this round-trips correctly for any title text.
 SAFE_TITLE="${TITLE//\\/\\\\}"
 SAFE_TITLE="${SAFE_TITLE//\"/\\\"}"
+
+# ── Validate body input for non-interactive mode ─────────────────────────────
+
+if $NON_INTERACTIVE; then
+  # Check that exactly one body source is provided
+  if [ -n "$BODY_FILE" ] && [ -n "$BODY" ]; then
+    echo "ERROR: Cannot specify both --body-file and --body. Choose one." >&2
+    exit 1
+  fi
+  
+  if [ -z "$BODY_FILE" ] && [ -z "$BODY" ]; then
+    echo "ERROR: --body-file or --body required in non-interactive mode." >&2
+    exit 1
+  fi
+  
+  # Validate body file if provided
+  if [ -n "$BODY_FILE" ]; then
+    if [ ! -f "$BODY_FILE" ]; then
+      echo "ERROR: Body file not found: $BODY_FILE" >&2
+      exit 1
+    fi
+    
+    if [ ! -r "$BODY_FILE" ]; then
+      echo "ERROR: Cannot read body file: $BODY_FILE" >&2
+      exit 1
+    fi
+  fi
+fi
 
 # ── Build description ─────────────────────────────────────────────────────────
 
 DESCRIPTION_FILE=$(mktemp /tmp/agile-flow-report-XXXXXX.md)
 trap 'rm -f "$DESCRIPTION_FILE"' EXIT
 
-cat > "$DESCRIPTION_FILE" <<'TEMPLATE'
+# Handle body content based on flags or interactive mode
+if [ -n "$BODY_FILE" ]; then
+  # Use provided body file
+  cp "$BODY_FILE" "$DESCRIPTION_FILE"
+elif [ -n "$BODY" ]; then
+  # Use provided body text
+  printf '%s\n' "$BODY" > "$DESCRIPTION_FILE"
+elif $NON_INTERACTIVE; then
+  # This should not happen due to earlier validation, but fail-safe
+  echo "ERROR: No body content provided in non-interactive mode." >&2
+  exit 1
+else
+  # Interactive mode: create template and let user edit
+  cat > "$DESCRIPTION_FILE" <<'TEMPLATE'
 ## Description
 
 <!-- What is the problem? Be specific. -->
@@ -197,7 +384,6 @@ cat > "$DESCRIPTION_FILE" <<'TEMPLATE'
 - Track:
 TEMPLATE
 
-if ! $NON_INTERACTIVE; then
   EDITOR="${EDITOR:-}"
   if [ -n "$EDITOR" ] && command -v "$EDITOR" >/dev/null 2>&1; then
     echo ""
@@ -243,31 +429,109 @@ REPORT
 echo "Report   : $REPORT_FILE"
 echo ""
 
+# ── Check if downstream-report label exists ────────────────────────────────────
+
+check_downstream_label() {
+  if command -v gh >/dev/null 2>&1; then
+    # Check if the downstream-report label exists in the target repo
+    if gh label list --repo "$UPSTREAM_REPO" 2>/dev/null | grep -q "downstream-report"; then
+      return 0  # Label exists
+    else
+      return 1  # Label does not exist
+    fi
+  else
+    return 1  # gh CLI not available, assume label doesn't exist
+  fi
+}
+
+# ── Dry-run preview ────────────────────────────────────────────────────────────
+
+if $DRY_RUN; then
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "=== DRY RUN PREVIEW ==="
+  echo "Issue would be created as:"
+  echo ""
+  echo "Repository: $UPSTREAM_REPO"
+  echo "Title: [downstream-report] $TITLE"
+  
+  # Check if downstream-report label exists and show what labels would be applied
+  if check_downstream_label; then
+    echo "Labels: downstream-report"
+  else
+    echo "Labels: (none - downstream-report label not found in target repo)"
+  fi
+  
+  echo ""
+  echo "Body:"
+  echo "────────────────────────────────────────────────────────"
+  cat "$REPORT_FILE"
+  echo "────────────────────────────────────────────────────────"
+  echo ""
+  echo "DRY RUN - No issue created"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 0
+fi
+
 # ── Deliver via gh issue create ───────────────────────────────────────────────
 
 ISSUE_TITLE="[downstream-report] $TITLE"
-GH_FAILED=false
 
 if command -v gh >/dev/null 2>&1; then
   echo "Submitting to $UPSTREAM_REPO..."
-  if gh issue create \
-      --repo "$UPSTREAM_REPO" \
-      --title "$ISSUE_TITLE" \
-      --label "downstream-report" \
-      --body-file "$REPORT_FILE"; then
-    echo ""
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "Issue filed successfully."
-    echo "Report saved: $REPORT_FILE"
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    exit 0
+  
+  # Check if downstream-report label exists and create issue accordingly
+  if check_downstream_label; then
+    # Create issue with label - capture stderr for better error reporting
+    set +e  # Temporarily disable exit on error to capture output
+    error_output=$(gh issue create \
+        --repo "$UPSTREAM_REPO" \
+        --title "$ISSUE_TITLE" \
+        --label "downstream-report" \
+        --body-file "$REPORT_FILE" 2>&1)
+    gh_exit_code=$?
+    set -e  # Re-enable exit on error
+    if [ $gh_exit_code -eq 0 ]; then
+      echo ""
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "Issue filed successfully."
+      echo "Report saved: $REPORT_FILE"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      exit 0
+    else
+      echo "" >&2
+      if [ -n "$error_output" ]; then
+        echo "WARNING: Issue creation failed: $error_output. Falling back to manual submission." >&2
+      else
+        echo "WARNING: Issue creation failed. Falling back to manual submission." >&2
+      fi
+    fi
   else
-    GH_FAILED=true
-    echo "" >&2
-    echo "WARNING: gh issue create failed. Falling back to manual submission." >&2
+    # Create issue without label - capture stderr for better error reporting
+    echo "Warning: 'downstream-report' label not found, creating issue without label" >&2
+    set +e  # Temporarily disable exit on error to capture output
+    error_output=$(gh issue create \
+        --repo "$UPSTREAM_REPO" \
+        --title "$ISSUE_TITLE" \
+        --body-file "$REPORT_FILE" 2>&1)
+    gh_exit_code=$?
+    set -e  # Re-enable exit on error
+    if [ $gh_exit_code -eq 0 ]; then
+      echo ""
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "Issue filed successfully."
+      echo "Report saved: $REPORT_FILE"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      exit 0
+    else
+      echo "" >&2
+      if [ -n "$error_output" ]; then
+        echo "WARNING: Issue creation failed: $error_output. Falling back to manual submission." >&2
+      else
+        echo "WARNING: Issue creation failed. Falling back to manual submission." >&2
+      fi
+    fi
   fi
 else
-  GH_FAILED=true
   echo "gh CLI not found. Falling back to manual submission." >&2
 fi
 
@@ -280,7 +544,11 @@ if command -v python3 >/dev/null 2>&1; then
   ENCODED_BODY=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(open(sys.argv[1]).read()))" "$REPORT_FILE" 2>/dev/null || echo "")
 fi
 
-BROWSER_URL="https://github.com/${UPSTREAM_REPO}/issues/new?title=${ENCODED_TITLE}&body=${ENCODED_BODY}&labels=downstream-report"
+# Build URL with conditional label parameter
+BROWSER_URL="https://github.com/${UPSTREAM_REPO}/issues/new?title=${ENCODED_TITLE}&body=${ENCODED_BODY}"
+if check_downstream_label; then
+  BROWSER_URL="${BROWSER_URL}&labels=downstream-report"
+fi
 
 # Try clipboard
 CLIPBOARD_CMD=""


### PR DESCRIPTION
Synced from vibeacademy/agile-flow:
- #225: unified metadata to .agile-flow-version
- #226: --body-file and --body flags
- #227: Codespaces ghu_* token detection
- #228: downstream-report label optional
- #229: --dry-run flag for preview
- #230: stderr surfacing in fallback
- #231: severity validation in skill
- #232: 4-option component menu
- #234: stdin docs

**Files synced:**
- `scripts/report-issue.sh`
- `.claude/commands/report-issue.md`