### PR TITLE
chore(rebrand): Phase 5 — GCP resource naming (forward-only)

### DIFF
--- a/docs/CI-CD-GUIDE.md
+++ b/docs/CI-CD-GUIDE.md
@@ -83,8 +83,8 @@ Deploys to Cloud Run production on merge to `main`.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `GCP_REGION` | `us-central1` | Cloud Run + Artifact Registry region |
-| `ARTIFACT_REPO` | `agile-flow` | Artifact Registry repo name |
-| `CLOUD_RUN_SERVICE` | `agile-flow-app` | Cloud Run service name |
+| `ARTIFACT_REPO` | `gembaflow` | Artifact Registry repo name |
+| `CLOUD_RUN_SERVICE` | `gembaflow-app` | Cloud Run service name |
 | `APP_URL` | (your URL) | Runtime env var for self-referential URL construction |
 | `PRODUCTION_DATABASE_URL` | Secret | Neon main branch pooled URL; used by `alembic upgrade head` before deploy |
 

--- a/docs/PATTERN-LIBRARY.md
+++ b/docs/PATTERN-LIBRARY.md
@@ -1100,14 +1100,14 @@ forwards `flags:` verbatim to `gcloud run deploy`) fails with
 - name: Deploy to Cloud Run
   uses: google-github-actions/deploy-cloudrun@v2
   with:
-    service: agile-flow-app
+    service: gembaflow-app
     image: ${{ env.IMAGE }}
     region: us-central1
     # Note: no --traffic flag here. `gcloud run deploy` rejects it.
 
 - name: Route traffic to latest revision
   run: |
-    gcloud run services update-traffic agile-flow-app \
+    gcloud run services update-traffic gembaflow-app \
       --region=us-central1 \
       --to-latest
 ```
@@ -1173,7 +1173,7 @@ inject the per-PR Neon branch URL).
 - name: Deploy to Cloud Run
   uses: google-github-actions/deploy-cloudrun@v2
   with:
-    service: agile-flow-app
+    service: gembaflow-app
     image: ${{ env.IMAGE }}
     region: us-central1
     env_vars: |
@@ -1189,7 +1189,7 @@ Production traffic shift to the new revision happens in a separate
 - name: Deploy preview revision
   uses: google-github-actions/deploy-cloudrun@v2
   with:
-    service: agile-flow-app
+    service: gembaflow-app
     image: ${{ env.IMAGE }}
     region: us-central1
     flags: --no-traffic --tag=pr-${{ github.event.pull_request.number }}
@@ -1215,7 +1215,7 @@ the previous run wrote. It breaks down the moment prod and preview
 alternate against the same service — see #66 (the workaround) and
 #68 (the structural fix). Larger remediation options like per-PR
 secrets (`database-url-pr-N`) or separate services per environment
-(`agile-flow-app-prod`, `agile-flow-app-pr-N`) are tracked for
+(`gembaflow-app-prod`, `gembaflow-app-pr-N`) are tracked for
 post-workshop work.
 
 Surfaced in the 2026-04-29 dry-run when production and preview

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -66,14 +66,14 @@ after enabling, wait a minute and retry.
 ### Step 3: Create an Artifact Registry Repository
 
 ```bash
