### PR TITLE
docs: remove stale auto-fix.yml references after upstream deletion

### DIFF
--- a/.claude/commands/bootstrap-workflow.md
+++ b/.claude/commands/bootstrap-workflow.md
@@ -82,9 +82,9 @@ Before running this phase, ensure you have:
 Before any board or ticket operations, verify the following. STOP and report
 to the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.

--- a/.claude/commands/create-ticket.md
+++ b/.claude/commands/create-ticket.md
@@ -9,9 +9,9 @@ Create a new ticket on the project board with guided workflow.
 Before creating any ticket, verify the following. STOP and report to the user
 if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -12,8 +12,9 @@ Before any work, verify the following. STOP and report if any check fails.
 1. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.
-2. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call. If the
-   MCP server is not connected, STOP.
+2. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 
 ## When to Use This Command
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -89,24 +89,6 @@ Any of these findings result in an immediate NO-GO recommendation:
 | Direct commits to main | Process — all changes go through feature branches |
 | Missing tests for new functionality | Quality — untested code is unverifiable |
 | Type errors or unresolved imports | Quality — code does not compile/run correctly |
-| Architecture-level changes without ADR reference | Governance — architectural decisions must be explicit and traceable |
-
-### Architecture ADR Check
-
-Flag as **NO-GO** when a PR changes architecture-level files without a referenced ADR in the PR body/checklist.
-
-Treat these paths as architecture-level for this repository:
-
-- `scripts/template-sync.sh`
-- `scripts/lib/overrides.sh`
-- `scripts/pull-upstream.sh`
-- `.github/workflows/**`
-
-Reviewer check:
-
-1. Inspect changed files for any path above.
-2. If matched, verify the PR explicitly references an ADR (for example `ADR-001`, `docs/adr/0001-...`, or a new ADR in `docs/adr/`).
-3. If no ADR reference exists, mark **NO-GO** and request ADR linkage before approval.
 
 ### When to Request Changes vs Comment
 

--- a/.claude/commands/work-ticket.md
+++ b/.claude/commands/work-ticket.md
@@ -11,9 +11,9 @@ Launch the github-ticket-worker agent to implement the next prioritized ticket.
 Before starting work on any ticket, verify the following. STOP and report to
 the user if any check fails — do not continue with partial tooling.
 
-1. **MCP GitHub server is reachable** — Attempt a GitHub MCP tool call (e.g.,
-   list repos). If the MCP server is not connected, STOP. Do not fall back to
-   CLI-only mode silently.
+1. **`gh` CLI is authenticated and the repository is accessible** — Run
+   `gh auth status` and `gh repo view --json nameWithOwner`. If either fails,
+   STOP and instruct the user to fix the issue.
 2. **GitHub account is correct** — Run `gh auth status` and confirm the active
    account matches the expected worker/bot account. If only a personal account
    is active, STOP and instruct the user to run `scripts/ensure-github-account.sh`.

--- a/.claude/hooks/ensure-github-account.sh
+++ b/.claude/hooks/ensure-github-account.sh
@@ -26,6 +26,20 @@ tool_name=$(echo "$input" | jq -r '.tool_name // empty')
 tool_command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Determine required account based on tool
+#
+# Routing rules (narrow on purpose):
+#   - `gh pr create`                     -> WORKER   (PR authorship)
+#   - `gh pr review` / `gh pr comment`   -> REVIEWER (PR approval / review comments)
+#   - all other gh commands              -> passthrough (no enforcement)
+#
+# Why so narrow: command patterns alone cannot reliably distinguish
+# "issue created during work" (worker) from "issue created during review
+# as a follow-up" (reviewer). The same applies to `gh project item-*`
+# board moves. Slash commands that need a specific account (e.g. the
+# reviewer when `/review-pr` files a follow-up ticket) are responsible
+# for calling `gh auth switch --user <account>` explicitly before
+# those operations. This hook only enforces the two cases where the
+# command name itself is unambiguous about which account should own it.
 required_account=""
 case "$tool_name" in
   Bash)
@@ -33,7 +47,7 @@ case "$tool_name" in
       *"gh pr create"*)
         required_account="$WORKER_ACCOUNT"
         ;;
-      *"gh pr review"*)
+      *"gh pr review"*|*"gh pr comment"*)
         required_account="$REVIEWER_ACCOUNT"
         ;;
       *)

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -116,7 +116,6 @@ upstream when the framework updates:
 - `.claude/skills/*`
 - `.claude/settings.template.json`
 - `.github/workflows/ci.yml` (language-agnostic, auto-detects stack)
-- `.github/workflows/auto-fix.yml`
 - `.github/workflows/auto-review.yml`
 - `.github/workflows/auto-triage.yml`
 - `.github/workflows/agent-audit-report.yml`

--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -14,7 +14,6 @@ required secrets, and default states. This fork targets **GCP Cloud Run
 | Preview Deploy | `preview-deploy.yml` | PR opened/updated | Inert | Same as Deploy, plus `NEON_API_KEY`, `NEON_PROJECT_ID` |
 | Preview Cleanup | `preview-cleanup.yml` | PR closed | Inert | Same as Preview Deploy |
 | Auto Review | `auto-review.yml` | PR opened/ready | Active | None |
-| Auto Fix | `auto-fix.yml` | PR opened/updated | Active | None |
 | Rollback | `rollback-production.yml` | Manual dispatch | Inert | Same as Deploy |
 
 Neon secrets are optional — if not configured, preview deploys will use
@@ -59,17 +58,6 @@ Triggers when a `v*` tag is pushed. Extracts the matching section from
 
 Posts a review reminder comment on new PRs, prompting the team to run
 `/review-pr` for an agent review.
