### PR TITLE
docs: correct ANTHROPIC_API_KEY claims for interactive Claude Code in Codespaces

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -190,24 +190,52 @@ the full classic-vs-fine-grained walkthrough.
 
 ## "Why is Claude Code asking me to log in via browser in my Codespace?"
 
-Claude Code authenticates from `ANTHROPIC_API_KEY` in env if it's
-set. If it's not set, Claude Code falls back to an OAuth browser
-flow. The browser flow works but it's awkward in a Codespace
-(extra clicks, port-forward roundtrip) and there's a faster path:
+**Short answer:** That's the expected path for interactive Claude
+Code, even in a Codespace, even with `ANTHROPIC_API_KEY` set. It is
+not a misconfiguration.
 
-**Set `ANTHROPIC_API_KEY` as a *Codespaces* secret (not an Actions
-secret).** GitHub has two separate secret stores:
+Claude Code's interactive CLI (`claude`) authenticates via browser
+OAuth against your Anthropic account or Claude.ai subscription. We
+previously documented `ANTHROPIC_API_KEY` as a way to skip the
+browser flow; this was empirically falsified on 2026-05-04 — with
+the secret set as a Codespaces secret and the Codespace restarted,
+`claude` still prompted for browser OAuth. The interactive CLI
+prefers OAuth/subscription auth over the env var. (See #156 for
+the original report.)
+
+The browser flow itself works fine in a Codespace — VS Code Server
+forwards the OAuth callback automatically. It's one extra click on
+first run per Codespace, then the session is cached.
+
+**Why set `ANTHROPIC_API_KEY` as a Codespaces secret at all?**
+
+It's still recommended, but for different reasons than "skip the
+browser":
+
+1. **App-side Anthropic SDK calls** — if your fork has code that
+   imports the Anthropic SDK and makes programmatic calls (e.g.,
+   `app/llm/anthropic_client.py`), that code reads
+   `ANTHROPIC_API_KEY` from env and has no browser fallback.
+2. **Headless `claude -p "..."` invocations** — one-shot prompts
+   from scripts, agent hooks, or CI-like flows can't open a
+   browser; they need the env var.
+3. **Billing separation** — using a pay-as-you-go API key for
+   workshop work keeps Anthropic API spend separate from a
+   personal Claude.ai subscription.
+
+**If you set the secret, it MUST be a *Codespaces* secret, not an
+Actions secret.** GitHub has two separate secret stores:
 
 | Secret type | Where it appears | Visible to Codespaces? |
 |-------------|------------------|------------------------|
 | **Codespaces** secret | Settings → Codespaces → Codespaces secrets | Yes — injected as env var |
 | **Actions** secret | Settings → Secrets and variables → Actions | No — only visible to workflow runs |
 
-If you set `ANTHROPIC_API_KEY` as an Actions secret, Claude Code
-in your Codespace terminal won't see it (the env var simply isn't
-there) and will fall back to the OAuth browser flow.
+If you set `ANTHROPIC_API_KEY` as an Actions secret, processes in
+your Codespace (your app code, `claude -p`) won't see it — the env
+var simply isn't there.
 
-**Fix:**
+**How to set it:**
 
 1. Open `https://github.com/settings/codespaces`
 2. Click **New secret** under "Codespaces secrets"
@@ -215,17 +243,15 @@ there) and will fall back to the OAuth browser flow.
    `https://console.anthropic.com/settings/keys`
 4. **Repository access:** select your fork
 5. Restart your Codespace so the new env var is injected
-6. Run `claude` again — should land directly in a session, no browser
 
-**For workshop facilitators** who want to fund attendees' API
-usage centrally, set `ANTHROPIC_API_KEY` as a **Codespaces org
-secret** scoped to the cohort's repos instead of asking each
-attendee to bring their own. See `docs/PLATFORM-GUIDE.md` →
-"Anthropic API key (Claude Code authentication)" and #104.
-
-The browser flow remains a perfectly fine fallback if you don't
-want to manage a Codespaces secret. It just takes one extra step
-each time the Codespace cold-starts.
+**For workshop facilitators** who want to fund attendees'
+app-side / headless API usage centrally, set `ANTHROPIC_API_KEY`
+as a **Codespaces org secret** scoped to the cohort's repos
+instead of asking each attendee to bring their own. Interactive
+`claude` sessions still authenticate per-attendee via browser
+OAuth against each attendee's own account. See
+`docs/PLATFORM-GUIDE.md` → "Anthropic API key (Claude Code
+authentication)" and #104.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -118,9 +118,29 @@ for you, identically across all attendees.
 2. Wait ~60 seconds for the container to provision.
 3. Run `gcloud auth login` in the integrated terminal to authenticate
    with GCP (browser OAuth flow).