-gcloud artifacts repositories create agile-flow \
+gcloud artifacts repositories create gembaflow \
   --repository-format=docker \
   --location=us-central1 \
   --project=YOUR_PROJECT_ID
 ```
 
 Container images will live at:
-`us-central1-docker.pkg.dev/YOUR_PROJECT_ID/agile-flow/agile-flow-app:TAG`
+`us-central1-docker.pkg.dev/YOUR_PROJECT_ID/gembaflow/gembaflow-app:TAG`
 
 **Do not use `gcr.io` paths.** Container Registry is deprecated and new
 projects cannot write to it.
@@ -135,7 +135,7 @@ either system — just secret values.
 
 **End-to-end for one participant (`bob`):**
 
-1. Facilitator's roster has bob's row with `github_full_repo=acme/widget-shop` (or empty, defaulting to `bob-gh/agile-flow-gcp` for personal forks).
+1. Facilitator's roster has bob's row with `github_full_repo=acme/widget-shop` (or empty, defaulting to `bob-gh/gembaflow-gcp` for personal forks).
 2. Facilitator runs `provision-workshop-roster.sh` → `af-bob-2026-05` exists with the deployer SA, and Step 5.5 binds the WIF trust to whatever GitHub repo bob's row specified.
 3. Facilitator emails bob the four secret values. (Template in `agile-flow-meta/docs/workshops/gcp-facilitator-runbook.md` §7.)
 4. Bob forks `vibeacademy/agile-flow-gcp` (to his account or his org), pastes the four secrets, pushes a trivial change to `main`. The deploy workflow uses WIF to assume the deployer SA and ships the container to bob's project.
@@ -172,7 +172,7 @@ for `GITHUB_OWNER` so older callers don't need to change.
 GCP_PROJECT_ID=af-alice-2026-05 \
 BILLING_ACCOUNT_ID=XXX-XXXX-XXXX \
 GITHUB_OWNER=alice-gh \
-GITHUB_REPO=agile-flow-gcp \
+GITHUB_REPO=gembaflow-gcp \
   ./scripts/provision-gcp-project.sh --create-project
 
 # Org fork with renamed repo
@@ -370,8 +370,8 @@ In your GitHub repo settings (Settings → Secrets and variables → Actions):
 | Name | Default | Purpose |
 |------|---------|---------|
 | `GCP_REGION` | `us-central1` | Cloud Run + Artifact Registry region |
-| `ARTIFACT_REPO` | `agile-flow` | Artifact Registry repo name |
-| `CLOUD_RUN_SERVICE` | `agile-flow-app` | Cloud Run service name |
+| `ARTIFACT_REPO` | `gembaflow` | Artifact Registry repo name |
+| `CLOUD_RUN_SERVICE` | `gembaflow-app` | Cloud Run service name |
 | `APP_URL` | (your production URL) | Passed to the container at runtime for self-referential URL construction |
 | `NEON_DB_USER` | `neondb_owner` | Neon database role |
 
@@ -611,7 +611,7 @@ Columns:
   identifying the participant's fork. Use the override when attendees
   fork into their organization's GitHub (e.g., `acme/widget-shop`) and
   rename the repo to fit their product. When empty or absent, defaults
-  to `<github_user>/agile-flow-gcp` (the personal-fork pattern).
+  to `<github_user>/gembaflow-gcp` (the personal-fork pattern).
   Validation: `^[A-Za-z0-9-]{1,39}/[A-Za-z0-9._-]{1,100}$`.
 
 Project IDs follow the pattern `af-{handle}-{cohort}`. This shape is
@@ -809,7 +809,7 @@ logs `[skip]` and continues. The placeholder revision pins
 the first real deploy doesn't change either property.
 
 Override the service name with `CLOUD_RUN_SERVICE=<name>`; defaults to
-`agile-flow-app`.
+`gembaflow-app`.
 
 ### What the lifecycle scripts do NOT do
 
@@ -995,7 +995,7 @@ issue #86 for the API research.
 ### Viewing Logs
 
 ```bash
-gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="agile-flow-app"' \
+gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="gembaflow-app"' \
   --project=YOUR_PROJECT_ID \
   --limit=50 \
   --format='value(timestamp,textPayload)'
@@ -1031,14 +1031,14 @@ Cloud Run keeps every revision. To roll back:
 ```bash
 # List recent revisions
 gcloud run revisions list \
-  --service=agile-flow-app \
+  --service=gembaflow-app \
   --region=us-central1 \
   --limit=10
 
 # Route 100% of traffic to a specific revision
-gcloud run services update-traffic agile-flow-app \
+gcloud run services update-traffic gembaflow-app \
   --region=us-central1 \
-  --to-revisions=agile-flow-app-00042-xyz=100
+  --to-revisions=gembaflow-app-00042-xyz=100
 ```
 
 ### Updating Runtime Secrets