-
-### Auto Fix (`auto-fix.yml`)
-
-Automatically fixes lint issues on PR branches. Detects the project
-type and runs the appropriate fixer:
-
-- **Python** (when `pyproject.toml` exists): runs `ruff check --fix`
-  and `ruff format`
-- **Node.js** (when `package.json` exists): runs `npx eslint . --fix`
-
-Fixed files are committed back to the PR branch automatically.
 
 ## Enable When Ready
 
@@ -216,7 +204,6 @@ Autogeneration is a starting point, not a final answer.
 | `python` tests fail | Test failures or coverage below threshold | Fix tests or lower `COVERAGE_THRESHOLD` |
 | `lint-agent-policies` fails | Agent file missing safety phrases | Check `scripts/verify-agent-restrictions.sh` output |
 | `build` fails | Shell script errors | Run `shellcheck <script>` locally |
-| `auto-fix` skips your stack | No fixer detected | Ensure `package.json` (Node.js) or `pyproject.toml` (Python) exists in the repo root |
 
 ### Secret-Gated Workflows Show "Skipped"
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -72,7 +72,6 @@ Content **outside** markers in hybrid files is user-owned. Content
 |------|----------|-----------|-----------------|
 | `ci.yml` | framework | Standard CI pipeline | Overwrite |
 | `agent-audit-report.yml` | framework | Agent action audit | Overwrite |
-| `auto-fix.yml` | framework | Auto-fix workflow | Overwrite |
 | `auto-review.yml` | framework | Auto-review workflow | Overwrite |
 | `auto-triage.yml` | framework | Error triage workflow | Overwrite |
 | `release.yml` | framework | Release workflow | Overwrite |

--- a/docs/LEAN-PRINCIPLES.md
+++ b/docs/LEAN-PRINCIPLES.md
@@ -19,7 +19,7 @@ is a way that code generation decouples from value delivery.
 | Overproduction | Extra Features | PM/PO gate, scope lock, feature evaluation |
 | Extra Processing | Relearning | Memory MCP, 4 Power Sections, session journals |
 | Transportation | Handoffs | Structured interfaces, review templates, account hooks |
-| Waiting | Delays | Pull-based Ready column, CI auto-fix, bot accounts |
+| Waiting | Delays | Pull-based Ready column, pre-push lint hooks, bot accounts |
 | Motion | Task Switching | Single-piece flow, focused agent sessions |
 | Defects | Defects | Shift-left testing, red flags, CI gates, pre-push hooks |
 
@@ -151,7 +151,7 @@ human review bandwidth.
 | Practice | How it helps |
 |----------|-------------|
 | Ready column always stocked (2-5 items) | Worker never waits for work to be defined |
-| CI auto-fix protocol (up to 3 retries) | Agent does not wait for human to fix lint errors |
+| Pre-push lint hooks (`scripts/hooks/`) | Lint errors caught locally before push; no CI round-trip |
 | Bot accounts | No waiting for human to switch contexts to do routine GitHub operations |
 | PR reviewer agent | Review starts immediately, not when a human has time |
 | `/sprint-status` wait detection | Surfaces items stuck in review too long |

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -527,10 +527,10 @@ billing in exchange for zero per-attendee setup. See #104 for
 the research on this model.
 
 **If you wire Claude into a CI workflow** (none of the framework's
-shipped workflows currently do — `auto-review.yml`, `auto-fix.yml`,
-and `auto-triage.yml` are trigger scaffolding that post comments
-inviting the user to invoke `/review-pr` etc. locally; they do not
-call the Anthropic API), the `ANTHROPIC_API_KEY` your custom
+shipped workflows currently do — `auto-review.yml` and `auto-triage.yml`
+are trigger scaffolding that post comments inviting the user to invoke
+`/review-pr` etc. locally; they do not call the Anthropic API), the
+`ANTHROPIC_API_KEY` your custom
 workflow consumes IS an Actions secret. The two stores are
 independent — set both if your fork ends up needing Claude Code
 in both Codespaces and CI.

