### PR TITLE
chore(sync): pull Phase 2a rebrand from upstream gembaflow

### DIFF
--- a/.claude/agents/agile-backlog-prioritizer.md
+++ b/.claude/agents/agile-backlog-prioritizer.md
@@ -582,5 +582,5 @@ Next grooming: after current sprint completes
 
 Your goal is to ensure the team always has clear, high-value, well-defined work ready to pick up, while maintaining a healthy backlog that reflects the product vision.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/agile-product-manager.md
+++ b/.claude/agents/agile-product-manager.md
@@ -473,5 +473,5 @@ When reporting on product decisions:
 
 Your goal is to ensure the product delivers value to customers and the business. You are the guardian of product-market fit, the voice of the customer, and the steward of strategic direction. Focus on outcomes over outputs, and always tie decisions back to customer value and business impact.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -572,5 +572,5 @@ See `docs/MEMORY-ARCHITECTURE.md` for full naming conventions.
 
 Your role is to be a guardian of quality while enabling velocity. Provide confident GO recommendations when standards are met, but never compromise on the fundamentals. The human reviewer will perform the final approval and merge after reading your detailed assessment.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/agents/quality-engineer.md
+++ b/.claude/agents/quality-engineer.md
@@ -257,5 +257,5 @@ Required changes: 0
 
 You are meticulous, thorough, and relentlessly focused on quality. You balance speed with rigor, knowing when to dig deep and when to move fast. Your test plans and reports are the definitive source of truth for project quality.
 