--- a/scripts/diagnose-cloudrun.sh
+++ b/scripts/diagnose-cloudrun.sh
@@ -20,7 +20,7 @@
 #   ./scripts/diagnose-cloudrun.sh --help
 #
 # Required: GCP_PROJECT_ID env or --project=<id>
-# Optional: GCP_REGION (default: us-central1), CLOUD_RUN_SERVICE (default: agile-flow-app)
+# Optional: GCP_REGION (default: us-central1), CLOUD_RUN_SERVICE (default: gembaflow-app)
 #
 # Surfaced from the 2026-04-29 dry-run on tck517/tck517-app, where the
 # diagnostic command that cracked the case was a hand-composed multi-
@@ -32,7 +32,7 @@ set -uo pipefail
 
 PROJECT="${GCP_PROJECT_ID:-}"
 REGION="${GCP_REGION:-us-central1}"
-SERVICE="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+SERVICE="${CLOUD_RUN_SERVICE:-gembaflow-app}"
 
 print_help() {
   sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'

--- a/scripts/diagnose-cloudrun.test.sh
+++ b/scripts/diagnose-cloudrun.test.sh
@@ -138,17 +138,17 @@ cat > "$T2/service.json" <<'JSON'
     "template": {
       "spec": {
         "containers": [
-          {"image": "us-central1-docker.pkg.dev/af-test/agile-flow/app:abc1234"}
+          {"image": "us-central1-docker.pkg.dev/af-test/gembaflow/app:abc1234"}
         ]
       }
     }
   },
   "status": {
-    "url": "https://agile-flow-app-xxx-uc.a.run.app",
-    "latestReadyRevisionName": "agile-flow-app-00005-abc",
-    "latestCreatedRevisionName": "agile-flow-app-00005-abc",
+    "url": "https://gembaflow-app-xxx-uc.a.run.app",
+    "latestReadyRevisionName": "gembaflow-app-00005-abc",
+    "latestCreatedRevisionName": "gembaflow-app-00005-abc",
     "traffic": [
-      {"percent": 100, "revisionName": "agile-flow-app-00005-abc"}
+      {"percent": 100, "revisionName": "gembaflow-app-00005-abc"}
     ]
   }
 }
@@ -173,7 +173,7 @@ ec=$?
 set -e
 
 assert_eq "0" "$ec" "exit 0 on happy path"
-assert_contains "=== Cloud Run service: agile-flow-app ===" "$T2/stdout.log" "section 1 header"
+assert_contains "=== Cloud Run service: gembaflow-app ===" "$T2/stdout.log" "section 1 header"
 assert_contains "=== Traffic split ===" "$T2/stdout.log" "section 2 header"
 assert_contains "=== Currently-serving image ===" "$T2/stdout.log" "section 3 header"
 assert_contains "=== Latest revision conditions ===" "$T2/stdout.log" "section 4 header"
@@ -181,15 +181,15 @@ assert_contains "=== Last 50 log lines ===" "$T2/stdout.log" "section 5 header"
 assert_contains "=== End of diagnostic ===" "$T2/stdout.log" "footer marker"
 
 # Section 1 fields
-assert_contains "URL:                  https://agile-flow-app-xxx-uc.a.run.app" "$T2/stdout.log" "URL line"
-assert_contains "Latest READY:         agile-flow-app-00005-abc" "$T2/stdout.log" "latest-ready line"
+assert_contains "URL:                  https://gembaflow-app-xxx-uc.a.run.app" "$T2/stdout.log" "URL line"
+assert_contains "Latest READY:         gembaflow-app-00005-abc" "$T2/stdout.log" "latest-ready line"
 
 # Section 2: 100% traffic, no STALE marker (latest-ready matches)