-4. The Claude Code extension is preinstalled. **Before starting an
-   agent session, set your Anthropic API key as a Codespaces secret
-   so Claude Code authenticates from env without a browser flow:**
+4. The Claude Code extension is preinstalled. Open the integrated
+   terminal (Ctrl+backtick) and run `claude`. **Expect a browser
+   OAuth prompt the first time** — Claude Code's interactive CLI
+   authenticates against your Anthropic account (or Claude.ai
+   subscription, if you have one on the same email) via OAuth, even
+   in a Codespace. This is the IDE/CLI's expected path; it is not a
+   misconfiguration. (This is your **Anthropic account**, separate
+   from the GitHub and Google Cloud auths above.)
+
+   **Optional but recommended: also set `ANTHROPIC_API_KEY` as a
+   Codespaces secret.** The env var does NOT skip the interactive
+   browser flow (empirically verified — Claude Code's interactive
+   session prefers OAuth/subscription auth over `ANTHROPIC_API_KEY`
+   for IDE/CLI sessions), but it IS needed for:
+   - App code that calls the Anthropic SDK directly (e.g., a fork
+     with `app/llm/anthropic_client.py`)
+   - Headless `claude -p "..."` one-shot invocations from scripts or
+     CI-like flows where no browser is available
+   - Separating Anthropic API billing from your Claude.ai
+     subscription (some attendees want the workshop on a fresh
+     pay-as-you-go key)
+
+   To set the Codespaces secret:
    - Open `https://github.com/settings/codespaces` → **Codespaces
      secrets** → **New secret**
    - Name: `ANTHROPIC_API_KEY`. Value: a key from
@@ -131,19 +151,11 @@ for you, identically across all attendees.
    - **Important:** this MUST be a *Codespaces* secret, NOT a repo
      **Actions** secret. Actions secrets are scoped to GitHub
      workflow runs and are not injected into Codespaces — setting