-<!-- Source: Agile Flow (https://github.com/vibeacademy/agile-flow) -->
+<!-- Source: Gemba Flow (https://github.com/vibeacademy/gembaflow) -->
 <!-- SPDX-License-Identifier: BUSL-1.1 -->

--- a/.claude/commands/report-issue.md
+++ b/.claude/commands/report-issue.md
@@ -87,7 +87,7 @@ The script generates a YAML front-matter Markdown file in .agile-flow-reports/:
 ```
 ---
 agile_flow_report: true
-upstream: https://github.com/vibeacademy/agile-flow
+upstream: https://github.com/vibeacademy/gembaflow
 fork_commit: abc123def456...
 upstream_version: v2.1.0 @ def789abc012
 severity: p2
@@ -106,7 +106,7 @@ End your response with a Result Block:
 ---
 
 **Result:** Issue filed
-URL: https://github.com/vibeacademy/agile-flow/issues/42
+URL: https://github.com/vibeacademy/gembaflow/issues/42
 Severity: p2
 Component: provisioning
 Report: .agile-flow-reports/report-20260508-143022.md
@@ -119,7 +119,7 @@ Or if fallback was used:
 
 **Result:** Report saved (manual submission required)
 Report: .agile-flow-reports/report-20260508-143022.md
-Browser URL: https://github.com/vibeacademy/agile-flow/issues/new?...
+Browser URL: https://github.com/vibeacademy/gembaflow/issues/new?...
 ```
 
 Or on error:

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Agile Flow Doctor — Local Diagnostic Script
+# Gemba Flow Doctor — Local Diagnostic Script
 #
 # Validates the full configuration needed for the workshop:
 #   CLI tools, git config, GitHub auth, MCP config, Claude settings,
@@ -114,7 +114,7 @@ resolve_cmd() {
 # ───────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${CYAN}║${NC}              ${BLUE}Agile Flow Doctor${NC}                              ${CYAN}║${NC}"
+echo -e "${CYAN}║${NC}              ${BLUE}Gemba Flow Doctor${NC}                              ${CYAN}║${NC}"
 echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
@@ -136,21 +136,21 @@ if [ -f ".agile-flow-version" ]; then
         local_version=$("$JQ_CMD" -r '.version' .agile-flow-version 2>/dev/null || echo "")
         if [ -n "$local_version" ]; then
             # Fetch latest release from GitHub
-            latest_json=$(curl -s --max-time 5 https://api.github.com/repos/vibeacademy/agile-flow/releases/latest 2>/dev/null || echo "")
+            latest_json=$(curl -s --max-time 5 https://api.github.com/repos/vibeacademy/gembaflow/releases/latest 2>/dev/null || echo "")
             if [ -n "$latest_json" ]; then
                 latest_version=$(echo "$latest_json" | "$JQ_CMD" -r '.tag_name // empty' 2>/dev/null | sed 's/^v//')
                 release_url=$(echo "$latest_json" | "$JQ_CMD" -r '.html_url // empty' 2>/dev/null)
                 if [ -n "$latest_version" ]; then
                     if [ "$local_version" = "$latest_version" ]; then
-                        pass "Framework Version" "Agile Flow v${local_version} (up to date)"
+                        pass "Framework Version" "Gemba Flow v${local_version} (up to date)"
                     else
-                        warn "Framework Version" "Agile Flow v${local_version} (update available: v${latest_version})" "${release_url}"
+                        warn "Framework Version" "Gemba Flow v${local_version} (update available: v${latest_version})" "${release_url}"
                     fi
                 else
-                    warn "Framework Version" "Agile Flow v${local_version} (could not check for updates)" "GitHub API returned unexpected response"
+                    warn "Framework Version" "Gemba Flow v${local_version} (could not check for updates)" "GitHub API returned unexpected response"
                 fi
             else
-                warn "Framework Version" "Agile Flow v${local_version} (could not check for updates)" "GitHub API unreachable"
+                warn "Framework Version" "Gemba Flow v${local_version} (could not check for updates)" "GitHub API unreachable"
             fi
         else
             warn "Framework Version" "Version manifest unreadable" "Check .agile-flow-version format"

--- a/scripts/report-issue.sh
+++ b/scripts/report-issue.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+# report-issue.sh — Report a downstream issue to the upstream Gemba Flow repo.
 #
 # Usage:
 #   bash scripts/report-issue.sh
@@ -31,7 +31,7 @@ DRY_RUN=false
 
 show_help() {
   cat <<'HELP'
-report-issue.sh — Report a downstream issue to the upstream Agile Flow repo.
+report-issue.sh — Report a downstream issue to the upstream Gemba Flow repo.
 
 Usage:
   bash scripts/report-issue.sh [FLAGS]

--- a/scripts/setup-accounts.sh
+++ b/scripts/setup-accounts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Agile Flow Account Setup
+# Gemba Flow Account Setup
 #
 # Streamlined setup for the three-account GitHub configuration.
 # Paste your PATs → done. No interactive gh prompts.
@@ -99,7 +99,7 @@ persist_env_var() {
     else
         {
             echo ""
-            echo "# Added by Agile Flow setup-accounts"
+            echo "# Added by Gemba Flow setup-accounts"
             echo "export ${var_name}=\"${var_value}\""
         } >> "$profile"
         print_info "Added ${var_name} to ${profile}"
@@ -124,7 +124,7 @@ trap restore_personal EXIT
 # ═══════════════════════════════════════════════════════════════════
 
 echo ""
-echo -e "${CYAN}━━━ Agile Flow Account Setup ━━━${NC}"
+echo -e "${CYAN}━━━ Gemba Flow Account Setup ━━━${NC}"
 echo ""
 
 # ───────────────────────────────────────────────────────────────────

--- a/scripts/template-sync.sh
+++ b/scripts/template-sync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# template-sync.sh -- Sync framework files from vibeacademy/agile-flow releases.
+# template-sync.sh -- Sync framework files from vibeacademy/gembaflow releases.
 # Called by .github/workflows/template-sync.yml (workflow_dispatch only).
 # Guardrails:
 #   - Only syncs directories/files listed in syncDirectories (.agile-flow-version)
@@ -31,11 +31,12 @@ if ! gh auth token >/dev/null 2>&1; then
   exit 1
 fi
 
-UPSTREAM_REPO="vibeacademy/agile-flow"
-# FALLBACK_REPO is only consulted when the primary returns 404 (e.g. during the
-# agile-flow -> gembaflow rename window). The primary default stays unchanged
-# in this PR; see #331 (Phase 0.5 of the gembaflow rebrand).
-FALLBACK_REPO="vibeacademy/gembaflow"
+UPSTREAM_REPO="vibeacademy/gembaflow"
+# FALLBACK_REPO is only consulted when the primary returns 404. Post-Phase 2a
+# (#332) the primary is now gembaflow natively; the fallback points at the
+# legacy name and would only fire via GitHub's redirect if the gembaflow name
+# is ever changed again. Belt-and-suspenders — see #331 / #332.
+FALLBACK_REPO="vibeacademy/agile-flow"
 VERSION_FILE=".agile-flow-version"
 OVERRIDES_FILE=".agile-flow-overrides"
 RUNNING_SCRIPT_REL=$(python3 -c "import os,sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.getcwd()))" "$0")
@@ -209,9 +210,9 @@ echo "Protected overrides: ${#OVERRIDE_PATTERNS[@]} pattern(s)"
 ###############################################################################
 # 2. Fetch latest release from GitHub (unauthenticated)
 ###############################################################################
-# Use -L so curl follows GitHub's 301 redirects when an upstream repo is
-# renamed (e.g. agile-flow -> gembaflow during the rebrand rollout). Without
-# -L, curl returns empty on a redirect and the next JSON parse fails silently.
+# Use -L so curl follows GitHub's 301 redirects in case an upstream repo is
+# renamed in the future. Without -L, curl returns empty on a redirect and the
+# next JSON parse fails silently.
 RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${UPSTREAM_REPO}/releases/latest" 2>/dev/null || true)
 
 # If the primary returned 404 (or curl produced no output), retry against the
@@ -466,7 +467,7 @@ mkdir -p .agile-flow-meta
 echo "$LATEST_VERSION" > .agile-flow-meta/version
 git add .agile-flow-meta/version
 
-COMMIT_MSG="chore(sync): update Agile Flow framework to v${LATEST_VERSION}"
+COMMIT_MSG="chore(sync): update Gemba Flow framework to v${LATEST_VERSION}"
 # Scope the bot identity to this single commit using -c so running locally
 # does NOT overwrite the user's per-repo git author config.
 git -c user.name="github-actions[bot]" \
@@ -481,7 +482,7 @@ for f in "${FILES_CHANGED[@]}"; do
 "
 done
 
-PR_BODY="## Agile Flow Framework Update
+PR_BODY="## Gemba Flow Framework Update
 
 Updates framework files from \`v${LOCAL_VERSION}\` to \`v${LATEST_VERSION}\`.
 
@@ -497,7 +498,7 @@ See the full release notes: ${RELEASE_URL}
 > **Please review the changes before merging.**"
 
 gh pr create \
-  --title "chore(sync): update Agile Flow framework to v${LATEST_VERSION}" \
+  --title "chore(sync): update Gemba Flow framework to v${LATEST_VERSION}" \
   --body "$PR_BODY" \
   --base main \
   --head "$SYNC_BRANCH"

--- a/scripts/template-sync.test.sh
+++ b/scripts/template-sync.test.sh
@@ -337,10 +337,10 @@ run_upstream_scenario "upstream-honored" "vibeacademy/agile-flow-gcp" "vibeacade
 run_upstream_scenario "upstream-url-normalized" "https://github.com/vibeacademy/agile-flow-gcp" "vibeacademy/agile-flow-gcp" ""
 
 # (b) absent upstream falls back to hardcoded default
-run_upstream_scenario "upstream-absent" "" "vibeacademy/agile-flow" ""
+run_upstream_scenario "upstream-absent" "" "vibeacademy/gembaflow" ""
 
 # (c) 404 from primary -> fallback URL is tried
-FAIL_URL="https://api.github.com/repos/vibeacademy/agile-flow/releases/latest"
+FAIL_URL="https://api.github.com/repos/vibeacademy/gembaflow/releases/latest"
 SCEN_DIR="$WORK_DIR/scen-fallback"
 mkdir -p "$SCEN_DIR/scripts/lib"
 cp scripts/template-sync.sh "$SCEN_DIR/scripts/template-sync.sh"
@@ -365,17 +365,17 @@ popd >/dev/null
 
 URL1=$(sed -n '1p' "$WORK_DIR/curl-fallback.log" || true)
 URL2=$(sed -n '2p' "$WORK_DIR/curl-fallback.log" || true)
-if [[ "$URL1" == *"/repos/vibeacademy/agile-flow/releases/latest" ]]; then
+if [[ "$URL1" == *"/repos/vibeacademy/gembaflow/releases/latest" ]]; then
   pass "[fallback] primary URL tried first"
 else
   fail "[fallback] expected primary URL first, got: ${URL1:-<none>}"
 fi
-if [[ "$URL2" == *"/repos/vibeacademy/gembaflow/releases/latest" ]]; then
+if [[ "$URL2" == *"/repos/vibeacademy/agile-flow/releases/latest" ]]; then
   pass "[fallback] fallback URL tried after primary 404"
 else
-  fail "[fallback] expected gembaflow fallback URL second, got: ${URL2:-<none>}"
+  fail "[fallback] expected agile-flow fallback URL second, got: ${URL2:-<none>}"
 fi
-if grep -q "retrying against fallback vibeacademy/gembaflow" "$WORK_DIR/scen-fallback.log"; then
+if grep -q "retrying against fallback vibeacademy/agile-flow" "$WORK_DIR/scen-fallback.log"; then
   pass "[fallback] informational stderr line emitted"
 else
   fail "[fallback] expected informational fallback log line"

--- a/scripts/test-report-issue.sh
+++ b/scripts/test-report-issue.sh
@@ -136,7 +136,7 @@ echo "Test 4: Error on invalid severity value"
 
 TEST_DIR="$WORK_DIR/test4"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -161,7 +161,7 @@ echo "Test 5: Error on invalid component value"
 
 TEST_DIR="$WORK_DIR/test5"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -186,7 +186,7 @@ echo "Test 6: Error when title is empty"
 
 TEST_DIR="$WORK_DIR/test6"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -213,7 +213,7 @@ echo "Test 7: Fallback to manual submission when gh CLI unavailable"
 
 TEST_DIR="$WORK_DIR/test7"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -237,7 +237,7 @@ if PATH="$WORK_DIR/nogh-bin:$PATH" bash "$REPO_ROOT/scripts/report-issue.sh" --n
     cat "$WORK_DIR/test7.log"
   fi
   
-  if grep -q "github.com/vibeacademy/agile-flow/issues/new" "$WORK_DIR/test7.log"; then
+  if grep -q "github.com/vibeacademy/gembaflow/issues/new" "$WORK_DIR/test7.log"; then
     pass "pre-filled GitHub issue URL is provided"
   else
     fail "expected pre-filled GitHub issue URL"
@@ -276,7 +276,7 @@ echo "Test 8: Happy path with successful gh issue create"
 
 TEST_DIR="$WORK_DIR/test8"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -288,7 +288,7 @@ cat > "$WORK_DIR/mock-gh-bin/gh" <<'SH'
 #!/usr/bin/env bash
 # Mock gh issue create
 if [[ "${1:-}" == "issue" && "${2:-}" == "create" ]]; then
-  echo "https://github.com/vibeacademy/agile-flow/issues/999"
+  echo "https://github.com/vibeacademy/gembaflow/issues/999"
   exit 0
 fi
 exit 1
@@ -335,7 +335,7 @@ echo "Test 9: Error on unknown flag"
 
 TEST_DIR="$WORK_DIR/test9"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 
@@ -360,7 +360,7 @@ echo "Test 10: Non-interactive mode requires --severity"
 
 TEST_DIR="$WORK_DIR/test10"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
 git commit --allow-empty -m "init" --quiet
@@ -385,7 +385,7 @@ echo "Test 11: Parse git@ format upstream URL"
 
 TEST_DIR="$WORK_DIR/test11"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "git@github.com:vibeacademy/agile-flow.git" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "git@github.com:vibeacademy/gembaflow.git" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet
@@ -393,7 +393,7 @@ git commit --allow-empty -m "init" --quiet
 
 # Use mock gh
 if PATH="$WORK_DIR/mock-gh-bin:$PATH" bash "$REPO_ROOT/scripts/report-issue.sh" --non-interactive --severity p3 --component docs --title "SSH URL test" > "$WORK_DIR/test11.log" 2>&1; then
-  if grep -q "vibeacademy/agile-flow" "$WORK_DIR/test11.log"; then
+  if grep -q "vibeacademy/gembaflow" "$WORK_DIR/test11.log"; then
     pass "git@ URL parsed to correct repo"
   else
     fail "git@ URL not parsed correctly"
@@ -413,7 +413,7 @@ echo "Test 12: Handle title with special characters"
 
 TEST_DIR="$WORK_DIR/test12"
 mkdir -p "$TEST_DIR/.agile-flow-meta"
-echo "https://github.com/vibeacademy/agile-flow" > "$TEST_DIR/.agile-flow-meta/upstream"
+echo "https://github.com/vibeacademy/gembaflow" > "$TEST_DIR/.agile-flow-meta/upstream"
 echo "1.0.0" > "$TEST_DIR/.agile-flow-meta/version"
 pushd "$TEST_DIR" >/dev/null
 git init --quiet

--- a/scripts/test-upgrade-cycle.sh
+++ b/scripts/test-upgrade-cycle.sh
@@ -75,7 +75,7 @@ init_test_fork() {
   
   # Set up as downstream fork
   mkdir -p .agile-flow-meta
-  echo "vibeacademy/agile-flow" > .agile-flow-meta/upstream
+  echo "vibeacademy/gembaflow" > .agile-flow-meta/upstream
   echo "v1.0.8" > .agile-flow-meta/version  # Start one version behind
   
   git add .agile-flow-meta >/dev/null 2>&1


### PR DESCRIPTION
## Summary

Pulls in [upstream gembaflow#345](https://github.com/vibeacademy/gembaflow/pull/345) (Phase 2a of the agile-flow → Gemba Flow rebrand) via `bash scripts/pull-upstream.sh`. Twelve framework files updated, five intentionally skipped per `.agile-flow-overrides`.

Source commit: `agile-flow@5993a9d` (upstream `vibeacademy/gembaflow`).

## Files updated

**Synced from upstream (12):**
- `.claude/agents/agile-backlog-prioritizer.md`
- `.claude/agents/agile-product-manager.md`
- `.claude/agents/pr-reviewer.md`
- `.claude/agents/quality-engineer.md`
- `.claude/commands/report-issue.md`
- `scripts/doctor.sh`
- `scripts/report-issue.sh`
- `scripts/setup-accounts.sh`
- `scripts/template-sync.sh`
- `scripts/template-sync.test.sh`
- `scripts/test-report-issue.sh`
- `scripts/test-upgrade-cycle.sh`

**Skipped (local overrides — GCP-customised, intentional):**
- `.claude/agents/devops-engineer.md`
- `.claude/agents/github-ticket-worker.md`
- `.claude/agents/system-architect.md`
- `.claude/commands/bootstrap-architecture.md`
- `.claude/commands/doctor.md`

## What this does for the rebrand

- Agent source footers now point at `vibeacademy/gembaflow` natively (no more redirect dependency).
- `scripts/template-sync.sh` `UPSTREAM_REPO` reads `vibeacademy/gembaflow` with `FALLBACK_REPO` at `vibeacademy/agile-flow` as defensive belt-and-suspenders.
- User-facing display strings in `doctor.sh`, `setup-accounts.sh`, etc. updated to "Gemba Flow".

## What this does NOT do

- Does not update `.agile-flow-meta/upstream` (this fork's own copy is not in `syncDirectories`) — that's a fork-local file change, tracked separately as [Phase 3b (#220)](https://github.com/vibeacademy/gembaflow-gcp/issues/220).
- Does not update fork-local `scripts/pull-upstream.sh` hardcoded URL — same ticket #220.
- Does not rename dotfiles (`.agile-flow-version` etc.) — Phase 4.

## Test plan

- [x] `bash scripts/template-sync.test.sh` passes (verified locally; 14/14)
- [x] All 12 updated files now reference `vibeacademy/gembaflow` where they previously referenced `vibeacademy/agile-flow`
- [x] Five overridden files unchanged
- [ ] After merge: `/upgrade` from this fork still functions (smoke test)
- [ ] After merge: file a follow-up issue via `/report-issue` to confirm it lands in `vibeacademy/gembaflow` natively (not via redirect)

This unblocks Phase 3b (fork-local URL edits in this repo) and is independent of Phases 2b/2c (which run in upstream gembaflow).