-assert_contains "100% -> agile-flow-app-00005-abc" "$T2/stdout.log" "traffic 100% to current"
+assert_contains "100% -> gembaflow-app-00005-abc" "$T2/stdout.log" "traffic 100% to current"
 assert_not_contains "STALE" "$T2/stdout.log" "no STALE marker when traffic matches latest-ready"
 
 # Section 3: real image, no PLACEHOLDER marker
-assert_contains "us-central1-docker.pkg.dev/af-test/agile-flow/app:abc1234" "$T2/stdout.log" "real image rendered"
+assert_contains "us-central1-docker.pkg.dev/af-test/gembaflow/app:abc1234" "$T2/stdout.log" "real image rendered"
 assert_not_contains "PLACEHOLDER" "$T2/stdout.log" "no PLACEHOLDER marker for real image"
 
 # Section 4: revision conditions
@@ -224,11 +224,11 @@ cat > "$T3/service.json" <<'JSON'
     }
   },
   "status": {
-    "url": "https://agile-flow-app-xxx-uc.a.run.app",
-    "latestReadyRevisionName": "agile-flow-app-00005-abc",
-    "latestCreatedRevisionName": "agile-flow-app-00005-abc",
+    "url": "https://gembaflow-app-xxx-uc.a.run.app",
+    "latestReadyRevisionName": "gembaflow-app-00005-abc",
+    "latestCreatedRevisionName": "gembaflow-app-00005-abc",
     "traffic": [
-      {"percent": 100, "revisionName": "agile-flow-app-00001-q7w"}
+      {"percent": 100, "revisionName": "gembaflow-app-00001-q7w"}
     ]
   }
 }
@@ -246,7 +246,7 @@ set -e
 
 assert_eq "0" "$ec" "exit 0"
 assert_contains "STALE" "$T3/stdout.log" "STALE marker on traffic going to non-latest-ready revision"
-assert_contains "latest-ready is agile-flow-app-00005-abc" "$T3/stdout.log" "STALE marker names latest-ready"
+assert_contains "latest-ready is gembaflow-app-00005-abc" "$T3/stdout.log" "STALE marker names latest-ready"
 assert_contains "PLACEHOLDER" "$T3/stdout.log" "PLACEHOLDER marker on cloudrun/container/hello image"
 
 # ── Test 4: latest-created != latest-ready → WARN line fires ────────────

--- a/scripts/provision-gcp-project.sh
+++ b/scripts/provision-gcp-project.sh
@@ -13,12 +13,12 @@
 # Environment variables:
 #   GCP_PROJECT_ID       (required) Project ID to provision into
 #   GCP_REGION           (default: us-central1)
-#   ARTIFACT_REPO        (default: agile-flow)
+#   ARTIFACT_REPO        (default: gembaflow)
 #   BILLING_ACCOUNT_ID   (required if --create-project)
 #   GITHUB_OWNER         (optional) GitHub owner of the participant's
 #                        fork. Personal username (alice-gh) or org (acme).
 #                        Required to enable Step 5.5 (WIF setup).
-#   GITHUB_REPO          (default: agile-flow-gcp) Repo name within
+#   GITHUB_REPO          (default: gembaflow-gcp) Repo name within
 #                        GITHUB_OWNER. Set when participants fork into
 #                        an org and rename the repo for their product.
 #   GITHUB_USERNAME      Legacy alias for GITHUB_OWNER. When GITHUB_OWNER
@@ -67,7 +67,7 @@
 set -euo pipefail
 
 GCP_REGION="${GCP_REGION:-us-central1}"
-ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}"
+ARTIFACT_REPO="${ARTIFACT_REPO:-gembaflow}"
 
 # ── Retry helper for GCP eventual consistency ────────────────────────────
 #
@@ -389,7 +389,7 @@ done
 #                    a personal username (alice-gh) or an organization
 #                    (acme). Required to enable Step 5.5.
 #   GITHUB_REPO      The repo name within the owner. Defaults to