--- a/scripts/setup-accounts.sh
+++ b/scripts/setup-accounts.sh
@@ -187,6 +187,8 @@ if [ -z "${AGILE_FLOW_WORKER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_WORKER_ACCOUNT:-}"
     echo ""
     echo "  Worker account: ${worker_account}"
     echo ""
+    echo "  Required PAT scopes (classic): repo, workflow, project, gist, read:org"
+    echo ""
     read -s -p "  Paste your WORKER PAT: " worker_pat
     echo ""
 
@@ -257,6 +259,13 @@ fi
 if [ -z "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" ] || [ "${AGILE_FLOW_REVIEWER_ACCOUNT:-}" != "$reviewer_account" ]; then
     echo ""
     echo "  Reviewer account: ${reviewer_account}"
+    echo ""
+    echo "  Required PAT scopes (classic): repo, workflow, project, gist, read:org"
+    echo "  NOTE: 'project' scope is required so the reviewer can file"
+    echo "        follow-up issues onto the project board after /review-pr."
+    echo "        If you have an existing PAT without 'project', upgrade with:"
+    echo "          gh auth refresh --user ${reviewer_account} \\"
+    echo "            --scopes repo,workflow,project,gist,read:org"
     echo ""
     read -s -p "  Paste your REVIEWER PAT: " reviewer_pat
     echo ""

--- a/scripts/test-dirty-fork.sh
+++ b/scripts/test-dirty-fork.sh
@@ -1,0 +1,475 @@
+#!/bin/bash
+#
+# test-dirty-fork.sh — Simulate various fork states for upgrade testing
+#
+# Creates realistic "dirty" states that a user might have before running
+# /upgrade, without going through the full bootstrap process.
+#
+# Usage:
+#   bash scripts/test-dirty-fork.sh <scenario>
+#
+# Scenarios:
+#   post-bootstrap-product  — User completed /bootstrap-product (has PRODUCT-*.md)
+#   post-bootstrap-full     — User completed full bootstrap (product + architecture + workflow)
+#   modified-agents         — User has customized agent definitions
+#   modified-commands       — User has customized command files
+#   has-overrides           — User has .agile-flow-overrides configured
+#   uncommitted-framework   — User has uncommitted changes in framework files
+#   uncommitted-userland    — User has uncommitted changes in user content only
+#   mid-feature             — User is mid-feature branch with changes
+#   stale-version           — User is on an old upstream version
+#   mixed-mess              — Combination of multiple scenarios (stress test)
+#   clean                   — Reset to clean state
+#   list                    — Show all scenarios
+#
+# Exit codes:
+#   0 — scenario applied successfully
+#   1 — error or unknown scenario
+
+set -euo pipefail
+
+SCENARIO="${1:-list}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Ensure we're in a git repo
+ensure_git_repo() {
+  if [ ! -d ".git" ]; then
+    log_error "Not in a git repository. Run from repo root."
+    exit 1
+  fi
+}
+
+# Safety warning for destructive scenarios
+warn_will_modify() {
+  log_warn "⚠️  This will modify your working tree!"
+  log_warn "Run in a TEST FORK, not your main development repo."
+  log_warn "Press Ctrl+C within 3 seconds to abort..."
+  sleep 3
+}
+
+# Scenario: post-bootstrap-product
+# Simulates user who ran /bootstrap-product
+scenario_post_bootstrap_product() {
+  log_info "Applying scenario: post-bootstrap-product"
+  
+  mkdir -p docs
+  
+  cat > docs/PRODUCT-DEFINITION.md << 'EOF'
+# Product Definition
+
+## Vision
+A SaaS platform for small business inventory management.
+
+## Target Users
+- Small retail store owners
+- E-commerce sellers managing physical inventory
+- Warehouse managers at SMBs
+
+## Core Problem
+Manual inventory tracking leads to stockouts, overstocking, and lost sales.
+
+## Key Features
+1. Real-time inventory tracking
+2. Low stock alerts
+3. Multi-location support
+4. Barcode scanning
+5. Sales integration
+
+## Success Metrics
+- Reduce stockouts by 50%
+- Save 5 hours/week on inventory tasks
+- 95% inventory accuracy
+
+## MVP Scope
+- Single location inventory tracking
+- Manual entry + barcode scan
+- Low stock email alerts
+- Basic reporting dashboard
+EOF
+
+  cat > docs/PRODUCT-ROADMAP.md << 'EOF'
+# Product Roadmap
+
+## Phase 1: MVP (Weeks 1-4)
+- [ ] User authentication
+- [ ] Product catalog CRUD
+- [ ] Inventory count management
+- [ ] Low stock alerts
+- [ ] Basic dashboard
+
+## Phase 2: Growth (Weeks 5-8)
+- [ ] Barcode scanning
+- [ ] Bulk import/export
+- [ ] Multi-user support
+- [ ] Advanced reporting
+
+## Phase 3: Scale (Weeks 9-12)
+- [ ] Multi-location
+- [ ] API integrations
+- [ ] Mobile app
+- [ ] Forecasting
+EOF
+
+  git add docs/PRODUCT-*.md 2>/dev/null || true
+  log_info "Created PRODUCT-DEFINITION.md and PRODUCT-ROADMAP.md"
+}
+
+# Scenario: post-bootstrap-full
+# Simulates user who completed full bootstrap
+scenario_post_bootstrap_full() {
+  log_info "Applying scenario: post-bootstrap-full"
+  
+  # First apply product bootstrap
+  scenario_post_bootstrap_product
+  
+  # Add architecture artifacts
+  cat > docs/ARCHITECTURE.md << 'EOF'
+# System Architecture
+
+## Tech Stack
+- Frontend: Next.js 14 + TypeScript
+- Backend: Next.js API Routes
+- Database: Supabase (PostgreSQL)
+- Auth: Supabase Auth
+- Hosting: Vercel
+
+## Data Model
+- users (id, email, name, created_at)
+- products (id, user_id, name, sku, description)
+- inventory (id, product_id, quantity, location)
+- alerts (id, user_id, product_id, threshold, enabled)
+
+## API Structure
+- /api/auth/* - Authentication endpoints
+- /api/products/* - Product CRUD
+- /api/inventory/* - Inventory management
+- /api/alerts/* - Alert configuration
+EOF
+
+  # Add some initial tickets (simulating workflow bootstrap)
+  mkdir -p .github/ISSUE_TEMPLATE
+  
+  git add docs/ARCHITECTURE.md .github/ 2>/dev/null || true
+  log_info "Created architecture docs and workflow artifacts"
+}
+
+# Scenario: modified-agents
+# Simulates user who customized agent definitions
+scenario_modified_agents() {
+  log_info "Applying scenario: modified-agents"
+  
+  if [ -f ".claude/agents/github-ticket-worker.md" ]; then
+    # Add custom section to worker
+    {
+      echo ""
+      echo "## Custom Team Guidelines"
+      echo ""
+      echo "- Always use TypeScript strict mode"
+      echo "- Prefer functional components over class components"
+      echo "- Use Tailwind CSS for styling"
+      echo "- All API routes must have Zod validation"
+    } >> .claude/agents/github-ticket-worker.md
+    
+    git add .claude/agents/github-ticket-worker.md 2>/dev/null || true
+    log_info "Modified github-ticket-worker.md with custom guidelines"
+  else
+    log_warn "Agent file not found, skipping"
+  fi
+}
+
+# Scenario: modified-commands
+# Simulates user who customized command files
+scenario_modified_commands() {
+  log_info "Applying scenario: modified-commands"
+  
+  if [ -f ".claude/commands/work-ticket.md" ]; then
+    # Add custom section
+    {
+      echo ""
+      echo "## Team-Specific Workflow"
+      echo ""
+      echo "Before starting work:"
+      echo "1. Check #dev-standup Slack for blockers"
+      echo "2. Verify Figma designs are approved"
+      echo "3. Update ticket status in Linear"
+    } >> .claude/commands/work-ticket.md
+    
+    git add .claude/commands/work-ticket.md 2>/dev/null || true
+    log_info "Modified work-ticket.md with custom workflow"
+  else
+    log_warn "Command file not found, skipping"
+  fi
+}
+
+# Scenario: has-overrides
+# Simulates user who configured overrides
+scenario_has_overrides() {
+  log_info "Applying scenario: has-overrides"
+  
+  cat > .agile-flow-overrides << 'EOF'
+# Files that should not be overwritten during /upgrade
+# One path per line, relative to repo root
+
+# Custom agent modifications
+.claude/agents/github-ticket-worker.md
+.claude/agents/pr-reviewer.md
+
+# Team-specific commands
+.claude/commands/work-ticket.md
+
+# Custom CI workflow
+.github/workflows/custom-deploy.yml
+EOF
+
+  git add .agile-flow-overrides 2>/dev/null || true
+  log_info "Created .agile-flow-overrides with protected paths"
+}
+
+# Scenario: uncommitted-framework
+# Simulates uncommitted changes in framework-controlled files
+scenario_uncommitted_framework() {
+  log_info "Applying scenario: uncommitted-framework"
+  
+  if [ -f "scripts/doctor.sh" ]; then
+    echo "# Local debug modification" >> scripts/doctor.sh
+    echo "echo 'DEBUG: Running modified doctor'" >> scripts/doctor.sh
+    log_info "Modified scripts/doctor.sh (uncommitted)"
+  fi
+  
+  if [ -f ".claude/agents/pr-reviewer.md" ]; then
+    echo "" >> .claude/agents/pr-reviewer.md
+    echo "<!-- Local testing note -->" >> .claude/agents/pr-reviewer.md
+    log_info "Modified pr-reviewer.md (uncommitted)"
+  fi
+  
+  log_warn "Framework files modified but NOT staged/committed"
+}
+
+# Scenario: uncommitted-userland
+# Simulates uncommitted changes in user content only
+scenario_uncommitted_userland() {
+  log_info "Applying scenario: uncommitted-userland"
+  
+  mkdir -p app/components
+  cat > app/components/Button.tsx << 'EOF'
+// Work in progress - do not commit yet
+export function Button({ children }: { children: React.ReactNode }) {
+  return (
+    <button className="bg-blue-500 text-white px-4 py-2 rounded">
+      {children}
+    </button>
+  );
+}
+EOF
+
+  mkdir -p docs
+  echo "# WIP: API Documentation" > docs/API.md
+  echo "" >> docs/API.md
+  echo "TODO: Document all endpoints" >> docs/API.md
+  
+  log_info "Created uncommitted user content (app/, docs/)"
+  log_warn "User files modified but NOT staged/committed"
+}
+
+# Scenario: mid-feature
+# Simulates being mid-feature branch
+scenario_mid_feature() {
+  log_info "Applying scenario: mid-feature"
+  
+  # Create and switch to feature branch
+  BRANCH_NAME="feature/test-user-auth-$(date +%s)"
+  git checkout -b "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+  
+  # Add some feature work
+  mkdir -p app/auth
+  cat > app/auth/login.tsx << 'EOF'
+'use client';
+
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: Implement actual auth
+    console.log('Login attempt:', email);
+  };
+  
+  return (
+    <form onSubmit={handleSubmit}>
+      <input 
+        type="email" 
+        value={email} 
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <input 
+        type="password" 
+        value={password} 
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      <button type="submit">Login</button>
+    </form>
+  );
+}
+EOF
+
+  git add app/auth/
+  git commit -m "WIP: Add login page skeleton" 2>/dev/null || true
+  
+  # Add more uncommitted work
+  echo "// More WIP" >> app/auth/login.tsx
+  
+  log_info "Created feature branch: $BRANCH_NAME"
+  log_info "Has 1 commit + uncommitted changes"
+}
+
+# Scenario: stale-version
+# Simulates being on an old upstream version
+scenario_stale_version() {
+  log_info "Applying scenario: stale-version"
+  
+  if [ -f ".agile-flow-meta/version" ]; then
+    echo "v0.9.0" > .agile-flow-meta/version
+    git add .agile-flow-meta/version 2>/dev/null || true
+    log_info "Set .agile-flow-meta/version to v0.9.0 (stale)"
+  else
+    mkdir -p .agile-flow-meta
+    echo "v0.9.0" > .agile-flow-meta/version
+    log_info "Created .agile-flow-meta/version at v0.9.0 (stale)"
+  fi
+}
+
+# Scenario: mixed-mess
+# Combination stress test
+scenario_mixed_mess() {
+  log_info "Applying scenario: mixed-mess (stress test)"
+  
+  scenario_post_bootstrap_full
+  scenario_modified_agents
+  scenario_has_overrides
+  scenario_stale_version
+  scenario_uncommitted_userland
+  
+  log_warn "Applied multiple scenarios - this is a stress test state"
+}
+
+# Reset to clean state
+scenario_clean() {
+  log_info "Resetting to clean state"
+  
+  # Discard uncommitted changes
+  git checkout -- . 2>/dev/null || true
+  git clean -fd 2>/dev/null || true
+  
+  # Return to main
+  git checkout main 2>/dev/null || git checkout master 2>/dev/null || true
+  
+  # Delete test branches
+  git branch | grep "feature/test-" | xargs -r git branch -D 2>/dev/null || true
+  
+  log_info "Cleaned up test artifacts"
+}
+
+# List all scenarios
+list_scenarios() {
+  echo ""
+  echo "Available scenarios:"
+  echo ""
+  echo "  post-bootstrap-product  — User completed /bootstrap-product (has PRODUCT-*.md)"
+  echo "  post-bootstrap-full     — User completed full bootstrap (product + architecture)"
+  echo "  modified-agents         — User has customized agent definitions"
+  echo "  modified-commands       — User has customized command files"
+  echo "  has-overrides           — User has .agile-flow-overrides configured"
+  echo "  uncommitted-framework   — User has uncommitted changes in framework files"
+  echo "  uncommitted-userland    — User has uncommitted changes in user content only"
+  echo "  mid-feature             — User is mid-feature branch with changes"
+  echo "  stale-version           — User is on an old upstream version"
+  echo "  mixed-mess              — Combination of multiple scenarios (stress test)"
+  echo "  clean                   — Reset to clean state"
+  echo ""
+  echo "Usage: bash scripts/test-dirty-fork.sh <scenario>"
+  echo ""
+}
+
+# Main dispatch
+main() {
+  case "$SCENARIO" in
+    post-bootstrap-product)
+      ensure_git_repo
+      warn_will_modify
+      scenario_post_bootstrap_product
+      ;;
+    post-bootstrap-full)
+      ensure_git_repo
+      warn_will_modify
+      scenario_post_bootstrap_full
+      ;;
+    modified-agents)
+      ensure_git_repo
+      warn_will_modify
+      scenario_modified_agents
+      ;;
+    modified-commands)
+      ensure_git_repo
+      warn_will_modify
+      scenario_modified_commands
+      ;;
+    has-overrides)
+      ensure_git_repo
+      warn_will_modify
+      scenario_has_overrides
+      ;;
+    uncommitted-framework)
+      ensure_git_repo
+      warn_will_modify
+      scenario_uncommitted_framework
+      ;;
+    uncommitted-userland)
+      ensure_git_repo
+      warn_will_modify
+      scenario_uncommitted_userland
+      ;;
+    mid-feature)
+      ensure_git_repo
+      warn_will_modify
+      scenario_mid_feature
+      ;;
+    stale-version)
+      ensure_git_repo
+      warn_will_modify
+      scenario_stale_version
+      ;;
+    mixed-mess)
+      ensure_git_repo
+      warn_will_modify
+      scenario_mixed_mess
+      ;;
+    clean)
+      ensure_git_repo
+      scenario_clean
+      ;;
+    list|--help|-h|"")
+      list_scenarios
+      ;;
+    *)
+      log_error "Unknown scenario: $SCENARIO"
+      list_scenarios
+      exit 1
+      ;;
+  esac
+}
+
+main

--- a/scripts/test-upgrade-cycle.sh
+++ b/scripts/test-upgrade-cycle.sh
@@ -1,0 +1,606 @@
+#!/bin/bash
+#
+# test-upgrade-cycle.sh — Automated upgrade cycle testing
+#
+# Tests the /upgrade flow against various dirty fork states.
+# Creates isolated temp directories, applies scenarios, runs upgrade,
+# and validates outcomes.
+#
+# Usage:
+#   bash scripts/test-upgrade-cycle.sh                    # Run all scenarios
+#   bash scripts/test-upgrade-cycle.sh <scenario>         # Run specific scenario
+#   bash scripts/test-upgrade-cycle.sh --list             # List scenarios
+#
+# Exit codes:
+#   0 — All tests passed
+#   1 — One or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_WORKDIR="${TEST_WORKDIR:-/tmp/agile-flow-upgrade-tests}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1" >&2; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+
+# Test results tracking
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+declare -a FAILED_TESTS=()
+
+# Safety check: refuse to run if host repo is dirty
+check_host_repo_clean() {
+  cd "$REPO_ROOT" || exit 1
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    log_fail "Host repo has uncommitted changes. Commit or stash before running tests."
+    log_fail "This prevents test scenarios from accidentally polluting your working tree."
+    exit 1
+  fi
+}
+
+# Initialize a fresh test fork
+# IMPORTANT: This function outputs ONLY the test_dir path to stdout.
+# All other output goes to stderr to prevent $() capture pollution.
+init_test_fork() {
+  local test_name="$1"
+  local test_dir="$TEST_WORKDIR/$test_name"
+  
+  # Always start from repo root to ensure consistent cwd
+  cd "$REPO_ROOT" || exit 1
+  
+  rm -rf "$test_dir"
+  mkdir -p "$test_dir"
+  
+  # Copy repo (excluding .git to simulate fresh clone, then re-init)
+  rsync -a --exclude='.git' --exclude='node_modules' --exclude='.venv' \
+    "$REPO_ROOT/" "$test_dir/" 2>&1 >&2
+  
+  cd "$test_dir" || exit 1
+  
+  # Suppress all git output - only the path should go to stdout
+  git init -q >/dev/null 2>&1
+  git add -A >/dev/null 2>&1
+  git commit -q -m "Initial fork state" >/dev/null 2>&1 || true
+  
+  # Set up as downstream fork
+  mkdir -p .agile-flow-meta
+  echo "vibeacademy/agile-flow" > .agile-flow-meta/upstream
+  echo "v1.0.8" > .agile-flow-meta/version  # Start one version behind
+  
+  git add .agile-flow-meta >/dev/null 2>&1
+  git commit -q -m "Configure as downstream fork" >/dev/null 2>&1 || true
+  
+  # Return to repo root before outputting path
+  cd "$REPO_ROOT" || exit 1
+  
+  # Output ONLY the path - this is what $() captures
+  echo "$test_dir"
+}
+
+# Validate we're in the expected directory before writing files
+assert_cwd() {
+  local expected="$1"
+  local actual
+  actual=$(pwd)
+  if [ "$actual" != "$expected" ]; then
+    log_fail "CWD assertion failed: expected '$expected', got '$actual'"
+    log_fail "Refusing to write to prevent host repo pollution"
+    exit 1
+  fi
+}
+
+# Apply a dirty scenario (inline, not calling external script)
+apply_scenario() {
+  local scenario="$1"
+  local test_dir="$2"
+  
+  # Safety: assert we're in the test directory, not host repo
+  assert_cwd "$test_dir"
+  
+  case "$scenario" in
+    post-bootstrap-product)
+      mkdir -p docs
+      cat > docs/PRODUCT-DEFINITION.md << 'PDEOF'
+# Product Definition
+## Vision
+Test product for upgrade testing.
+## Target Users
+- Developers testing upgrade flows
+PDEOF
+      cat > docs/PRODUCT-ROADMAP.md << 'PREOF'
+# Product Roadmap
+## Phase 1
+- [ ] Test upgrade flow
+PREOF
+      git add docs/PRODUCT-*.md >/dev/null 2>&1
+      git commit -q -m "Complete bootstrap-product" >/dev/null 2>&1 || true
+      ;;
+      
+    modified-agents)
+      if [ -f ".claude/agents/github-ticket-worker.md" ]; then
+        {
+          echo ""
+          echo "## Custom Team Guidelines"
+          echo "- Use TypeScript strict mode"
+          echo "- Prefer functional components"
+        } >> .claude/agents/github-ticket-worker.md
+        git add .claude/agents/github-ticket-worker.md >/dev/null 2>&1
+        git commit -q -m "Add custom agent guidelines" >/dev/null 2>&1 || true
+      fi
+      ;;
+      
+    has-overrides)
+      cat > .agile-flow-overrides << 'OVEOF'
+# Protected files
+.claude/agents/github-ticket-worker.md
+.claude/commands/work-ticket.md
+OVEOF
+      git add .agile-flow-overrides >/dev/null 2>&1
+      git commit -q -m "Configure overrides" >/dev/null 2>&1 || true
+      ;;
+      
+    uncommitted-framework)
+      if [ -f "scripts/doctor.sh" ]; then
+        echo "# DEBUG: test modification" >> scripts/doctor.sh
+      fi
+      # Don't commit - leave dirty
+      ;;
+      
+    uncommitted-userland)
+      mkdir -p app/components
+      echo "// WIP component" > app/components/Button.tsx
+      # Don't commit - leave dirty
+      ;;
+      
+    stale-version)
+      echo "v0.9.0" > .agile-flow-meta/version
+      git add .agile-flow-meta/version >/dev/null 2>&1
+      git commit -q -m "Set stale version" >/dev/null 2>&1 || true
+      ;;
+      
+    clean)
+      # Already clean from init
+      ;;
+      
+    *)
+      log_warn "Unknown scenario: $scenario"
+      return 1
+      ;;
+  esac
+}
+
+# Run upgrade and capture results
+run_upgrade() {
+  local test_dir="$1"
+  local output_file="$test_dir/.upgrade-output.txt"
+  local exit_code
+  
+  cd "$test_dir" || exit 1
+  
+  # Run template-sync.sh and capture output
+  if [ -f "scripts/template-sync.sh" ]; then
+    bash scripts/template-sync.sh > "$output_file" 2>&1 || true
+    exit_code=$?
+  else
+    echo "ERROR: template-sync.sh not found" > "$output_file"
+    exit_code=127
+  fi
+  
+  # Return to repo root after running upgrade
+  cd "$REPO_ROOT" || exit 1
+  
+  echo "$exit_code"
+}
+
+# Validation functions
+
+check_no_conflict_markers() {
+  local test_dir="$1"
+  # Use regex anchored at line start to avoid matching grep patterns in scripts
+  # Exclude the test script itself from the search
+  if grep -rE '^<{7} ' "$test_dir" \
+       --include="*.md" --include="*.sh" \
+       --exclude="test-upgrade-cycle.sh" \
+       --exclude="test-dirty-fork.sh" \
+       2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
+check_version_updated() {
+  local test_dir="$1"
+  # Don't hardcode version - check that it's different from the starting v1.0.8
+  # and that it looks like a valid version tag
+  local actual_version
+  
+  if [ -f "$test_dir/.agile-flow-meta/version" ]; then
+    actual_version=$(cat "$test_dir/.agile-flow-meta/version")
+    # Version should be updated from starting v1.0.8 and match vX.Y.Z pattern
+    if [ "$actual_version" != "v1.0.8" ] && [[ "$actual_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+check_overrides_preserved() {
+  local test_dir="$1"
+  local override_file="$2"
+  
+  # If override was configured and file exists, check it wasn't overwritten
+  if [ -f "$test_dir/.agile-flow-overrides" ] && [ -f "$test_dir/$override_file" ]; then
+    # Check if custom content still exists
+    grep -q "Custom Team Guidelines" "$test_dir/$override_file" 2>/dev/null
+  else
+    return 0  # No override to check
+  fi
+}
+
+check_userland_untouched() {
+  local test_dir="$1"
+  
+  # If user content exists, verify it wasn't deleted
+  if [ -d "$test_dir/app/components" ]; then
+    [ -f "$test_dir/app/components/Button.tsx" ]
+  else
+    return 0
+  fi
+}
+
+check_upgrade_blocked() {
+  local output_file="$1"
+  grep -q "uncommitted changes" "$output_file" 2>/dev/null || \
+  grep -q "refusing to upgrade" "$output_file" 2>/dev/null
+}
+
+# Test case runner
+run_test_case() {
+  local test_name="$1"
+  local scenario="$2"
+  local expect_success="$3"  # true/false
+  shift 3
+  local validations=("$@")
+  
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log_info "Running test: $test_name"
+  
+  # Always start from repo root
+  cd "$REPO_ROOT" || exit 1
+  
+  # Initialize fresh fork
+  local test_dir
+  test_dir=$(init_test_fork "$test_name")
+  
+  # Validate the captured path looks correct
+  if [[ ! "$test_dir" =~ ^/ ]] || [[ ! -d "$test_dir" ]]; then
+    log_fail "$test_name: init_test_fork returned invalid path: '$test_dir'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+    return
+  fi
+  
+  # Apply scenario (pass test_dir for cwd assertion)
+  cd "$test_dir" || exit 1
+  apply_scenario "$scenario" "$test_dir"
+  
+  # Return to repo root before running upgrade
+  cd "$REPO_ROOT" || exit 1
+  
+  # Run upgrade
+  local exit_code
+  exit_code=$(run_upgrade "$test_dir")
+  local output_file="$test_dir/.upgrade-output.txt"
+  
+  # Check basic outcome
+  local test_passed=true
+  
+  if [ "$expect_success" = "true" ]; then
+    if [ "$exit_code" != "0" ]; then
+      log_fail "$test_name: Expected success but got exit code $exit_code"
+      head -20 "$output_file" >&2
+      test_passed=false
+    fi
+  else
+    if [ "$exit_code" = "0" ]; then
+      log_fail "$test_name: Expected failure but upgrade succeeded"
+      test_passed=false
+    fi
+  fi
+  
+  # Run validations
+  for validation in "${validations[@]}"; do
+    case "$validation" in
+      no-conflicts)
+        if ! check_no_conflict_markers "$test_dir"; then
+          log_fail "$test_name: Found conflict markers"
+          test_passed=false
+        fi
+        ;;
+      version-updated)
+        if ! check_version_updated "$test_dir"; then
+          log_fail "$test_name: Version not updated"
+          test_passed=false
+        fi
+        ;;
+      overrides-preserved)
+        if ! check_overrides_preserved "$test_dir" ".claude/agents/github-ticket-worker.md"; then
+          log_fail "$test_name: Overrides not preserved"
+          test_passed=false
+        fi
+        ;;
+      userland-untouched)
+        if ! check_userland_untouched "$test_dir"; then
+          log_fail "$test_name: Userland content was modified/deleted"
+          test_passed=false
+        fi
+        ;;
+      upgrade-blocked)
+        if ! check_upgrade_blocked "$output_file"; then
+          log_fail "$test_name: Upgrade should have been blocked"
+          test_passed=false
+        fi
+        ;;
+    esac
+  done
+  
+  if [ "$test_passed" = "true" ]; then
+    log_pass "$test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+  fi
+  
+  # Return to repo root BEFORE cleanup to avoid cwd-in-deleted-dir bug
+  cd "$REPO_ROOT" || exit 1
+  
+  # Cleanup
+  rm -rf "$test_dir"
+}
+
+# Test suite
+run_all_tests() {
+  log_info "Starting upgrade cycle tests..."
+  log_info "Work directory: $TEST_WORKDIR"
+  echo "" >&2
+  
+  # Safety check before running any tests
+  check_host_repo_clean
+  
+  mkdir -p "$TEST_WORKDIR"
+  
+  # Test 1: Clean upgrade (baseline)
+  run_test_case "clean-upgrade" "clean" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 2: Post-bootstrap-product upgrade
+  run_test_case "post-bootstrap-product-upgrade" "post-bootstrap-product" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 3: Modified agents (without overrides - should get overwritten)
+  run_test_case "modified-agents-no-override" "modified-agents" "true" \
+    "no-conflicts" "version-updated"
+  
+  # Test 4: Modified agents WITH overrides (should preserve)
+  run_test_case_compound "modified-agents-with-override" \
+    "modified-agents" "has-overrides" \
+    "true" \
+    "no-conflicts" "version-updated" "overrides-preserved"
+  
+  # Test 5: Uncommitted framework files (should block)
+  run_test_case "uncommitted-framework-blocked" "uncommitted-framework" "false" \
+    "upgrade-blocked"
+  
+  # Test 6: Uncommitted userland files (should allow)
+  run_test_case "uncommitted-userland-allowed" "uncommitted-userland" "true" \
+    "no-conflicts" "userland-untouched"
+  
+  # Test 7: Stale version upgrade
+  run_test_case "stale-version-upgrade" "stale-version" "true" \
+    "no-conflicts" "version-updated"
+  
+  echo "" >&2
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+  echo -e "Tests run: $TESTS_RUN | ${GREEN}Passed: $TESTS_PASSED${NC} | ${RED}Failed: $TESTS_FAILED${NC}" >&2
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+  
+  if [ ${#FAILED_TESTS[@]} -gt 0 ]; then
+    echo "" >&2
+    log_fail "Failed tests:"
+    for t in "${FAILED_TESTS[@]}"; do
+      echo "  - $t" >&2
+    done
+    return 1
+  fi
+  
+  return 0
+}
+
+# Compound scenario test (applies multiple scenarios)
+run_test_case_compound() {
+  local test_name="$1"
+  local scenario1="$2"
+  local scenario2="$3"
+  local expect_success="$4"
+  shift 4
+  local validations=("$@")
+  
+  TESTS_RUN=$((TESTS_RUN + 1))
+  log_info "Running test: $test_name (compound)"
+  
+  # Always start from repo root
+  cd "$REPO_ROOT" || exit 1
+  
+  local test_dir
+  test_dir=$(init_test_fork "$test_name")
+  
+  # Validate the captured path
+  if [[ ! "$test_dir" =~ ^/ ]] || [[ ! -d "$test_dir" ]]; then
+    log_fail "$test_name: init_test_fork returned invalid path: '$test_dir'"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+    return
+  fi
+  
+  cd "$test_dir" || exit 1
+  apply_scenario "$scenario1" "$test_dir"
+  apply_scenario "$scenario2" "$test_dir"
+  
+  # Return to repo root
+  cd "$REPO_ROOT" || exit 1
+  
+  local exit_code
+  exit_code=$(run_upgrade "$test_dir")
+  local output_file="$test_dir/.upgrade-output.txt"
+  
+  local test_passed=true
+  
+  if [ "$expect_success" = "true" ]; then
+    if [ "$exit_code" != "0" ]; then
+      log_fail "$test_name: Expected success but got exit code $exit_code"
+      head -20 "$output_file" >&2
+      test_passed=false
+    fi
+  else
+    if [ "$exit_code" = "0" ]; then
+      log_fail "$test_name: Expected failure but upgrade succeeded"
+      test_passed=false
+    fi
+  fi
+  
+  for validation in "${validations[@]}"; do
+    case "$validation" in
+      no-conflicts)
+        if ! check_no_conflict_markers "$test_dir"; then
+          log_fail "$test_name: Found conflict markers"
+          test_passed=false
+        fi
+        ;;
+      version-updated)
+        if ! check_version_updated "$test_dir"; then
+          log_fail "$test_name: Version not updated"
+          test_passed=false
+        fi
+        ;;
+      overrides-preserved)
+        if ! check_overrides_preserved "$test_dir" ".claude/agents/github-ticket-worker.md"; then
+          log_fail "$test_name: Overrides not preserved"
+          test_passed=false
+        fi
+        ;;
+      userland-untouched)
+        if ! check_userland_untouched "$test_dir"; then
+          log_fail "$test_name: Userland content was modified/deleted"
+          test_passed=false
+        fi
+        ;;
+      upgrade-blocked)
+        if ! check_upgrade_blocked "$output_file"; then
+          log_fail "$test_name: Upgrade should have been blocked"
+          test_passed=false
+        fi
+        ;;
+    esac
+  done
+  
+  if [ "$test_passed" = "true" ]; then
+    log_pass "$test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_TESTS+=("$test_name")
+  fi
+  
+  # Return to repo root BEFORE cleanup
+  cd "$REPO_ROOT" || exit 1
+  rm -rf "$test_dir"
+}
+
+# Single scenario test (for manual testing)
+run_single_test() {
+  local scenario="$1"
+  
+  log_info "Running single scenario test: $scenario"
+  
+  # Safety check
+  check_host_repo_clean
+  
+  mkdir -p "$TEST_WORKDIR"
+  
+  local test_dir
+  test_dir=$(init_test_fork "single-$scenario")
+  
+  if [[ ! "$test_dir" =~ ^/ ]] || [[ ! -d "$test_dir" ]]; then
+    log_fail "init_test_fork returned invalid path: '$test_dir'"
+    exit 1
+  fi
+  
+  cd "$test_dir" || exit 1
+  apply_scenario "$scenario" "$test_dir"
+  
+  log_info "Test fork ready at: $test_dir"
+  log_info "Run upgrade manually: cd $test_dir && bash scripts/template-sync.sh"
+  echo "" >&2
+  log_info "Current state:"
+  git status --short >&2
+  echo "" >&2
+  log_info "Version: $(cat .agile-flow-meta/version 2>/dev/null || echo 'not set')"
+  
+  # Return to repo root
+  cd "$REPO_ROOT" || exit 1
+}
+
+# List available tests
+list_tests() {
+  cat >&2 << 'EOF'
+
+Available test scenarios:
+
+  clean                    — Fresh fork, no changes
+  post-bootstrap-product   — Has PRODUCT-*.md files
+  modified-agents          — Custom agent guidelines added
+  has-overrides            — .agile-flow-overrides configured
+  uncommitted-framework    — Dirty framework files (should block)
+  uncommitted-userland     — Dirty user content (should allow)
+  stale-version            — Old version marker
+
+Usage:
+  bash scripts/test-upgrade-cycle.sh           # Run full test suite
+  bash scripts/test-upgrade-cycle.sh <scenario> # Setup single scenario for manual testing
+
+EOF
+}
+
+# Main
+main() {
+  local arg="${1:-all}"
+  
+  case "$arg" in
+    --list|-l|list)
+      list_tests
+      ;;
+    --help|-h|help)
+      list_tests
+      ;;
+    all)
+      run_all_tests
+      ;;
+    *)
+      run_single_test "$arg"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Cleans up downstream doc references to `auto-fix.yml` that became stale when upstream [agile-flow#338](https://github.com/vibeacademy/agile-flow/pull/338) deleted the workflow.
- Mirrors upstream's replacement language for `LEAN-PRINCIPLES.md`, `CI-CD-GUIDE.md`, `DISTRIBUTION.md`, `PLATFORM-GUIDE.md`, and drops the `UPSTREAM.md` tracking row.
- Includes the `chore(upstream): sync framework files from agile-flow@e3025d0` commit from running `/pull-upstream` as the ticket's Happy Path step 2.

## Note on `.github/workflows/auto-fix.yml` itself

The file still exists locally in this fork because `.github/workflows/` is **outside the `syncDirectories` list** in `.agile-flow-version` — this fork owns its workflow files. Deleting the fork-local workflow is out of scope for this docs-only ticket. Worth filing as a small follow-up.

## Files changed (docs cleanup commit)

- `UPSTREAM.md` — drop `auto-fix.yml` from the upstream-tracking list
- `docs/LEAN-PRINCIPLES.md` — replace "CI auto-fix" claims with pre-push lint hook claims
- `docs/PLATFORM-GUIDE.md` — drop `auto-fix.yml` from list of shipped Claude-trigger workflows
- `docs/CI-CD-GUIDE.md` — drop the Auto Fix table row, dedicated section, and troubleshooting row
- `docs/DISTRIBUTION.md` — drop `auto-fix.yml` row from distribution table

Historical/unrelated references intentionally LEFT:
- `CHANGELOG.md` (historical setup-uv bump entry)
- `reports/session-journals/2026-05-03.md` (historical record)
- `.claude/commands/work-ticket.md` and `docs/FAQ.md` (refer to local `ruff --fix` CLI, not the workflow)
- `.claude/commands/triage-downstream-feedback.md` (unrelated phrase)

## Test plan

- [x] `grep -rn "auto-fix.yml" .` returns only intentional historical references
- [x] No active doc claim implies an `auto-fix.yml` workflow ships with the framework
- [x] `markdownlint-cli2` passes on changed docs
- [ ] After merge: file follow-up to delete the fork-local `.github/workflows/auto-fix.yml` (out of scope here)

Closes #222
