### PR TITLE
refactor(rebrand): Phase 3b — fork-local URL fixups

### DIFF
--- a/.agile-flow-meta/upstream
+++ b/.agile-flow-meta/upstream
@@ -1,1 +1,1 @@
-vibeacademy/agile-flow
+vibeacademy/gembaflow

--- a/.agile-flow-version
+++ b/.agile-flow-version
@@ -1,6 +1,6 @@
 {
   "version": "1.1.0",
-  "upstream": "vibeacademy/agile-flow",
+  "upstream": "vibeacademy/gembaflow",
   "installedAt": null,
   "distribution": "fork",
   "syncDirectories": [

--- a/scripts/pull-upstream.sh
+++ b/scripts/pull-upstream.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pull-upstream.sh — Apply latest framework changes from vibeacademy/agile-flow.
+# pull-upstream.sh — Apply latest framework changes from vibeacademy/gembaflow.
 #
 # Safe to run mid-workshop from a Codespace. Only updates files that exist in
 # the upstream repo AND are in the syncDirectories list. Files listed in
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-UPSTREAM_REPO="https://github.com/vibeacademy/agile-flow.git"
+UPSTREAM_REPO="https://github.com/vibeacademy/gembaflow.git"
 UPSTREAM_REMOTE="upstream"
 VERSION_FILE=".agile-flow-version"
 OVERRIDES_FILE=".agile-flow-overrides"
@@ -146,7 +146,7 @@ done
 
 git -c user.name="pull-upstream" \
     -c user.email="noreply@github.com" \
-    commit -m "chore(upstream): sync framework files from agile-flow@${UPSTREAM_SHA:0:7}
+    commit -m "chore(upstream): sync framework files from gembaflow@${UPSTREAM_SHA:0:7}
 
 ${BODY}"
 


### PR DESCRIPTION
## Summary

Phase 3b of the agile-flow → Gemba Flow rebrand. Three fork-local files live
outside `syncDirectories` (so `/pull-upstream` cannot rewrite them), and they
were still pointing at `vibeacademy/agile-flow` while relying on GitHub's 301
redirect. Make them native.

| File | Before | After |
|---|---|---|
| `scripts/pull-upstream.sh` `UPSTREAM_REPO` | `https://github.com/vibeacademy/agile-flow.git` | `https://github.com/vibeacademy/gembaflow.git` |
| `.agile-flow-meta/upstream` (read by `/report-issue`) | `vibeacademy/agile-flow` | `vibeacademy/gembaflow` |
| `.agile-flow-version` `upstream` field (read by `/upgrade`) | `vibeacademy/agile-flow` | `vibeacademy/gembaflow` |

The script header comment and the commit-message string emitted by
`pull-upstream.sh` were also updated to say "gembaflow".

### Out of scope (intentional)

- Dotfile names (`.agile-flow-version`, `.agile-flow-meta/`,
  `.agile-flow-overrides`) — Phase 4 owns the coordinated rename.
- Env var names — Phase 2b owns the shim and rename.
- `scripts/template-sync.sh` — already updated by Phase 2a sync (PR #226).
- GCP infra names (`agile-flow-app`, `agile-flow-pool`) — Phase 5.
- Doc/historical refs in `docs/`, `CHANGELOG.md`, `UPSTREAM.md`,
  `README.md`, session journals — not in this PR's scope (some are
  intentional historical refs; others will be revisited as the rebrand
  rollout completes).

## Test plan

- [x] Pre-push checks: `ruff check` clean, `pytest` 62 passed.
- [ ] Post-merge: `grep -rn "vibeacademy/agile-flow" .` shows only intentional
  historical refs (docs, CHANGELOG, session journals).
- [ ] Post-merge smoke: run `/upgrade` against the new URL — confirm
  `.agile-flow-version` `upstream` resolves to `vibeacademy/gembaflow` and
  the upgrade flow completes without hitting the redirect.
- [ ] Post-merge smoke: run `/report-issue` — confirm it files against
  `vibeacademy/gembaflow` natively.

Closes #220