-#                    'agile-flow-gcp' when unset.
+#                    'gembaflow-gcp' when unset.
 #   GITHUB_USERNAME  Legacy alias for GITHUB_OWNER. Used when GITHUB_OWNER
 #                    is unset, so external callers that set the older
 #                    name continue to work.
@@ -412,7 +412,7 @@ done
 # Resolve GITHUB_OWNER, falling back to GITHUB_USERNAME for backwards
 # compatibility with external callers from before #40.
 WIF_OWNER="${GITHUB_OWNER:-${GITHUB_USERNAME:-}}"
-WIF_REPO_NAME="${GITHUB_REPO:-agile-flow-gcp}"
+WIF_REPO_NAME="${GITHUB_REPO:-gembaflow-gcp}"
 
 # Org-trust mode (#107). When WIF_ORG_TRUST_PATTERN is set (typically
 # from the workshop-org provisioning flow with WIF_ORG_TRUST_PATTERN=
@@ -842,7 +842,7 @@ fi
 #                              so first real deploy doesn't change ACL
 #   --port=8080 = matches the FastAPI Dockerfile and preview-deploy config
 
-SERVICE_NAME="${CLOUD_RUN_SERVICE:-agile-flow-app}"
+SERVICE_NAME="${CLOUD_RUN_SERVICE:-gembaflow-app}"
 
 if gcloud run services describe "$SERVICE_NAME" \
     --region="$GCP_REGION" \
@@ -1079,7 +1079,7 @@ fi
 echo ""
 echo "   GCP_REGION             = $GCP_REGION"
 echo "   ARTIFACT_REPO          = $ARTIFACT_REPO"
-echo "   CLOUD_RUN_SERVICE      = agile-flow-app"
+echo "   CLOUD_RUN_SERVICE      = gembaflow-app"
 echo "   NEXT_PUBLIC_APP_URL    = (your production URL)"
 echo ""
 echo "5. Push to main to trigger your first deployment."

--- a/scripts/provision-gcp-project.test.sh
+++ b/scripts/provision-gcp-project.test.sh
@@ -794,11 +794,11 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-if grep -q "alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
-  echo -e "  ${GREEN}✓${NC} binding log names alice-gh/agile-flow-gcp (default WIF_REPO)"
+if grep -q "alice-gh/gembaflow-gcp" "$T13/stdout.log"; then
+  echo -e "  ${GREEN}✓${NC} binding log names alice-gh/gembaflow-gcp (default WIF_REPO)"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}✗${NC} expected binding log to mention alice-gh/agile-flow-gcp"
+  echo -e "  ${RED}✗${NC} expected binding log to mention alice-gh/gembaflow-gcp"
   cat "$T13/stdout.log"
   FAIL=$((FAIL + 1))
 fi
@@ -806,18 +806,18 @@ fi
 # Both WIF roles must be bound. workloadIdentityUser alone leaves the deploy
 # step unable to mint access tokens for docker push. We learned that the
 # hard way during smoke 2026-04-28.
-if grep -q "\[bind\] roles/iam.workloadIdentityUser <- alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
+if grep -q "\[bind\] roles/iam.workloadIdentityUser <- alice-gh/gembaflow-gcp" "$T13/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} workloadIdentityUser binding logged"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.workloadIdentityUser <- alice-gh/agile-flow-gcp'"
+  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.workloadIdentityUser <- alice-gh/gembaflow-gcp'"
   FAIL=$((FAIL + 1))
 fi
-if grep -q "\[bind\] roles/iam.serviceAccountTokenCreator <- alice-gh/agile-flow-gcp" "$T13/stdout.log"; then
+if grep -q "\[bind\] roles/iam.serviceAccountTokenCreator <- alice-gh/gembaflow-gcp" "$T13/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} serviceAccountTokenCreator binding logged"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.serviceAccountTokenCreator <- alice-gh/agile-flow-gcp'"
+  echo -e "  ${RED}✗${NC} expected '[bind] roles/iam.serviceAccountTokenCreator <- alice-gh/gembaflow-gcp'"
   FAIL=$((FAIL + 1))
 fi
 