-     `ANTHROPIC_API_KEY` there won't help Claude Code in your
-     terminal. (See FAQ: "Why is Claude Code asking me to log in
-     via browser in my Codespace?")
+     `ANTHROPIC_API_KEY` there won't reach the env vars your app
+     code or `claude -p` invocations read. (See FAQ: "Why is Claude
+     Code asking me to log in via browser in my Codespace?")
    - If your Codespace is already running, restart it so the new
      secret is picked up.
-
-   Then open the integrated terminal (Ctrl+backtick) and run
-   `claude`. You should land directly in an agent session. If Claude Code
-   prompts you to authenticate via browser, the secret isn't
-   reaching the Codespace — see the FAQ entry above. The browser
-   flow still works as a fallback if you'd rather not configure
-   the secret (this is your **Anthropic account**, separate from
-   the GitHub and Google Cloud auths above).
 5. Skip to **Step 2: Set Up GitHub Access** below — except gh is
    already authenticated, so you can skip Step 2 entirely.
 6. **For local-dev work** (running the FastAPI app, iterating on

--- a/docs/PLATFORM-GUIDE.md
+++ b/docs/PLATFORM-GUIDE.md
@@ -428,9 +428,12 @@ gh state across the user's terminals; #82). The hook
 (`.claude/hooks/ensure-github-account.sh`) short-circuits on
 `AGILE_FLOW_SOLO_MODE=true` and no longer tries to switch accounts.
 
-**Anthropic API key:** Claude Code in a Codespace authenticates
-from `ANTHROPIC_API_KEY` if set, or falls back to OAuth otherwise.
-For Codespaces this MUST be a Codespaces secret, not an Actions
+**Anthropic API key:** Claude Code's interactive CLI in a Codespace
+authenticates via browser OAuth against your Anthropic account or
+Claude.ai subscription — `ANTHROPIC_API_KEY` does NOT skip this for
+interactive sessions (empirically verified). The env var is still
+needed for app-code SDK calls and headless `claude -p` invocations;
+for Codespaces it MUST be a Codespaces secret, not an Actions
 secret — see "Anthropic API key (Claude Code authentication)"
 below.
 
@@ -460,10 +463,12 @@ operations (issue create, label create, branch protection) require
 the agent to verify the active account and STOP if wrong — never
 switch from agent context (#82).
 
-**Anthropic API key:** same requirement as solo mode — Claude
-Code reads `ANTHROPIC_API_KEY` from env. For Codespaces this MUST
-be a Codespaces secret, not an Actions secret. See "Anthropic API
-key (Claude Code authentication)" below for the full distinction.
+**Anthropic API key:** same situation as solo mode — Claude Code's
+interactive CLI authenticates via browser OAuth even with
+`ANTHROPIC_API_KEY` set; the env var is for app-code SDK calls and
+headless `claude -p` invocations. For Codespaces this MUST be a
+Codespaces secret, not an Actions secret. See "Anthropic API key
+(Claude Code authentication)" below for the full distinction.
 
 ### Choosing between them
 
@@ -485,55 +490,72 @@ worth the setup cost.
 
 ### Anthropic API key (Claude Code authentication)
 
-Both solo and multi-bot modes need Claude Code to authenticate
-inside whatever environment the agents run in. There are two
-auth paths:
+Both solo and multi-bot modes use Claude Code in two distinct ways,
+each with its own auth path. Conflating them was the bug that
+shipped in PR #145 (see #156) — be precise about which you mean.
 
-1. **API key (recommended for Codespaces and CI-like flows)** —
-   Claude Code reads `ANTHROPIC_API_KEY` from env and starts
-   sessions immediately, no browser flow needed.
-2. **OAuth browser flow (fallback)** — Claude Code opens a browser
-   on first run to authenticate against your Anthropic account.
-   Works on local dev machines but is awkward in Codespaces
-   (requires port-forwarding the OAuth callback) and impossible
-   in headless CI.
+**Interactive Claude Code (`claude` CLI / IDE extension):**
 
-**Where to set `ANTHROPIC_API_KEY`:**
+Authenticates via **browser OAuth** against your Anthropic account
+or Claude.ai subscription. Empirically verified on 2026-05-04:
+setting `ANTHROPIC_API_KEY` as a Codespaces secret does NOT skip
+this — the interactive CLI prefers OAuth/subscription auth even
+when the env var is present. This is the expected behavior, not a
+misconfiguration. Workshop attendees should expect to click through
+a browser OAuth prompt the first time they run `claude` in a
+Codespace.
 
-| Where you run Claude Code | Where to set the key |
-|---------------------------|----------------------|
-| Local dev machine | Shell rc (`set -x ANTHROPIC_API_KEY ...` in fish, `export ANTHROPIC_API_KEY=...` in bash/zsh) — or just use OAuth |
-| GitHub Codespace | **Codespaces secret** (NOT Actions secret — see below) |
+**Headless Claude Code and app-side Anthropic SDK calls:**
+
+These read `ANTHROPIC_API_KEY` from env:
+- `claude -p "..."` one-shot invocations (scripts, CI, agent hooks)
+- App code that imports the Anthropic SDK (e.g., a fork with
+  `app/llm/anthropic_client.py` making programmatic calls)
+
+These cannot do an interactive browser flow, so they require the
+env var. This is the real reason to set `ANTHROPIC_API_KEY` as a
+Codespaces secret even though interactive `claude` doesn't need it.
+
+**Where to set `ANTHROPIC_API_KEY` for headless/app-side use:**
+
+| Where the key is consumed | Where to set it |
+|---------------------------|-----------------|
+| Local dev machine (app code, `claude -p`) | Shell rc (`set -x ANTHROPIC_API_KEY ...` in fish, `export ANTHROPIC_API_KEY=...` in bash/zsh) |
+| GitHub Codespace (app code, `claude -p`) | **Codespaces secret** (NOT Actions secret — see below) |
+| GitHub Actions workflow | **Actions secret** (separate store from Codespaces) |
 
 **Critical distinction for Codespaces:**
 
 GitHub has two separate secret stores: **Actions secrets** (scoped
 to workflow runs only) and **Codespaces secrets** (injected as
 env vars into running Codespaces). Setting `ANTHROPIC_API_KEY`
-as an Actions secret will NOT make it available to Claude Code
-in a Codespace — the env var won't exist, and Claude Code will
-fall through to the OAuth browser flow.
+as an Actions secret will NOT make it available to processes in
+a Codespace — the env var won't exist there, so app code that
+reads it will fail and `claude -p` will error out.
 
 **For workshop attendees:** set `ANTHROPIC_API_KEY` as a
 **Codespaces user secret** at `https://github.com/settings/codespaces`
 and scope it to your fork. See `docs/GETTING-STARTED.md` Path A
-step 4 for the click-by-click.
+step 4 for the click-by-click. Note that this is for app-side and
+headless use; interactive `claude` will still prompt for browser
+OAuth on first run.
 
 **For workshop facilitators (org-funded BYOK):** instead of each
 attendee setting their own key, you can configure a **Codespaces
 org secret** on `vibeacademy` scoped to the cohort's attendee
-repos. This pushes the cost to the facilitator's Anthropic
-billing in exchange for zero per-attendee setup. See #104 for
-the research on this model.
+repos. This pushes app-side / headless API costs to the
+facilitator's Anthropic billing in exchange for zero per-attendee
+setup. Interactive `claude` sessions still authenticate per-attendee
+against each attendee's own Anthropic account / Claude.ai
+subscription. See #104 for the research on this model.
 
 **If you wire Claude into a CI workflow** (none of the framework's
 shipped workflows currently do — `auto-review.yml` and `auto-triage.yml`
 are trigger scaffolding that post comments inviting the user to invoke
 `/review-pr` etc. locally; they do not call the Anthropic API), the
-`ANTHROPIC_API_KEY` your custom
-workflow consumes IS an Actions secret. The two stores are
-independent — set both if your fork ends up needing Claude Code
-in both Codespaces and CI.
+`ANTHROPIC_API_KEY` your custom workflow consumes IS an Actions
+secret. The two stores are independent — set both if your fork ends
+up needing Claude Code app-side in both Codespaces and CI.
 
 ### Database access from a Codespace (local development)
 


### PR DESCRIPTION
## Summary

Corrects three doc files that overclaimed `ANTHROPIC_API_KEY` as a way to skip Claude Code's browser OAuth flow in a Codespace. Empirically falsified 2026-05-04 on `vibeacademy/worker`: secret set as documented, Codespace restarted, `claude` in integrated terminal still required browser OAuth. The interactive CLI prefers OAuth/Claude.ai-subscription auth over the env var for IDE/CLI sessions.

Files updated:

- `docs/GETTING-STARTED.md` — Path A step 4: tell attendees to expect the browser OAuth prompt as the normal path; reframe the secret as recommended for app-code SDK calls, headless `claude -p`, and billing separation
- `docs/PLATFORM-GUIDE.md` — rewrite the "Anthropic API key (Claude Code authentication)" section to split interactive Claude Code (browser OAuth, env var ignored) from headless / app-side use (reads env var); update the two short references in Solo Mode and Multi-bot Mode to match
- `docs/FAQ.md` — rewrite "Why is Claude Code asking me to log in via browser in my Codespace?": short answer is now "that's the expected path, even with the secret set", followed by the three real reasons to still set the secret

## What was preserved (per ticket Guardrails)

- Recommendation to set `ANTHROPIC_API_KEY` as a Codespaces secret remains — motivation corrected from "skip OAuth" to "app-side SDK calls, headless `claude -p`, billing separation"
- Critical Codespaces-vs-Actions secret distinction preserved in all three files
- Workshop facilitator org-secret model preserved — now framed as funding app-side / headless usage centrally, with interactive sessions still authenticating per-attendee
- FAQ entry not deleted, just rewritten
- No "skip the browser flow" / "no browser needed" / "land directly in" language remains (verified by grep)

## What I did NOT do

**Skipped optional Definition-of-Done item (meta-note on `.claude/agents/pr-reviewer.md`'s empirical-verification section).**

The empirical-verification section that #146 added in commit `44640c8` is no longer in `.claude/agents/pr-reviewer.md` — it was overwritten by an upstream sync (commits `9fd3e8d`, `640c1f2`). `pr-reviewer.md` is not listed in `.gembaflow-overrides`, so `pull-upstream.sh` / `template-sync.sh` overwrites it wholesale on each sync. The optional task's precondition (the section exists) is not met. Restoring lost framework content is a different problem than the docs correction in this PR, so I left it out rather than expanding scope. **Recommend a separate ticket** to either (a) add `.claude/agents/pr-reviewer.md` to `.gembaflow-overrides` and restore the section, or (b) push the rule upstream into `vibeacademy/gembaflow` so it survives syncs.

## Empirical verification status

The ticket Happy Path step 1 asked the implementer to launch a fresh Codespace, run `claude`, and observe the auth path. **This PR applies the rewrite based on the existing 2026-05-04 empirical evidence cited in the ticket Problem Statement.** I did not re-launch a fresh Codespace myself. Reviewer should decide whether a fresh-Codespace re-verification is required before merge, or whether the 2026-05-04 evidence already in the ticket is sufficient.

## Fork impact

- **Active downstream forks of `gembaflow-gcp`:** docs files are not in `.gembaflow-overrides`, so this fix will propagate cleanly to any fork on next `/upgrade` / `/pull-upstream`. No fork-side blockers expected.
- **`vibeacademy/gembaflow` (upstream platform repo):** these three doc files are fork-specific (GCP/FastAPI/Neon workshop framing) and do not exist in upstream — no upstream port needed for this content. The underlying empirical finding (interactive Claude Code ignores `ANTHROPIC_API_KEY`) may be worth surfacing in upstream platform docs separately.
- **Other downstream forks (`agile-flow`, `agile-flow-meta`):** N/A — these docs only exist in the GCP fork.

## Test plan

- [x] `grep -ni 'skip.*browser|without a browser|no browser flow|land directly in'` returns empty across all three files
- [x] Pre-push hook ran (`uv run --extra dev ruff check .` + `uv run --extra dev pytest`): all green, 62/62 tests pass
- [ ] Reviewer to confirm: read the three rewrites end-to-end and check the framing matches observed Codespace behavior
- [ ] Optional: reviewer launches a fresh Codespace to re-verify the empirical claim (the central claim being corrected was originally shipped without empirical verification — re-verification before merge would satisfy the spirit of the rule from #146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)