@@ -865,7 +865,7 @@ fi
 
 # ── Test 14b: GITHUB_OWNER + GITHUB_REPO (org-fork path) ────────────────
 # Verifies the new env-var pair from #40. Owner is acme (an org); repo
-# name diverges from `agile-flow-gcp` because the participant renamed it.
+# name diverges from `gembaflow-gcp` because the participant renamed it.
 
 echo ""
 echo "Test 14b: Step 5.5 honors GITHUB_OWNER + GITHUB_REPO"
@@ -874,7 +874,7 @@ echo "Test 14b: Step 5.5 honors GITHUB_OWNER + GITHUB_REPO"
 T14B=$(run_step5_5_test "absent" "" "acme" "widget-shop")
 
 if grep -q "bind.*<- acme/widget-shop" "$T14B/stdout.log"; then
-  echo -e "  ${GREEN}✓${NC} binding member is acme/widget-shop (not <user>/agile-flow-gcp)"
+  echo -e "  ${GREEN}✓${NC} binding member is acme/widget-shop (not <user>/gembaflow-gcp)"
   PASS=$((PASS + 1))
 else
   echo -e "  ${RED}✗${NC} expected '[bind] ... <- acme/widget-shop' in stdout"
@@ -1616,7 +1616,7 @@ echo "Test 22: Step 5.8 pre-creates Cloud Run service when absent"
 
 T22=$(run_step5_8_test "absent")
 
-if grep -q "create.*Cloud Run service.*agile-flow-app.*placeholder" "$T22/stdout.log"; then
+if grep -q "create.*Cloud Run service.*gembaflow-app.*placeholder" "$T22/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} create log line names service + placeholder"
   PASS=$((PASS + 1))
 else
@@ -1625,11 +1625,11 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-if grep -q "run deploy agile-flow-app" "$T22/gcloud.log"; then
+if grep -q "run deploy gembaflow-app" "$T22/gcloud.log"; then
   echo -e "  ${GREEN}✓${NC} gcloud run deploy invoked"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}✗${NC} expected 'run deploy agile-flow-app' in gcloud.log"
+  echo -e "  ${RED}✗${NC} expected 'run deploy gembaflow-app' in gcloud.log"
   FAIL=$((FAIL + 1))
 fi
 
@@ -1660,7 +1660,7 @@ echo "Test 23: Step 5.8 idempotent when service already exists"
 
 T23=$(run_step5_8_test "present")
 
-if grep -q "skip.*Cloud Run service.*agile-flow-app.*already exists" "$T23/stdout.log"; then
+if grep -q "skip.*Cloud Run service.*gembaflow-app.*already exists" "$T23/stdout.log"; then
   echo -e "  ${GREEN}✓${NC} skip-existing log line"
   PASS=$((PASS + 1))
 else

--- a/scripts/provision-workshop-roster.sh
+++ b/scripts/provision-workshop-roster.sh
@@ -35,7 +35,7 @@
 #
 # Optional environment variables:
 #   GCP_REGION           (default: us-central1) — passed through to inner script
-#   ARTIFACT_REPO        (default: agile-flow)  — passed through to inner script
+#   ARTIFACT_REPO        (default: gembaflow)  — passed through to inner script
 #   PROVISION_SCRIPT     (default: scripts/provision-gcp-project.sh) — for tests
 #   NEON_API_KEY         optional; forwarded to inner script for branch creation
 #   NEON_PROJECT_ID      optional; forwarded to inner script for branch creation
@@ -531,7 +531,7 @@ while IFS=',' read -r handle github_user email cohort neon_branch github_full_re
   GCP_PROJECT_ID="$project_id" \
   BILLING_ACCOUNT_ID="$BILLING_ACCOUNT_ID" \
   GCP_REGION="${GCP_REGION:-us-central1}" \
-  ARTIFACT_REPO="${ARTIFACT_REPO:-agile-flow}" \
+  ARTIFACT_REPO="${ARTIFACT_REPO:-gembaflow}" \
   GITHUB_OWNER="$github_owner" \
   GITHUB_REPO="$github_repo" \
   GITHUB_USERNAME="$github_user" \

--- a/scripts/workshop-setup.sh
+++ b/scripts/workshop-setup.sh
@@ -15,7 +15,7 @@
 #
 # Optional (forwarded to provision-workshop-roster.sh):
 #   GCP_REGION           default: us-central1
-#   ARTIFACT_REPO        default: agile-flow
+#   ARTIFACT_REPO        default: gembaflow
 #   PROVISION_SCRIPT     default: scripts/provision-gcp-project.sh
 #
 # Pre-flight checks (in order):


### PR DESCRIPTION
## Summary

Phase 5 of the agile-flow → Gemba Flow rebrand: flip the **default** names of GCP resources that get provisioned for **new** workshops from `agile-flow-*` to `gembaflow-*`. Forward-only — no existing GCP resources are renamed.

Existing workshop projects keep their old resource names (AR repo `agile-flow`, Cloud Run service `agile-flow-app`, WIF binding scoped to `<user>/agile-flow-gcp`). Those are torn down per-cohort, so no migration is needed.

## Resource defaults changed

| Resource type | Old default | New default |
|---|---|---|
| Artifact Registry repo (`ARTIFACT_REPO`) | `agile-flow` | `gembaflow` |
| Cloud Run service (`CLOUD_RUN_SERVICE`) | `agile-flow-app` | `gembaflow-app` |
| WIF binding repo (`GITHUB_REPO` default → `WIF_REPO_NAME`) | `agile-flow-gcp` | `gembaflow-gcp` |

Operator-facing summary echo at the end of `provision-gcp-project.sh` updated to match.

## Companion updates

- `scripts/diagnose-cloudrun.sh` — `CLOUD_RUN_SERVICE` default for the read-only diagnostic
- `scripts/provision-workshop-roster.sh` — `ARTIFACT_REPO` pass-through default in the wrapper that calls the inner script
- `scripts/workshop-setup.sh` — header doc reflecting new default
- Tests: `provision-gcp-project.test.sh` (Tests 13/14b/22/23 cover the changed defaults), `diagnose-cloudrun.test.sh` (fixture + assertions for the new service name)
- Docs: `PLATFORM-GUIDE.md`, `CI-CD-GUIDE.md`, `PATTERN-LIBRARY.md` — current-default tables and example commands

## Intentionally left untouched

- Upstream remote URL `vibeacademy/agile-flow` (Phase 1 / repo-rename territory, not GCP)
- Dotfile names `.agile-flow-version` / `.agile-flow-overrides` (Phase 4 territory)
- `provision-workshop-roster.sh` `github_full_repo` personal-fork default `<user>/agile-flow-gcp` — this is a GitHub-repo-lookup default, not a GCP resource default; the canonical fork target is still `vibeacademy/agile-flow-gcp` (the GitHub redirect to `gembaflow-gcp` exists but the clone URL is unchanged)
- Workshop roster CSV fixtures with `acme/agile-flow-alice`-style entries — they exercise the override-the-default path; the literal is arbitrary
- Historical references (`reports/session-journals/*`, CHANGELOG, issue-number URLs)

## Test plan

- [x] Local `bash scripts/provision-gcp-project.test.sh` — Tests 13, 14b, 22, 23 (the ones that exercise the changed defaults) all pass
- [x] Local `bash scripts/diagnose-cloudrun.test.sh` — 35/0 pass
- [x] Local `bash scripts/provision-workshop-roster.test.sh` — exit 0 (override-and-lookup-default behavior preserved)
- [x] Pre-push hook (full lint + pytest 62 passed)
- [x] `grep -rn 'agile-flow-app\|"agile-flow"\|'\''agile-flow'\''' scripts/ docs/` returns no hits outside historical/session-journal scope
- [ ] Dry-run check on a fresh GCP project before the next live workshop (recommended; not blocking this PR since no live cohort is active)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)